### PR TITLE
Use SNI for make_http_connection connections. Fixes #355

### DIFF
--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -7347,6 +7347,7 @@ if ($ssl) {
 		return $error if ($error);
 		}
 	Net::SSLeay::set_fd($rv->{'ssl_con'}, fileno($rv->{'fh'}));
+	Net::SSLeay::set_tlsext_host_name($rv->{'ssl_con'}, $host);
 	Net::SSLeay::connect($rv->{'ssl_con'}) ||
 		return "SSL connect() failed";
 	if ($certreqs) {


### PR DESCRIPTION
This seems to fix the problem in #355 but I don't know enough about `Net::SSLeay` or SNI specs to know if this will break connections to servers using old SSL versions. From a skim on Github of other repos using `Net::SSLeay::set_tlsext_host_name`, it seems like it's normally used unconditionally like I am. I didn't test other parts of webmin (other than the status monitoring) with this change but I am using it on my production server at the moment.