### PR TITLE
Fix 1 error+2 warnings in openbsd-mounts-2.c

### DIFF
--- a/mount/openbsd-mounts-2.c
+++ b/mount/openbsd-mounts-2.c
@@ -3,6 +3,8 @@
 #include <sys/param.h>
 #include <sys/ucred.h>
 #include <sys/mount.h>
+#include <stdlib.h>
+#include <string.h>
 
 char *find_type(int t);
 char *expand_flags(int f);
@@ -40,7 +42,9 @@ if (f & MNT_NODEV) strcat(buf, "nodev,");
 if (f & MNT_SYNCHRONOUS) strcat(buf, "sync,");
 if (f & MNT_ASYNC) strcat(buf, "async,");
 if (f & MNT_QUOTA) strcat(buf, "quota,");
+#ifdef MNT_UNION
 if (f & MNT_UNION) strcat(buf, "union,");
+#endif
 if (buf[0] == 0) return "-";
 buf[strlen(buf)-1] = 0;
 return buf;


### PR DESCRIPTION
Fix 1 error+2 warnings. Tested with Webmin 1.570 and OpenBSD 5.0 2011-08-07 snapshot.
Before:
http://i.imgur.com/HyioL.png
After:
http://i.imgur.com/lsruU.png
