### PR TITLE
Don't blank the password field on the login page

### DIFF
--- a/session_login.cgi
+++ b/session_login.cgi
@@ -39,8 +39,7 @@ if ($gconfig{'showhost'}) {
 &ui_print_unbuffered_header(
 	undef, undef, undef, undef, undef, 1, 1, undef,
 	"<title>$title</title>",
-	"onLoad='document.forms[0].pass.value = \"\"; ".
-	"document.forms[0].user.focus()'");
+	"onLoad='document.forms[0].user.focus()'");
 
 if ($tconfig{'inframe'}) {
 	# Framed themes lose original page


### PR DESCRIPTION
This interferes with password managers and the general consensus from the security community is that password managers improve security by encouraging stronger passwords and reducing password re-use.

There was no useful GIT blame for this line as it dates back to the initial import. I assume it's leftover from the old days and thinking has changed since then.