### PR TITLE
Important addition to make icons work with Authentic Theme

### DIFF
--- a/apache/index.cgi
+++ b/apache/index.cgi
@@ -368,10 +368,12 @@ else {
 	print "<table width=100% cellpadding=5>\n";
 	for($i=0; $i<@vname; $i++) {
 		print "<tr class='mainbody ".($i % 2 ? 'row0' : 'row1')."'> <td valign=top align=center nowrap>";
+		print '<div class="row icons-row inline-row">';
 		&generate_icon("images/virt.gif", $vname[$i], $vlink[$i],
 			       undef, undef, undef,
 			       $vidx[$i] && $access{'vaddr'} ?
 					&ui_checkbox("d", $vidx[$i]) : "");
+		print "</div>\n";
 		print "</td> <td valign=top>\n";
 		print "$vdesc[$i]<br>\n";
 		print "<table width=100%><tr>\n";


### PR DESCRIPTION
Jamie, ok! It's very complicated to make things work in all possible situations. At the moment it doesn't work as in 90% of cases the certain rules are used. Those are that container for `&generate_icon` should be `<div class="row icons-row></div>`. In case it's done in funky way like in this module, I add extra class `inline-row` to make things work. For example, latest update 13.03 does great with style, that is used in Webmin Servers Index module. You can test it. Try using right mouse clicks for selects.

I strongly recommend, to try to recall all funky ways of using `&generate_icon` like in this module and add  `<div class="row icons-row></div>` wrapper.

It will not affect neither your nor Joe's themes.

Thanks!