### PR TITLE
Clone rules are added after the original Rule

### DIFF
--- a/firewall/save_rule.cgi
+++ b/firewall/save_rule.cgi
@@ -19,6 +19,7 @@ if ($in{'clone'}) {
 	# Go back to the editing page
 	&redirect("edit_rule.cgi?new=1&clone=$in{'idx'}&".
 		  "table=".&urlize($in{'table'})."&".
+		  "after=$in{'idx'}&".
 		  "chain=".&urlize($rule->{'chain'}));
 	}
 


### PR DESCRIPTION
In the existing state the clone rules are added in the bottom of the firewall wall rule list. Generally the clone rules are for similar interface, port, etc and most of the time after adding they need to be arranged. The change enable the clone rule to be placed after the original rule. This will allow a better comparison and arrangement of the firewall rules.