### PR TITLE
Support for extracting: .7z, .bz2, .xz, .gz, .rar

### DIFF
--- a/filemin/extract.cgi
+++ b/filemin/extract.cgi
@@ -9,16 +9,29 @@ get_paths();
 
 $archive_type = mimetype($cwd.'/'.$in{'file'});
 
-if ($archive_type eq 'application/zip') {
-    &backquote_logged("unzip ".quotemeta("$cwd/$in{'file'}").
-		      " -d ".quotemeta($cwd));
+
+if ( index( $archive_type, "x-bzip" ) != -1 ) {
+    &backquote_logged( "tar xvjfp " . quotemeta("$cwd/$in{'file'}") . " -C " . quotemeta($cwd) );
     &redirect("index.cgi?path=$path");
-} elsif (index($archive_type, "tar") != -1) {
-    &backquote_logged("tar xf ".quotemeta("$cwd/$in{'file'}").
-		      " -C ".quotemeta($cwd));
-    &redirect("index.cgi?path=$path");
-} else {
-    &ui_print_header(undef, "Filemin", "");
-    print "$archive_type $text{'error_archive_type_not_supported'}";
-    &ui_print_footer("index.cgi?path=$path", $text{'previous_page'});
 }
+elsif (index( $archive_type, "x-tar" ) != -1
+    || index( $archive_type, "/gzip" ) != -1
+    || index( $archive_type, "x-xz" ) != -1
+    || index( $archive_type, "x-compressed-tar" ) != -1 )
+{
+    &backquote_logged( "tar xfp " . quotemeta("$cwd/$in{'file'}") . " -C " . quotemeta($cwd) );
+    &redirect("index.cgi?path=$path");
+}
+elsif ( index( $archive_type, "x-7z" ) != -1 ) {
+    &backquote_logged( "7z x " . quotemeta("$cwd/$in{'file'}") . " -o" . quotemeta($cwd) );
+    &redirect("index.cgi?path=$path");
+}
+elsif ( index( $archive_type, "/zip" ) != -1 ) {
+    &backquote_logged( "unzip " . quotemeta("$cwd/$in{'file'}") . " -d " . quotemeta($cwd) );
+    &redirect("index.cgi?path=$path");
+}
+elsif ( index( $archive_type, "/x-rar" ) != -1 ) {
+    &backquote_logged( "unrar x -r -y " . quotemeta("$cwd/$in{'file'}") . " " . quotemeta($cwd) );
+    &redirect("index.cgi?path=$path");
+}
+


### PR DESCRIPTION
Commands are checked before they run so no need for last else part which outputted an error message. The rest of the code I will add to -lib file.

P.S. Jamie, I tried removing `use File::MimeInfo;` in this file as on current branch and it returned an error!? Please double check.

P.S.S. Just noticed - `&redirect("index.cgi?path=$path");` must be put to the very end only once.