### PR TITLE
Add date.timezone support to PHP "Other Settings".

### DIFF
--- a/phpini/help/misc_timezone.html
+++ b/phpini/help/misc_timezone.html
@@ -1,0 +1,10 @@
+<header>PHP Timezone</header>
+
+<p>Default timezone used by all date/time functions. Setting this to an empty value uses the default for your version of PHP.</p>
+
+<p>Please see <a href='http://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone'>the PHP manual's documentation of the configuration option</a> for more details.</p>
+
+<p><em>(Available since PHP 5.1.0)</em></p>
+<hr>
+
+<footer>

--- a/phpini/lang/en
+++ b/phpini/lang/en
@@ -154,6 +154,7 @@ misc_esendmail=Invalid command for sending email
 misc_esendmail2=Missing command for sending email
 misc_include=Allow opening of remote Includes?
 misc_path=CGI Fix Path Info?
+misc_timezone=PHP Timezone
 
 log_manual=Manually edit file $1
 log_vars=Changed PHP variables in $1

--- a/phpini/save_misc.cgi
+++ b/phpini/save_misc.cgi
@@ -53,6 +53,10 @@ else {
 &save_directive($conf, "cgi.fix_pathinfo",
 	$in{"cgi.fix_pathinfo"} || undef);
 
+# Save Timezone
+&save_directive($conf, "date.timezone",
+	$in{"date.timezone"} || undef);
+
 &flush_file_lines_as_user($in{'file'});
 &unlock_file($in{'file'});
 &graceful_apache_restart();


### PR DESCRIPTION
Hi there! This is my first pull request for Webmin, so please be kind. :)
# Problem:
- Starting in PHP 5.1.0, you can now define the time zone to be used by PHP.
- Starting in PHP 5.3.0, it's practically required if you don't want to be inundated with warnings:
  <pre>[Thu Apr 14 02:24:09 2011] [warn] mod_fcgid: stderr: PHP Warning:
  date(): It is not safe to rely on the system's timezone settings.
  You are _required_ to use the date.timezone setting or the
  date_default_timezone_set() function. In case you used any of those
  methods and you are still getting this warning, you most likely misspelled
  the timezone identifier. We selected 'America/Los_Angeles' for 'PDT/-7.0/DST'
  instead in /home/blahblahblah/public_html/plugins/log/log.php on line 44</pre>
# Solution:
- Add a dropdown on the "Other Settings" page in Webmin's PHP Configuration module.
# Implementation:
1. Read all time zones from the system's zone.tab.
2. Create a hash containing each time zone "name" as the key, along with the other data available via the zonetab as a multidimensional hash, for potential use by others looking to add the latitude/longitude in the future (or perhaps other PHP options which may be able to use this same data sanely).
3. Place an empty ('') entry at the top of the list, allowing the user to revert to the default behavior.
4. Add "comments" for the empty entry and any custom entry which may have been manually entered by the user.
5. Display a table row with a select element, containing the list of time zones.
6. Save their selection to the configuration.
# Known problems:
1. This is also displayed for systems running PHP 4. I do not see a way to discriminate based on PHP version. However, it should be harmless for those users.
# Future functionality:
- It would be nice to see the descriptions/comments from the time zone database be visible to the user somehow. I haven't figured out a good way to do that yet.
- This should also be usable as the jumping-off point for someone to add date.default_latitude and date.default_longitude support. (They'd have to parse `%tzlist{$tzname}{'coords'}` to get it, but that should be fairly trivial.)
# Additional information:
- I also have added a help file for the new option, as there aren't enough help links as there aren't enough help links in some of the modules, PHP included. :)
- Support for an "Other" menu option was purposely omitted. There is almost no reason for someone to choose an unavailable time zone, such as old System V "legacy" names e.g. `PST8PDT`. (It is retained, however, if they have set one and save again without choosing another value from the list.)
- I have not made the location of the zonetab configurable, as it is in a standard location. There is very little compelling reason to accommodate the very few users/admins who even know that they can have two time zone databases on one system. (And I believe every system supported by Webmin has it in this location; the big ones [Linux, BSD, Solaris] do...)
