### PR TITLE
Add TLSv1.1 and TLSv1.2 in mod_ssl.pl

### DIFF
--- a/apache/mod_ssl.pl
+++ b/apache/mod_ssl.pl
@@ -34,7 +34,7 @@ if ($in{'SSLEngine'} eq 'on' &&
 return &parse_choice("SSLEngine");
 }
 
-@sslprotos = ("SSLv2", "SSLv3", "TLSv1");
+@sslprotos = ("SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2");
 sub edit_SSLProtocol
 {
 local ($rv, $p, %prot);


### PR DESCRIPTION
This patch adds TLSv1.1 and TLSv1.2 to @sslprotos in mod_ssl.pl.

Without this patch the user will have to manually enable TLSv1.2
support in their apache configuration. TLSv1.2 support is required
to recieve a good SSL score on the Qualys SSL test (otherwise the
score is capped to B).
#172
