### PR TITLE
Added check for hide_admin_url config item

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1304,7 +1304,7 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 			&write_keep_alive(0);
 			&write_data("\r\n");
 			return 0;
-		} elsif ($config{'display_admin_url'} != 0) {
+		} elsif ($config{'hide_admin_url'} <> 1) {
 			# Tell user the correct URL
 			&http_error(200, "Document follows",
 				"This web server is running in SSL mode. ".
@@ -1363,7 +1363,7 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 				&write_keep_alive(0);
 				&write_data("\r\n");
 				return 0;
-			} elsif ($config{'display_admin_url'} != 0) {
+			} elsif ($config{'hide_admin_url'} <> 1) {
 				# Tell user the correct URL
 				&http_error(200, "Bad Request", "This web server is not running in SSL mode. Try the URL <a href='$url'>$url</a> instead.<br>");
 			} else {


### PR DESCRIPTION
Added check for display_admin_url config item which if not 
set to 1 will prevent the server from revealing the admin URL
when the user visits the incorrect domain
(more useful in combination with the musthost config item)

This allows the user to lock the admin to a specific domain and
prevent the server revealing that domain to the public
