### PR TITLE
increase specificity of regex to avoid problems with new output from certbot/letsencrypt client

### DIFF
--- a/webmin/letsencrypt-lib.pl
+++ b/webmin/letsencrypt-lib.pl
@@ -81,7 +81,7 @@ if ($letsencrypt_cmd) {
 		return (0, "<pre>".&html_escape($out || "No output from $letsencrypt_cmd")."</pre>");
 		}
 	my ($full, $cert, $key, $chain);
-	if ($out =~ /(\/etc[a-zA-Z0-9\.\_\-\/\r\n ]*\.pem)/) {
+	if ($out =~ /(\/etc\/letsencrypt\/(?:live|archive)\/[a-zA-Z0-9\.\_\-\/\r\n ]*\.pem)/) {
 		# Output contained the full path
 		$full = $1;
 		$full =~ s/\s//g;


### PR DESCRIPTION
Some changes in the output of certbot/letsencrypt mean that the general regex is matching lines like `/etc/letsencrypt/keys/0037_key-certbot.pem` - this is resulting in the directory for finding cert.pem, fullchain.pem and privkey.pem is incorrect - they are looking up in `/etc/letsencrypt/keys/` instead of `/etc/letsencrypt/live/{domain}/`.

being this only applies when `$letsencrypt_cmd` has been set, it should be safe to push it to `/etc/letsencrypt/(live|archive)` as a hard folder match, to avoid this issue.
