### PR TITLE
Added Linux Mint to os_list.txt

### DIFF
--- a/os_list.txt
+++ b/os_list.txt
@@ -94,6 +94,14 @@ Ubuntu Linux			$1	debian-linux	3.1	$etc_issue =~ /Ubuntu.*\s([0-9\.]+)\s/i
 Mepis Linux			$1	debian-linux	$1	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /([0-9\.]+)/
 Mepis Linux			$1	debian-linux	4.0	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /(stable)/
 
+# Linux Mint (Mint should be before Debian to avoid false-positive)
+Linux Mint  		6	debian-linux	5.0	`cat /etc/lsb-release | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION\="Linux Mint 6 Felicia"/
+Linux Mint			7	debian-linux	5.0	`cat /etc/lsb-release | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION\="Linux Mint 7 Gloria"/
+Linux Mint			8	debian-linux	6.0	`cat /etc/lsb-release | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION\="Linux Mint 8 Helena"/
+Linux Mint			9	debian-linux	6.0	`cat /etc/lsb-release | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION\="Linux Mint 9 Isadora"/
+Linux Mint			10	debian-linux	6.0	`cat /etc/lsb-release | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION\="Linux Mint 10 Julia"/
+Linux Mint			11	debian-linux	6.0	`cat /etc/lsb-release | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION\="Linux Mint 11 Katya"/
+
 # Debian Linux versions with numbers
 Debian Linux			$1	debian-linux	$1	$etc_issue =~ /Debian.*\s([0-9\.]+)\s/i || `cat /etc/debian_version 2>/dev/null` =~ /([0-9\.]+)/
 Debian Linux			2.0	debian-linux	2.0	`cat /etc/debian_version 2>/dev/null` =~ /^(hamm)/i


### PR DESCRIPTION
Linux Mint should be before Debian to avoid getting tagged as Debian (becuase it has /etc/debian_version)
