### PR TITLE
When there is no value we need to return 0 but not empty

### DIFF
--- a/ui-lib.pl
+++ b/ui-lib.pl
@@ -1131,7 +1131,7 @@ my ($name, $value, $yes, $no, $dis) = @_;
 return &theme_ui_yesno_radio(@_) if (defined(&theme_ui_yesno_radio));
 $yes = 1 if (!defined($yes));
 $no = 0 if (!defined($no));
-if ( $value =~ /^[0-9,.E]+$/ ) {
+if ( $value =~ /^[0-9,.E]+$/ || !$value) {
         $value = int($value);
 }
 return &ui_radio($name, $value, [ [ $yes, $text{'yes'} ],


### PR DESCRIPTION
As reported here, it's true:

https://github.com/qooob/authentic-theme/issues/726