### PR TITLE
Update index.cgi

### DIFF
--- a/file/index.cgi
+++ b/file/index.cgi
@@ -81,6 +81,11 @@ if ($config{'extract'} &&
 	}
 
 print <<EOF;
+
+<style>
+body { margin: 0px; }
+</style>
+
 <script>
 function upload(dir)
 {


### PR DESCRIPTION
In Google Chrome with the default body margin of 8px, the Java applet gets confused as to where you are clicking. Setting the body margin to 0px fixes the problem and makes the applet fill the space properly.
