### PR TITLE
Add httpOnly to cookies on login page. Solves #4565.

### DIFF
--- a/pam_login.cgi
+++ b/pam_login.cgi
@@ -23,6 +23,9 @@ if ($gconfig{'loginbanner'} && $ENV{'HTTP_COOKIE'} !~ /banner=1/ &&
 	return;
 	}
 $sec = uc($ENV{'HTTPS'}) eq 'ON' ? "; secure" : "";
+if (!$config{'no_httponly'}) {
+	$sec .= "; httpOnly";
+}
 &get_miniserv_config(\%miniserv);
 $sidname = $miniserv{'sidname'} || "sid";
 print "Set-Cookie: banner=0; path=/$sec\r\n" if ($gconfig{'loginbanner'});

--- a/session_login.cgi
+++ b/session_login.cgi
@@ -24,6 +24,9 @@ if ($gconfig{'loginbanner'} && $ENV{'HTTP_COOKIE'} !~ /banner=1/ &&
 	return;
 	}
 $sec = uc($ENV{'HTTPS'}) eq 'ON' ? "; secure" : "";
+if (!$config{'no_httponly'}) {
+	$sec .= "; httpOnly";
+}
 &get_miniserv_config(\%miniserv);
 $sidname = $miniserv{'sidname'} || "sid";
 print "Set-Cookie: banner=0; path=/$sec\r\n" if ($gconfig{'loginbanner'});


### PR DESCRIPTION
Add httpOnly to pam_login and session_login to avoid security scans reporting false positives on cookies without httpOnly.

Should solve http://sourceforge.net/p/webadmin/bugs/4565/