### PR TITLE
Check for valid encoding

### DIFF
--- a/filemin/save_file.cgi
+++ b/filemin/save_file.cgi
@@ -20,7 +20,7 @@ $data = $in{'data'};
 $data =~ s/\r\n/\n/g;
 
 if ( $in{'encoding'} && lc( $in{'encoding'} ) ne "utf-8" ) {
-    $data = Encode::encode( $in{'encoding'}, Encode::decode( 'utf-8', $data ) );
+    eval { $data = Encode::encode( $in{'encoding'}, Encode::decode( 'utf-8', $data ) ) };
 }
 open(SAVE, ">", $cwd.'/'.$file) or push @errors, "$text{'error_saving_file'} - $!";
 print SAVE $data;


### PR DESCRIPTION
There are cases when detected `$encoding_name` is not recognized by `decode()` subroutine leading to fatal error.