### PR TITLE
Added v flag for tar extraction

### DIFF
--- a/backup-config/backup-config-lib.pl
+++ b/backup-config/backup-config-lib.pl
@@ -588,7 +588,7 @@ if (!$show) {
 	}
 
 # Extract contents (only files specified by manifests)
-my $flag = $show ? "t" : "x";
+my $flag = $show ? "t" : "xv";
 my $qfiles = join(" ", map { s/^\///; quotemeta($_) } &unique(@files));
 if ($gzipped) {
 	&execute_command("cd / ; gunzip -c $qfile | tar ${flag}f - $qfiles",


### PR DESCRIPTION
Added the v (verbose) flag when really extracting the backup tar.
If this flag is not set tar will not print the list of files, that are extracted. This leads to an empty output which later leads to an empty @$files when trying to split the output from the untar command.
This then leads to restore.cgi falsely reporting "0 files have been restored".
Tested on Ubuntu 14.04.5