### PR TITLE
Escaping filename.

### DIFF
--- a/apache/create_virt.cgi
+++ b/apache/create_virt.cgi
@@ -118,7 +118,7 @@ else {
 	# Use a user-specified file
 	$f = $in{'file'};
 	}
--r $f || open(FILE, ">>$f") || &error(&text('cvirt_efile', $f, $!));
+-r $f || open(FILE, ">>$f") || &error(&text('cvirt_efile', &html_escape($f), $!));
 close(FILE);
 
 &lock_apache_files();


### PR DESCRIPTION
Nice example of something that can be exploited if referer protection is disabled.
