### PR TITLE
Escape user-generated content.

### DIFF
--- a/useradmin/delete_user.cgi
+++ b/useradmin/delete_user.cgi
@@ -138,8 +138,8 @@ else {
 	    $access{'delhome'} != 0) {
 		# Has a home directory, so check for files owned by others
 		$size = &disk_usage_kb($user->{'home'});
-		$msg = &text('udel_sure', $user->{'user'},
-                           "<tt>$user->{'home'}</tt>", &nice_size($size*1024));
+		$msg = &text('udel_sure', &html_escape($user->{'user'}),
+                           "<tt>".&html_escape($user->{'home'})."</tt>", &nice_size($size*1024));
 		if ($access{'delhome'} != 1) {
 			push(@buts, [ undef, $text{'udel_del1'} ]);
 			}
@@ -151,7 +151,7 @@ else {
 		}
 	else {
 		# No home directory
-		$msg = &text('udel_sure2', $user->{'user'});
+		$msg = &text('udel_sure2',&html_escape($user->{'user'}));
 		push(@buts, [ undef, $text{'udel_del1'} ]);
 		}
 
@@ -162,11 +162,10 @@ else {
 		$access{'dothers'} == 1 ?
 			&ui_checkbox("others", 1, $text{'udel_dothers'},
                                      $config{'default_other'}) : "",
-		(@others ? &text('udel_others', "<tt>$user->{'home'}</tt>",
+		(@others ? &text('udel_others', "<tt>".&html_escape($user->{'home'})."</tt>",
                                                    scalar(@others))."<p>" : "").
 		($user->{'user'} eq 'root' ? $text{'udel_root'} : ""),
 		);
 
 	&ui_print_footer("", $text{'index_return'});
 	}
-


### PR DESCRIPTION
before
http://i.imgur.com/CuLhN.png
after
http://i.imgur.com/iwv1O.png

A couple of things
thing 1)
There are no security risk at all in having this unescaped. Although if admin disable referer protection, there are plenty of CSRF, clickjacking and probably XSS out there. (this is not one of them)
So why fix this?
1-Aesthetics. e.g. if a user has <ManDraKe> as username, you will not see his name when deleting him.
2-To avoid generating non-sense like this:
https://mrmichaelwill.wordpress.com/2008/04/24/webmin-1410-insecurities-xss-exploit/

thing 2)
If its ok with you, I will submit small fixes to bugs like this, that some of them _maybe_ could be exploited if referer protection is disabled.

thing 3)
By the way, currently Webmin is vuln to clickjacking (yes, with referer protection enabled). Good side, exploits are not easy to make. I will try to find an easy-to-implement solution when I have time. (If you don't know what clickjacking is (its 'new') check out Black Hat 2010 talk about it (pretty cool talk)
