### PR TITLE
For search page path could be printed twice in some cases

### DIFF
--- a/filemin/filemin-lib.pl
+++ b/filemin/filemin-lib.pl
@@ -269,8 +269,12 @@ sub print_interface {
 
         $actions = "<a class='action-link' href='javascript:void(0)' onclick='renameDialog(\"$vlink\")' title='$text{'rename'}' data-container='body'>$rename_icon</a>";
 
-        if ($list[$count - 1][15] == 1) {
-            $href = "index.cgi?path=".&urlize("$path/$link");
+        if ( $list[ $count - 1 ][15] == 1 ) {
+            if ($path eq '/'. $link) {
+                $href = "index.cgi?path=" . &urlize("$path");
+            } else {
+                $href = "index.cgi?path=" . &urlize("$path/$link");
+            }
         } else {
             $href = "download.cgi?file=".&urlize($link)."&path=".&urlize($path);
             if($0 =~ /search.cgi/) {


### PR DESCRIPTION
This fix will prevent double printing of the path for searched (found) folders.

It doesn't happen always but only if search results contain same value for directory and file.

Can be reproduced by going to `/boot/grub` and searching for `grub`. With the current code the folder `grub` (same as the current folder) printed on the results with doubled path on the link and thus doesn't open correctly. The best is to tweak `search.cgi` that filters search results and remove from results same folder as parent. It's more complicated. My fix does it safely, I think.