### PR TITLE
Add UTC timezone to Linux.

### DIFF
--- a/time/linux-lib.pl
+++ b/time/linux-lib.pl
@@ -26,6 +26,7 @@ while(<ZONE>) {
 	}
 close(ZONE);
 push(@rv, [ "GMT", "GMT" ]) if (!$done{'GMT'});
+push(@rv, [ "UTC", "UTC" ]) if (!$done{'UTC'});
 return sort { $a->[0] cmp $b->[0] } @rv;
 }
 


### PR DESCRIPTION
As GMT is not quite the same as UTC (and the latter is preferred for new systems), I have added UTC to the list of available time zones.
