### PR TITLE
Fixed not calling switch_from_folder_user() for some types of maildir

### DIFF
--- a/mailboxes/folders-lib.pl
+++ b/mailboxes/folders-lib.pl
@@ -1719,7 +1719,7 @@ if ($f->{'type'} == 0) {
 	}
 elsif ($f->{'type'} == 1) {
 	# A qmail maildir
-	return &count_maildir($f->{'file'});
+	$rv = &count_maildir($f->{'file'});
 	}
 elsif ($f->{'type'} == 2) {
 	# A POP3 server
@@ -1739,7 +1739,7 @@ elsif ($f->{'type'} == 2) {
 	}
 elsif ($f->{'type'} == 3) {
 	# An MH directory
-	return &count_mhdir($f->{'file'});
+	$rv = &count_mhdir($f->{'file'});
 	}
 elsif ($f->{'type'} == 4) {
 	# An IMAP server


### PR DESCRIPTION
My spam was no longer being cleared up automatically and after some investigation and debugging it turned out that it doesn't work correctly when you use qmail maildirs. The first user on a domain will work just fine, any others will run into permission errors.

This turned out to be caused by not resetting the switch_to_folder_user() on certain types of mail directory by calling switch_from_folder_user() when needed. I replaced some return statements with an assignment to $rv. There may be other changed needed in the module, but with these changes it worked correctly for me.

The error messages looked like this:

    Error
    -----
    Failed to open /home/<user>/domains/<domain>/homes/<emailuser>/Maildir/.spam/cur : Permission denied
    -----
