### PR TITLE
Teach SSL Tunnels module new stunnel binary location for RHEL 6.

### DIFF
--- a/stunnel/config-redhat-linux-14-*
+++ b/stunnel/config-redhat-linux-14-*
@@ -1,0 +1,1 @@
+stunnel_path=/usr/bin/stunnel


### PR DESCRIPTION
RHEL 6 moved stunnel from /usr/sbin to /usr/bin.

Note that this will only affect RHEL and any RHEL clones using \d rather than \S in os_list.txt.
