### PR TITLE
Make editor respect file's initial encoding: Saver

### DIFF
--- a/filemin/save_file.cgi
+++ b/filemin/save_file.cgi
@@ -19,11 +19,8 @@ $error && &error(&text('notallowed', &html_escape($file),
 $data = $in{'data'};
 $data =~ s/\r\n/\n/g;
 
-#52019
-if ( ( get_charset() ne "UTF8" && get_charset() ne "UTF-8" ) || $in{'encoding'} ) {
-    $data =
-      Encode::encode( ( $in{'encoding'} ? $in{'encoding'} : get_charset() ),
-                      Encode::decode( 'utf-8', $data ) );
+if ( $in{'encoding'} && lc( $in{'encoding'} ) ne "utf-8" ) {
+    $data = Encode::encode( $in{'encoding'}, Encode::decode( 'utf-8', $data ) );
 }
 open(SAVE, ">", $cwd.'/'.$file) or push @errors, "$text{'error_saving_file'} - $!";
 print SAVE $data;


### PR DESCRIPTION
An addition to `edit_file.cgi`, [previous pull request #543](https://github.com/webmin/webmin/pull/543).