### PR TITLE
Use Server Name Indication (SNI) for SSL certificate monitoring

### DIFF
--- a/status/sslcert-monitor.pl
+++ b/status/sslcert-monitor.pl
@@ -13,6 +13,7 @@ if ($_[0]->{'url'}) {
 
 	# Run the openssl command to connect
 	local $cmd = "openssl s_client -host ".quotemeta($host).
+		     " -servername ".quotemeta($host).
 		     " -port ".quotemeta($port)." </dev/null 2>&1";
 	local $out = &backquote_with_timeout($cmd, 10);
 	if ($?) {


### PR DESCRIPTION
SSL Certificate monitoring would consistently fail for me on a HTTPS site using a shared IP address because s_client wasn't using Server Name Indication (SNI) and therefore the certificate for the default site was being checked. The failure was because I had "detect hostname mismatch" turned on which is good otherwise I wouldn't have known it was checking the wrong cert. This servername option has been supported in openssl for many years (despite the option not being listed on the man page) so I suspect it's fine to rely on this argument. I'm not sure if there is a case where supplying the servername argument would be undesirable.
