### PR TITLE
Include the same Apache config within different VirtualHost blocks

### DIFF
--- a/apache/apache-lib.pl
+++ b/apache/apache-lib.pl
@@ -343,7 +343,7 @@ if (@get_config_cache) {
 # read primary config file
 ($conf) = &find_httpd_conf();
 return undef if (!$conf);
-local %seenfiles;
+my %seenfiles;
 @get_config_cache = &get_config_file($conf, \%seenfiles);
 
 # Read main resource and access config files
@@ -368,6 +368,7 @@ push(@get_config_cache, &get_config_file($acc, \%seenfiles));
 # Read extra config files in VirtualHost sections
 @virt = &find_directive_struct("VirtualHost", \@get_config_cache);
 foreach $v (@virt) {
+	my %seenfiles;
 	$mref = $v->{'members'};
 	foreach $idn ("ResourceConfig", "AccessConfig", "Include") {
 		foreach $inc (&find_directive_struct($idn, $mref)) {


### PR DESCRIPTION
Sorry, forgot to put this with the last pull request.

That last pull dealt with the [infinite loop concern](http://github.com/webmin/webmin/issues/issue/3#issue/3/comment/443197), this patch wasn't directly affected by that.

As an aside, my patches were tested on 2 servers (Debian Lenny and Ubuntu Lucid) with something like this Apache config:
    <VirtualHost 1.2.3.4:80>
        Include /path/to/common.conf
    </VirtualHost>
    <VirtualHost 1.2.3.4:443>
        Include /path/to/common.conf
        Include /path/to/ssl.conf
    </VirtualHost>
Hope that reveals why these fixes are useful. :)
