### PR TITLE
Improve download speed of large files

### DIFF
--- a/updown/fetch.cgi
+++ b/updown/fetch.cgi
@@ -53,8 +53,8 @@ if ($ENV{'PATH_INFO'}) {
 		print "Content-type: application/zip\n\n";
 		open(FILE, $temp);
 		unlink($temp);
-		while(<FILE>) {
-			print $_;
+		while(read(FILE, $buffer, 1000000)) {
+			print("$buffer");
 			}
 		close(FILE);
 		}
@@ -83,8 +83,8 @@ if ($ENV{'PATH_INFO'}) {
 		@st = stat($file);
 		print "Content-length: $st[7]\n";
 		print "Content-type: $type\n\n";
-		while(<FILE>) {
-			print $_;
+		while(read(FILE, $buffer, 1000000)) {
+			print("$buffer");
 			}
 		close(FILE);
 		}


### PR DESCRIPTION
When downloading a 800MB file over a LAN connection using the "Upload and download" module it took over an hour. With this fix it was completed in 30 seconds. 

Versions:
Webmin 1.630
Debian 6.0
Safari 6.0.5
