### PR TITLE
Hotfix: Update typo from samba-lib.pl preventing add a group

### DIFF
--- a/samba/samba-lib.pl
+++ b/samba/samba-lib.pl
@@ -963,7 +963,7 @@ else {
 	local $maxrid = $out =~ /rid:\s+(\d+)/ ? $1 + 1 : undef;
 	$maxrid = 1000 if ($maxrid < 1000);	# Should be >1000
 	if (&foreign_check("useradmin")) {
-		&foriegn_require("useradmin");
+		&foreign_require("useradmin");
 		local %taken;
 		&useradmin::build_user_used(\%taken);
 		while($taken{$maxrid}) {


### PR DESCRIPTION
foriegn_require => foreign_require