### PR TITLE
Debugging tweak

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -166,3 +166,4 @@ Added support for Ubuntu 12.04.
 ---- Changes since 1.590 ----
 Even more German translation updates, thanks to Raymond Vetter.
 Norwegian updates, thanks to Stein-Aksel Basma.
+Switch order of command and mode in debug logs to make it clear that "mode=X" is part of the log, not part of the command.

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -8797,7 +8797,7 @@ if (&is_readonly_mode() && !$safe) {
 		}
 	}
 # Really run it
-&webmin_debug_log('CMD', "cmd=$realcmd mode=$mode")
+&webmin_debug_log('CMD', "mode=$mode cmd=$realcmd")
 	if ($gconfig{'debug_what_cmd'});
 if ($mode == 0) {
 	return open($fh, "| $cmd");


### PR DESCRIPTION
Hi Jamie,

This tweak is to clarify the debug logs.  On my system i got this message in the logs:

18884 [31/Aug/2012 10:04:43.584169] root 10.1.0.1 samba CMD "cmd=/usr/bin/net -s /etc/samba/smb.conf groupmap list verbose mode=1"

This gives the impression that "mode=1" is part of the samba command, which it isn't.  The patch simply reverses the order of mode and cmd in the debug logs to make this clear.

Regards,
Paul
