### PR TITLE
minor fixes to Apache module's Include support

### DIFF
--- a/apache/apache-lib.pl
+++ b/apache/apache-lib.pl
@@ -343,7 +343,7 @@ if (@get_config_cache) {
 # read primary config file
 ($conf) = &find_httpd_conf();
 return undef if (!$conf);
-local %seenfiles;
+my %seenfiles;
 @get_config_cache = &get_config_file($conf, \%seenfiles);
 
 # Read main resource and access config files
@@ -368,6 +368,7 @@ push(@get_config_cache, &get_config_file($acc, \%seenfiles));
 # Read extra config files in VirtualHost sections
 @virt = &find_directive_struct("VirtualHost", \@get_config_cache);
 foreach $v (@virt) {
+	my %seenfiles;
 	$mref = $v->{'members'};
 	foreach $idn ("ResourceConfig", "AccessConfig", "Include") {
 		foreach $inc (&find_directive_struct($idn, $mref)) {


### PR DESCRIPTION
Hi, I'm new to all this so hopefully this is the right thing to do...

I noticed a problem with Webmin not displaying all my included Apache configuration files, after a bit of hacking it turned out to be 2 problems.

1) Within a VirtualHost block, only the final Include statement was being parsed by Webmin.

2) If the same file was included in different VirtualHost blocks, Webmin only parsed the file for the first virtual host.

-- Will
