### PR TITLE
That seems incorrect for non numerical values

### DIFF
--- a/ui-lib.pl
+++ b/ui-lib.pl
@@ -1131,7 +1131,7 @@ my ($name, $value, $yes, $no, $dis) = @_;
 return &theme_ui_yesno_radio(@_) if (defined(&theme_ui_yesno_radio));
 $yes = 1 if (!defined($yes));
 $no = 0 if (!defined($no));
-$value = int($value);
+#$value = int($value);
 return &ui_radio($name, $value, [ [ $yes, $text{'yes'} ],
 				  [ $no, $text{'no'} ] ], $dis);
 }


### PR DESCRIPTION
In case it's used you can't use other values there, like 'true/false'. I think it should be removed, right?