### PR TITLE
Enable/Disable for Winbind & File/Printer Share buttons

### DIFF
--- a/samba/acl_security.pl
+++ b/samba/acl_security.pl
@@ -84,6 +84,13 @@ printf "<input type=radio name=winbind value=0 %s> $text{'no'}</td>\n",
 		$_[0]->{'winbind'} ? "" : "checked";
 print "</tr>\n";
 
+print "<tr>\n<td><b>$text{'acl_bind'}</b></td> <td>\n";
+printf "<input type=radio name=conf_bind value=1 %s> $text{'yes'}\n",
+                $_[0]->{'conf_bind'} ? "checked" : "";
+printf "<input type=radio name=conf_bind value=0 %s> $text{'no'}</td>\n",
+                $_[0]->{'conf_bind'} ? "" : "checked";
+print "</tr>\n";
+
 print "<tr> <td colspan=4><hr></td> </tr>\n";
 
 # encripted passwords
@@ -223,6 +230,18 @@ sub acl_security_save
 if ($in{'r_fs'} < $in{'w_fs'} || $in{'r_ps'} < $in{'w_ps'}) {
 	&error($text{'acl_ernow'});
 	}
+
+# If create, read, AND write are all turned off... dont SHOW file shares...
+$_[0]->{'conf_fs'}=1;
+if ($in{'c_fs'} == "" && $in{'r_fs'} == "" && $in{'w_fs'} == "") {
+        $_[0]->{'conf_fs'}=0;
+        }
+# If create, read, AND write are all turned off... dont SHOW print shares...
+$_[0]->{'conf_ps'}=1;
+if ($in{'c_ps'} == "" && $in{'r_ps'} == "" && $in{'w_ps'} == "") {
+        $_[0]->{'conf_ps'}=0;
+        }
+
 $_[0]->{'apply'}=$in{'apply'};
 $_[0]->{'view_all_con'}=$in{'view_all_con'};
 $_[0]->{'kill_con'}=$in{'kill_con'};
@@ -250,6 +269,7 @@ $_[0]->{'maint_sync'}=$in{'maint_sync'};
 $_[0]->{'maint_groups'}=$in{'maint_groups'};
 $_[0]->{'maint_gsync'}=$in{'maint_gsync'};
 $_[0]->{'winbind'}=$in{'winbind'};
