### PR TITLE
get_paths(); doesn't return proper results

### DIFF
--- a/filemin/bookmark.cgi
+++ b/filemin/bookmark.cgi
@@ -5,7 +5,7 @@ use lib './lib';
 
 &ReadParse();
 
-get_paths();
+switch_to_remote_user();
 
 $confdir = "$remote_user_info[7]/.filemin";
 if(!-e $confdir) {


### PR DESCRIPTION
For wheel users (non-root but admins) `get_paths();` has a bug and doesn't work correctly.

It causes some other issues in user mode. Probably, if you on the `inthebox` login as `blog` user and go to File Manager, click copy - Perl Error happens. (under all themes)