### PR TITLE
Support MariaDB 10.x in the mysql module

### DIFF
--- a/mysql/mysql-lib.pl
+++ b/mysql/mysql-lib.pl
@@ -790,7 +790,7 @@ ${$_[0]} = $out if ($_[0]);
 if ($out =~ /lib\S+\.so/) {
 	return -1;
 	}
-elsif ($out =~ /distrib\s+((3|4|5|6)\.[0-9\.]*)/i) {
+elsif ($out =~ /distrib\s+((3|4|5|6|10)\.[0-9\.]*)/i) {
 	return $1;
 	}
 else {


### PR DESCRIPTION
The MariaDB version number has jumped ahead of MySQL and is now at 10.x.

mysql -V gives the following:
mysql  Ver 15.1 Distrib 10.0.1-MariaDB, for Linux (x86_64) using readline 5.1

This is a simple patch to get the module working again.  Perhaps MariaDB will need to be special-cased in the future.

I also found a discussion between other affected users at http://sourceforge.net/projects/webadmin/forums/forum/600155/topic/6686941
