### PR TITLE
Add check for VirtIO to possible interface types

### DIFF
--- a/net/linux-lib.pl
+++ b/net/linux-lib.pl
@@ -447,6 +447,10 @@ if ($name =~ /^(.*)\.(\d+)$/) {
 return "PPP" if ($name =~ /^ppp/);
 return "SLIP" if ($name =~ /^sl/);
 return "PLIP" if ($name =~ /^plip/);
+# Check if this is a VirtIO interface
+my $ethtool = &has_command("ethtool");
+my $out = &backquote_command("$ethtool -i $name 2>/dev/null");
+return "VirtIO Interface" if ($out =~ /driver:\s+virtio_net/i);
 return "Ethernet" if ($name =~ /^eth|em|eno|ens|enp|enx|p\d+p\d+/);
 return "Wireless Ethernet" if ($name =~ /^(wlan|ath)/);
 return "Arcnet" if ($name =~ /^arc/);


### PR DESCRIPTION
A VirtIO interface is now shown as "Ethernet" because it is a "ethX"
The speed will never be shown as there is no "speed" for a VirtIO interface because it is a virtual interface. This way makes a distinction between Ethernet and VirtIO interfaces.