### PR TITLE
Minor modification to let Webmin run with Apache without patching after installation.

### DIFF
--- a/WebminCore.pm
+++ b/WebminCore.pm
@@ -30,8 +30,11 @@ push(@EXPORT, qw($config_directory $var_directory $remote_error_handler %month_t
 push(@EXPORT, qw(&theme_post_save_domain &theme_post_save_domains &theme_post_save_server &theme_select_server &theme_select_domain &theme_post_save_folder &theme_post_change_modules &theme_address_button &theme_virtualmin_ui_rating_selector &theme_virtualmin_ui_show_cron_time &theme_virtualmin_ui_parse_cron_time &theme_virtualmin_ui_html_editor_bodytags &theme_virtualmin_ui_show_html_editor));
 
 $called_from_webmin_core = 1;
-do "web-lib.pl";
-do "ui-lib.pl";
+my $script;
+$script = -r '../web-lib.pl' ? '../web-lib.pl' : './web-lib.pl';
+do $script;
+$script = -r '../ui-lib.pl' ? '../ui-lib.pl' : './ui-lib.pl';
+do $script;
 
 1;
 

--- a/webmin/refresh_modules.cgi
+++ b/webmin/refresh_modules.cgi
@@ -1,7 +1,7 @@
 #!/usr/local/bin/perl
 # Refresh the list of visible modules
 
-require 'webmin-lib.pl';
+require './webmin-lib.pl';
 &ReadParse();
 
 &ui_print_unbuffered_header(undef, $text{'refreshmods_title'}, "", undef, 0, 1);

--- a/webmin/webmin-lib.pl
+++ b/webmin/webmin-lib.pl
@@ -1035,7 +1035,7 @@ if ($cache) {
 	}
 my $temp = &transname();
 my $perl = &get_perl_path();
-system("$perl $root_directory/oschooser.pl $file $temp 1");
+system("$root_directory/oschooser.pl $file $temp 1");
 my %rv;
 &read_env_file($temp, \%rv);
 $rv{'time'} = time();


### PR DESCRIPTION
When running Webmin through Apache, some perl includes cannot be found with the same path specification as miniserv.
The proposed path change works also for miniserv usage (backward compatible)..
When running under Apache with setuid rights, the perl call in the scripts must be changed by adding "-UX". This is easy to do, as Webmin installation does the same with the perl path. But there is one line (webmin-lib.pl call of oschooser) where another script is called with perl path specified. This wont have the -UX included after installation, so this does not work.
As oschooser.pl has the path of the perl interpreter already in itself (first line), it is not necessary to call with perl. If not done, change of perl path with -UX matches all occurrences.
