### PR TITLE
Make editor respect file's initial encoding: Viewer

### DIFF
--- a/filemin/edit_file.cgi
+++ b/filemin/edit_file.cgi
@@ -5,39 +5,49 @@ require './filemin-lib.pl';
 
 get_paths();
 
-$data = &read_file_contents($cwd.'/'.$in{file});
+my $data = &read_file_contents( $cwd . '/' . $in{file} );
 
-&ui_print_header(undef, $text{'edit_file'}, "");
+use Encode::Detect::Detector;
+my $encoding_name = Encode::Detect::Detector::detect($data);
+if ( $encoding_name && lc($encoding_name) ne "utf-8" ) {
+    use Encode qw( encode decode );
+    $data = Encode::encode( 'utf-8', Encode::decode( $encoding_name, $data ) );
+}
+
+&ui_print_header( undef, $text{'edit_file'}, "" );
 $head = "<link rel='stylesheet' type='text/css' href='unauthenticated/css/style.css' />";
 
-if ($current_theme ne 'authentic-theme') {
-    $head.= "<script type='text/javascript' src='unauthenticated/jquery/jquery.min.js'></script>";
-    $head.= "<script type='text/javascript' src='unauthenticated/jquery/jquery-ui.min.js'></script>";
-    $head.= "<link rel='stylesheet' type='text/css' href='unauthenticated/jquery/jquery-ui.min.css' />";
+if ( $current_theme ne 'authentic-theme' ) {
+    $head .= "<script type='text/javascript' src='unauthenticated/jquery/jquery.min.js'></script>";
+    $head .= "<script type='text/javascript' src='unauthenticated/jquery/jquery-ui.min.js'></script>";
+    $head .= "<link rel='stylesheet' type='text/css' href='unauthenticated/jquery/jquery-ui.min.css' />";
 
     # Include Codemirror specific files
-    $head.= "<link rel='stylesheet' href='unauthenticated/js/lib/codemirror/lib/codemirror.css' />";
-    $head.= "<script src='unauthenticated/js/lib/codemirror/lib/codemirror.js'></script>";
-    $head.= "<script src='unauthenticated/js/lib/codemirror/addon/mode/loadmode.js'></script>";
-    $head.= "<script src='unauthenticated/js/lib/codemirror/mode/meta.js'></script>";
-    $head.= "<script src='unauthenticated/js/lib/codemirror/mode/javascript/javascript.js'></script>";
-    $head.= "<script src='unauthenticated/js/lib/codemirror/mode/scheme/scheme.js'></script>";
-    $head.= "<style type='text/css'>.CodeMirror {height: auto;}</style>";
+    $head .= "<link rel='stylesheet' href='unauthenticated/js/lib/codemirror/lib/codemirror.css' />";
+    $head .= "<script src='unauthenticated/js/lib/codemirror/lib/codemirror.js'></script>";
+    $head .= "<script src='unauthenticated/js/lib/codemirror/addon/mode/loadmode.js'></script>";
+    $head .= "<script src='unauthenticated/js/lib/codemirror/mode/meta.js'></script>";
+    $head .= "<script src='unauthenticated/js/lib/codemirror/mode/javascript/javascript.js'></script>";
+    $head .= "<script src='unauthenticated/js/lib/codemirror/mode/scheme/scheme.js'></script>";
+    $head .= "<style type='text/css'>.CodeMirror {height: auto;}</style>";
 }
 
 print $head;
 
-print ui_table_start("$path/$in{'file'}", undef, 1);
+print ui_table_start( "$path/$in{'file'}", undef, 1 );
 
-print &ui_form_start("save_file.cgi", "post");
-print &ui_hidden("file", $in{'file'}),"\n";
-print &ui_textarea("data", $data, 20, 80, undef, undef, "style='width: 100%' id='data'");
-print &ui_hidden("path", $path);
-print &ui_form_end([ [ save, $text{'save'} ], [ save_close, $text{'save_close'} ] ]);
+print &ui_form_start( "save_file.cgi", "post", undef, "data-encoding=\"$encoding_name\"" );
+print &ui_hidden( "file", $in{'file'} ), "\n";
+print &ui_hidden( "encoding", $encoding_name ), "\n";
+print &ui_textarea( "data", $data, 20, 80, undef, undef, "style='width: 100%' id='data'" );
+print &ui_hidden( "path", $path );
+print &ui_form_end( [ [ save, $text{'save'} ], [ save_close, $text{'save_close'} ] ] );
 
 print ui_table_end();
 
 print "<script type='text/javascript' src='unauthenticated/js/cmauto.js'></script>";
-print "<script type='text/javascript'>\$(document).ready( function() { change('".$in{'file'}."'); });</script>";
+print "<script type='text/javascript'>\$(document).ready( function() { change('"
+  . $in{'file'}
+  . "'); });</script>";
 
-&ui_print_footer("index.cgi?path=$path", $text{'previous_page'});
+&ui_print_footer( "index.cgi?path=$path", $text{'previous_page'} );


### PR DESCRIPTION
This patch will make sure that user, will be able to READ files with different encodings properly and also, will be able to SAVE them without changing the initial encoding.

This awesomeness requires dependencies. However, RHEL has it installed by default but not Debian. New Webmin release should make sure to require/pull dependent packages:

For RHEL: `perl-Encode-Detect`
For Debian: `libencode-detect-perl`

Example of how editor will display detected encoding and display encodning in the editor's header/tabs:
![screenshot from 2017-05-02 12-32-37](https://cloud.githubusercontent.com/assets/4426533/25614568/285e64d0-2f3b-11e7-8c2f-6ae249b8dd80.png)

<br>

-----

> P.S. We should no let user to set non-UTF8 locale anymore. All languages should be displayed unambiguously, like Google does, (Русский, svenska, Deutsche, English (United States) .. ).

-----

<br>