### PR TITLE
Fix for bug #4094. dns-search is now only one line.

### DIFF
--- a/net/linux-lib.pl
+++ b/net/linux-lib.pl
@@ -520,7 +520,7 @@ if ($gconfig{'os_type'} eq 'debian-linux' && defined(&get_interface_defs)) {
 	local @ifaces = &get_interface_defs();
 	local @dnssearch;
 	if (@{$_[0]->{'domain'}} > 1) {
-		@dnssearch = map { [ 'dns-search', $_ ] } @{$_[0]->{'domain'}};
+		@dnssearch = ( [ 'dns-domain', join(" ", @{$_[0]->{'domain'}}) ] );
 		}
 	elsif (@{$_[0]->{'domain'}}) {
 		@dnssearch = ( [ 'dns-domain', $_[0]->{'domain'}->[0] ] );


### PR DESCRIPTION
Fix for bug #4094

http://sourceforge.net/p/webadmin/bugs/4094/

Newer versions of Debian and Ubuntu do not work with multiple dns-search lines in /etc/network/interfaces.
