### PR TITLE
For the future so user could choose encoding in file editor window

### DIFF
--- a/filemin/save_file.cgi
+++ b/filemin/save_file.cgi
@@ -20,8 +20,10 @@ $data = $in{'data'};
 $data =~ s/\r\n/\n/g;
 
 #52019
-if (get_charset() ne "UTF8" && get_charset() ne "UTF-8") {
-	$data = Encode::encode(get_charset(), Encode::decode('utf-8', $data));
+if ( ( get_charset() ne "UTF8" && get_charset() ne "UTF-8" ) || $in{'encoding'} ) {
+    $data =
+      Encode::encode( ( $in{'encoding'} ? $in{'encoding'} : get_charset() ),
+                      Encode::decode( 'utf-8', $data ) );
 }
 open(SAVE, ">", $cwd.'/'.$file) or push @errors, "$text{'error_saving_file'} - $!";
 print SAVE $data;


### PR DESCRIPTION
I think I did it correctly, theoretically looks good. I just don't know if `$in{'encoding'}` has to be escaped anyhow. Other than that, it seems ok, as when user passes encoding, it will tell the script to use one.