### PR TITLE
Excluding bind mounts properly

### DIFF
--- a/quota/linux-lib.pl
+++ b/quota/linux-lib.pl
@@ -82,14 +82,16 @@ the following :
 =cut
 sub quota_can
 {
-if ($_[0]->[2] =~ /^bind/) {
-	# Not possible on bind mounts
-	return 0;
-	}
-return ($_[1]->[3] =~ /usrquota|usrjquota/ ||
-	$_[0]->[3] =~ /usrquota|usrjquota/ ? 1 : 0) +
-       ($_[1]->[3] =~ /grpquota|grpjquota/ ||
-        $_[0]->[3] =~ /grpquota|grpjquota/ ? 2 : 0);
+    my %exclude_mounts =
+    map { $_ => 1 } split( /\n/m, backquote_command('findmnt | grep -oP \'\[\K[^\]]+\'') );
+    
+    # Not possible on bind mounts
+    if ( $_[0]->[2] =~ /^bind/ || exists( $exclude_mounts{ $_[0]->[0] } ) ) {
+        return 0;
+    }
+
+    return ( $_[1]->[3] =~ /usrquota|usrjquota/ || $_[0]->[3] =~ /usrquota|usrjquota/ ? 1 : 0 ) +
+      ( $_[1]->[3] =~ /grpquota|grpjquota/      || $_[0]->[3] =~ /grpquota|grpjquota/ ? 2 : 0 );
 }
 
 =head2 quota_now(&mnttab, &fstab)


### PR DESCRIPTION
Jamie, hi.

I finally had a time to take a look. The fix is simple and straight forward. It works perfectly on my production system. All "bad" mounts are excluded and not listed anymore.