### PR TITLE
Slow FileManager downloads

### DIFF
--- a/file/show.cgi
+++ b/file/show.cgi
@@ -112,7 +112,7 @@ if ($in{'format'}) {
 	print "Content-type: $type\n\n";
 	open(FILE, $temp);
 	unlink($temp);
-	while(read(FILE, $buf, 1024)) {
+	while(read(FILE, $buf, 1000000)) {
 		print $buf;
 		}
 	close(FILE);
@@ -136,13 +136,13 @@ else {
 	print "X-Content-Type-Options: nosniff\n";
 	&print_content_type($type);
 	if ($type =~ /^text\/html/i && !$in{'edit'}) {
-		while(read(FILE, $buf, 1024)) {
+		while(read(FILE, $buf, 1000000)) {
 			$data .= $buf;
 			}
 		print &filter_javascript($data);
 		}
 	else {
-		while(read(FILE, $buf, 1024)) {
+		while(read(FILE, $buf, 1000000)) {
 			print $buf;
 			}
 		}


### PR DESCRIPTION
The 1024 read length seemed to be causing slow downloads (3 Mbps) on local networks. Changing it to 1000000 like the "Upload and Download" module fixes this problem and I get more than 50 Mbps.  I tried 1,000,000,000 but it locked up my server briefly.

This update matches the value in:
https://github.com/webmin/webmin/blob/master/updown/fetch.cgi
