### PR TITLE
Do not use LDAP objectclass userclass and groupclass, instead use what is configu...

### DIFF
--- a/acl/acl-lib.pl
+++ b/acl/acl-lib.pl
@@ -1450,8 +1450,8 @@ if ($userdb) {
 		}
 	elsif ($proto eq "ldap") {
 		# Search in LDAP
-		my $fromclass = $fromtype eq "user" ? "userclass"
-						    : "groupclass";
+		my $fromclass = $fromtype eq "user" ? $args->{'userclass'}
+						    : $args->{'groupclass'};
 		my $rv = $dbh->search(
 			base => $prefix,
 			filter => '(&(cn='.$from.')(objectClass='.
@@ -1460,8 +1460,8 @@ if ($userdb) {
 		$rv->code && &error($rv->error);
 		my ($fromobj) = $rv->all_entries;
 		$fromid = $fromobj ? $fromobj->dn() : undef;
-		my $toclass = $totype eq "user" ? "userclass"
-						: "groupclass";
+		my $toclass = $totype eq "user" ? $args->{'userclass'}
+						: $args->{'groupclass'};
 		$rv = $dbh->search(
 			base => $prefix,
 			filter => '(&(cn='.$to.')(objectClass='.


### PR DESCRIPTION
...red as userclass and groupclass.
Without this change, copy_acl_files will copy LDAP ACL only if the objectclass for the user is userclass und the objectclass for the group is groupclass, which is not the case most times.
Userclass and groupclass can be configured, but is not used in copy_acl_file in case of LDAP.
