### PR TITLE
Let non-unicode users read files in their charset correctly + check f…

### DIFF
--- a/filemin/edit_file.cgi
+++ b/filemin/edit_file.cgi
@@ -12,9 +12,9 @@ eval "use Encode::Detect::Detector;";
 if (!$@) {
 	$encoding_name = Encode::Detect::Detector::detect($data);
 	}
-if ( $encoding_name && lc($encoding_name) ne "utf-8" ) {
+if ( lc( get_charset() ) eq "utf-8" && ( $encoding_name && lc($encoding_name) ne "utf-8" ) ) {
     use Encode qw( encode decode );
-    $data = Encode::encode( 'utf-8', Encode::decode( $encoding_name, $data ) );
+    eval { $data = Encode::encode( 'utf-8', Encode::decode( $encoding_name, $data ) ) };
 }
 
 &ui_print_header( undef, $text{'edit_file'}, "" );


### PR DESCRIPTION
…or valid encoding

In case a user still have old, non-UTF8 setup, they still need to see files in their encoding correctly, thus without converting output to utf-8. The way it is now, breaks things.

Also, there are cases when detected `$encoding_name` is not recognized by `decode()` subroutine.