### PR TITLE
Avoid warning messages of squid

### DIFF
--- a/squid/squid-lib.pl
+++ b/squid/squid-lib.pl
@@ -16,7 +16,7 @@ our @caseless_acl_types = ( "url_regex", "urlpath_regex", "proxy_auth_regex",
 			    "srcdom_regex", "dstdom_regex", "ident_regex" );
 
 # Get the squid version
-our $squid_version = &read_file_contents("$module_config_directory/version");
+our $squid_version = &read_file_contents("$module_config_directory/version") || 0;
 $squid_version =~ s/\r|\n//g;
 
 # choice_input(text, name, &config, default, [display, option]+)


### PR DESCRIPTION
There were these error messages in /var/webmin/miniserv.error when squid is not installed.

Use of uninitialized value $squid::squid_version in substitution (s///) at ./squid-lib.pl line 20.
Use of uninitialized value $squid::squid_version in numeric ge (>=) at ./squid-lib.pl line 295.
Use of uninitialized value $squid::squid_version in numeric ge (>=) at ./squid-lib.pl line 302.
Use of uninitialized value $squid::squid_version in numeric ge (>=) at ./squid-lib.pl line 307.
Use of uninitialized value $squid::squid_version in numeric ge (>=) at ./squid-lib.pl line 312.
Use of uninitialized value $squid::squid_version in numeric ge (>=) at ./squid-lib.pl line 316.