+$_[0]->{'conf_bind'}=$in{'conf_bind'};
 
 foreach (keys %in) {
 	  $_[0]->{$1} .= $in{$_} if /^\w\w_(ACL\w\w_\w+)$/;

--- a/samba/defaultacl
+++ b/samba/defaultacl
@@ -28,3 +28,5 @@ maint_gsync=1
 winbind=1
 conf_bind=1
 manual=1
+conf_fs=1
+conf_ps=1

--- a/samba/index.cgi
+++ b/samba/index.cgi
@@ -180,41 +180,62 @@ if ($donefirst) {
 	print &ui_form_end([ [ "delete", $text{'index_delete'} ] ]);
 	}
 
-@gc_acl = qw(conf_net conf_smb conf_pass conf_print conf_misc conf_bind
-			  ACLfs_global ACLps_global manual swat winbind);
-@gc_progs = ("conf_net.cgi", "conf_smb.cgi", "conf_pass.cgi",
-	     "conf_print.cgi", "conf_misc.cgi", "conf_bind.cgi",
-	     "edit_fshare.cgi?share=global", "edit_pshare.cgi?share=global",
-	     "edit_manual.cgi");
-@gc_names = ($text{'global_unixnetwork'}, $text{'global_winnetwork'},
-	     $text{'global_auth'}, $text{'global_printing'},
-	     $text{'global_misc'}, $text{'global_bind'},
-	     $text{'global_filedefault'},
-	     $text{'global_prndefault'},
-	     $text{'manual_title'});
-@gc_icons = ("images/icon_0.gif", "images/icon_1.gif", "images/icon_2.gif",
-	     "images/icon_3.gif", "images/icon_4.gif",
-	     "images/icon_10.gif", "images/icon_5.gif", "images/icon_6.gif",
-	     "images/manual.gif");
+# Generate table of accessible global configuration icons
+if ($access{'conf_net'}) {
+	push(@gc_progs, "conf_net.cgi");
+	push(@gc_names, $text{'global_unixnetwork'});
+        push(@gc_icons, "images/icon_0.gif");
+	}
+if ($access{'conf_smb'}) {
+	push(@gc_progs, "conf_smb.cgi");
+	push(@gc_names, $text{'global_winnetwork'});
+	push(@gc_icons, "images/icon_1.gif");
+	}
+if ($access{'conf_pass'}) {
+        push(@gc_progs, "conf_pass.cgi");
+        push(@gc_names, $text{'global_auth'});
+        push(@gc_icons, "images/icon_2.gif");
+	}
+if ($access{'conf_print'}) {
+        push(@gc_progs, "conf_print.cgi");
+        push(@gc_names, $text{'global_printing'});
+        push(@gc_icons, "images/icon_3.gif");
+	}
+if ($access{'conf_misc'}) {
+        push(@gc_progs, "conf_misc.cgi");
+        push(@gc_names, $text{'global_misc'});
+        push(@gc_icons, "images/icon_4.gif");
+	}
+if ($access{'conf_bind'}) {
+        push(@gc_progs, "conf_bind.cgi");
+        push(@gc_names, $text{'global_bind'});
+        push(@gc_icons, "images/icon_10.gif");
+	}
+if ($access{'conf_fs'}) {
+        push(@gc_progs, "edit_fshare.cgi?share=global");
+        push(@gc_names, $text{'global_filedefault'});
+        push(@gc_icons, "images/icon_5.gif");
+	}
+if ($access{'conf_ps'}) {
+        push(@gc_progs, "edit_pshare.cgi?share=global");
+        push(@gc_names, $text{'global_prndefault'});
+        push(@gc_icons, "images/icon_6.gif");
+	}
+if ($access{'manual'}) {
+        push(@gc_progs, "edit_manual.cgi");
+        push(@gc_names, $text{'manual_title'});
+        push(@gc_icons, "images/manual.gif");
+	}
 if (&has_command($config{'swat_path'})) {
 	push(@gc_progs, "swat.cgi");
-	push(@gc_names, "SWAT");
+	push(@gc_names, $text{'swat_title'});
 	push(@gc_icons, "images/icon_9.gif");
 	}
 
-foreach $i (0..$#gc_acl) {
-	next unless ($access{$gc_acl[$i]} && $gc_progs[$i]);
-	next if ($gc_acl[$i] eq "conf_winbind" && $samba_version < 3);
-	push(@gc_progs1, $gc_progs[$i]);
-	push(@gc_names1, $gc_names[$i]);
-	push(@gc_icons1, $gc_icons[$i]);
-	$disp++;
-	}
-
-if ($disp) {
+if (@gc_progs) {
 	print &ui_hr();
 	print &ui_subheading($text{'global_title'});
-	&icons_table(\@gc_progs1, \@gc_names1, \@gc_icons1, 4);
+	&icons_table(\@gc_progs, \@gc_names, \@gc_icons, 4);
 	}
 
 # Generate table of accessible user and group editing icons
@@ -297,4 +318,3 @@ if ($access{'apply'}) {
 	}
 
 &ui_print_footer("/", $text{'index'});
-

--- a/samba/lang/en
+++ b/samba/lang/en
@@ -569,6 +569,7 @@ acl_group_opts=Samba group options
 acl_maint_groups=Can view, edit and add groups?
 acl_maint_gsync=Can maintain auto UNIX to SAMBA groups sync?
 acl_winbind=Can bind to domains?
+acl_bind=Can access winbind options?
 
 groups_title=Samba Groups
 groups_name=Group name

--- a/samba/rbac-mapping
+++ b/samba/rbac-mapping
@@ -1,4 +1,4 @@
 # RBAC authorization		# Webmin ACL
 solaris.admin.fsmgr.write	noconfig=1
-solaris.admin.fsmgr.read	r_fs=1,noconfig=1,maint_users=0,conf_print=0,conf_pass=0,view_users=0,swat=0,conf_misc=0,copy=0,apply=0,c_ps=,per_ps_acls=0,r_ps=1,maint_gsync=0,winbind=0,maint_sync=0,per_fs_acls=0,conf_smb=0,conf_net=0,kill_con=0,view_all_con=0,c_fs=,maint_groups=0,w_ps=,hide=0,maint_makepass=0,w_fs=,winbind=0,conf_bind=0,ACLfs_global=0,ACLps_global=0
+solaris.admin.fsmgr.read	r_fs=1,noconfig=1,maint_users=0,conf_print=0,conf_pass=0,view_users=0,swat=0,conf_misc=0,copy=0,apply=0,c_ps=,per_ps_acls=0,r_ps=1,maint_gsync=0,winbind=0,maint_sync=0,per_fs_acls=0,conf_smb=0,conf_net=0,kill_con=0,view_all_con=0,c_fs=,maint_groups=0,w_ps=,hide=0,maint_makepass=0,w_fs=,winbind=0,conf_bind=0,ACLfs_global=0,ACLps_global=0,conf_fs=0,conf_ps=0
 


### PR DESCRIPTION
The following adds an administrative ability to:
- turn on or off the "winbind options" button
- if create/read/write ALL disabled for File sharing, then dont display the button
- if create/read/write ALL disabled for Printer sharing, then dont display the button

There is additional cleanup of some code inside of samba/index.cgi to improve readability, and minor fix to maintain more I18N consistency (see SWAT-title reference)

This DOES NOT fix the fact that "winbind" variables are used for the feature "Bind to Domain" and "conf_bind" variables are used for the feature "Winbind Options"... which is seemingly backward... but at least is consistent... so was left like that for now.