### PR TITLE
Let a function to accept non numeric value

### DIFF
--- a/ui-lib.pl
+++ b/ui-lib.pl
@@ -1131,7 +1131,9 @@ my ($name, $value, $yes, $no, $dis) = @_;
 return &theme_ui_yesno_radio(@_) if (defined(&theme_ui_yesno_radio));
 $yes = 1 if (!defined($yes));
 $no = 0 if (!defined($no));
-$value = int($value);
+if ( $value =~ /^[0-9,.E]+$/ ) {
+        $value = int($value);
+}
 return &ui_radio($name, $value, [ [ $yes, $text{'yes'} ],
 				  [ $no, $text{'no'} ] ], $dis);
 }


### PR DESCRIPTION
In case the way it is now, there is no use in custom values for radio buttons. For example, it will never let it to set it `false` or `true` (as a string), thus always passing an integer to the `ui_radio()`.