### PR TITLE
Update Webmin SSL Encryption Configuration to grok "new format" OpenSSL keys.

### DIFF
--- a/webmin/savekey.cgi
+++ b/webmin/savekey.cgi
@@ -8,8 +8,8 @@ require './webmin-lib.pl';
 # Validate inputs
 $key = $in{'key'} || $in{'keyfile'};
 $key =~ s/\r//g;
-$key =~ /BEGIN RSA PRIVATE KEY/ &&
-  $key =~ /END RSA PRIVATE KEY/ || &error($text{'savekey_ekey'});
+$key =~ /BEGIN .*PRIVATE KEY/ &&
+  $key =~ /END .*PRIVATE KEY/ || &error($text{'savekey_ekey'});
 if (!$in{'cert_def'}) {
 	# Make sure cert is valid
 	$cert = $in{'cert'} || $in{'certfile'};


### PR DESCRIPTION
Apparently OpenSSL 1.0.0 no longer uses the phrase "RSA PRIVATE KEY" in the private keys it generates, opting to omit the "RSA " part of the string.

This commit accommodates both formats of keys, with a 4-character code reduction in total. Woo! ;)
