### PR TITLE
fix: memory leak  - remove circular reference in bind8 lib

### DIFF
--- a/bind8/bind8-lib.pl
+++ b/bind8/bind8-lib.pl
@@ -284,7 +284,7 @@ if ($str{'name'} eq 'inet') {
 				my $substr = &parse_struct(
 						$_[0], $_[1], \$i, $j++, $_[4]);
 				if ($substr) {
-					$substr->{'parent'} = \%str;
+					$substr->{'parent'} = {%str};
 					push(@{$str{'members'}->{$t}}, $substr);
 					}
 				}
@@ -318,7 +318,7 @@ else {
 			my $substr = &parse_struct(
 				$_[0], $_[1], \$i, $j++, $_[4]);
 			if ($substr) {
-				$substr->{'parent'} = \%str;
+				$substr->{'parent'} = {%str};
 				push(@mems, $substr);
 				}
 			}


### PR DESCRIPTION
Spotted when restoring from backup.
So memory pressure when restoring is significantly reduced.