### PR TITLE
Fix header missing

### DIFF
--- a/acl/twofactor_form.cgi
+++ b/acl/twofactor_form.cgi
@@ -8,6 +8,7 @@ require './acl-lib.pl';
 &ReadParse();
 
 if (!$miniserv{'twofactor_provider'}) {
+	&ui_print_header(undef, $text{'twofactor_title'});
 	&ui_print_endpage(&text('twofactor_setup',
 				'../webmin/edit_twofactor.cgi'));
 	return;


### PR DESCRIPTION
File acl/twofactor_form.cgi return "Error - Bad Header" when Two-factor authentication not enabled.
