### PR TITLE
filter out chains not managed by firewall and add warning if fail2ban detected

### DIFF
--- a/firewall/config
+++ b/firewall/config
@@ -4,3 +4,4 @@ view_condition=1
 cluster_mode=1
 comment_mod=0
 force_init=0
+filter_chain=forever

--- a/firewall/config
+++ b/firewall/config
@@ -4,4 +4,3 @@ view_condition=1
 cluster_mode=1
 comment_mod=0
 force_init=0
-filter_chain=forever

--- a/firewall/config.info
+++ b/firewall/config.info
@@ -11,4 +11,4 @@ after_apply_cmd=Command to run after applying configuration,3,None
 line1=System configuration,11
 save_file=IPtables save file to edit,3,Use operating system or Webmin default
 direct=Directly edit firewall rules instead of save file?,1,1-Yes,0-No
-filter_chain=Regex to filter out chains not managed by firewall, e.g. fail2ban chains,0
+filter_chain=Comma sepeated list of regexes to filter out chains not managed by firewall,0

--- a/firewall/config.info
+++ b/firewall/config.info
@@ -11,3 +11,4 @@ after_apply_cmd=Command to run after applying configuration,3,None
 line1=System configuration,11
 save_file=IPtables save file to edit,3,Use operating system or Webmin default
 direct=Directly edit firewall rules instead of save file?,1,1-Yes,0-No
+filter_chain=Regex to filter out chains not managed by firewall, e.g. fail2ban chains,0

--- a/firewall/config.info.de
+++ b/firewall/config.info.de
@@ -11,4 +11,4 @@ after_apply_cmd=Befehle zum Anwendung der Konfiguration,3,Keiner
 line1=System Konfiguration,11
 save_file=IPtables Speicherdatei zum Bearbeiten,3,Verwendung des Betriebssystems oder Webmin Standard
 direct=Direktes Bearbeiten der Firewall-Regeln anstatt von gespeicherter Datei?,1,1-Ja,0-Nein
-filter_chain=Regex zum Ausfiltern von Ketten die nicht von Firewall verwaltet werden, z.B. fail2ban,0
+filter_chain=Komma getrennte Liste von Regex zum Ausfiltern von Ketten die nicht von Firewall verwaltet werden,0

--- a/firewall/config.info.de
+++ b/firewall/config.info.de
@@ -11,3 +11,4 @@ after_apply_cmd=Befehle zum Anwendung der Konfiguration,3,Keiner
 line1=System Konfiguration,11
 save_file=IPtables Speicherdatei zum Bearbeiten,3,Verwendung des Betriebssystems oder Webmin Standard
 direct=Direktes Bearbeiten der Firewall-Regeln anstatt von gespeicherter Datei?,1,1-Ja,0-Nein
+filter_chain=Regex zum Ausfiltern von Ketten die nicht von Firewall verwaltet werden, z.B. fail2ban,0

--- a/firewall/firewall-lib.pl
+++ b/firewall/firewall-lib.pl
@@ -55,7 +55,9 @@ open(FILE, $_[0] || ($config{'direct'} ? "iptables-save 2>/dev/null |"
 local $cmt;
 while(<FILE>) {
         local $read_comment;
-	s/\r|\n//g;
+	# regex to filter out chains not manage by firewall, i.e. fail2ban
+        next if ($config{'filter_chain'} && s/$config{'filter_chain'}//);
+        s/\r|\n//g;
 	if (s/#\s*(.*)$//) {
 		$cmt .= " " if ($cmt);
 		$cmt .= $1;

--- a/firewall/index.cgi
+++ b/firewall/index.cgi
@@ -50,6 +50,7 @@ if (!$config{'direct'} && &foreign_check("init")) {
 @livetables = &get_iptables_save("iptables-save 2>/dev/null |");
 &shorewall_message(\@livetables);
 &firewalld_message(\@livetables);
+&fail2ban_message(\@livetables);
 if (!$config{'direct'} &&
     (!-s $iptables_save_file || $in{'reset'}) && $access{'setup'}) {
 	@tables = @livetables;
@@ -429,5 +430,15 @@ if ($filter->{'defaults'}->{'INPUT_ZONES'}) {
 	      &text('index_firewalld', "$gconfig{'webprefix'}/firewalld/"),
 	      "</b></center><p>\n";
 	}
+}
+
+sub fail2ban_message
+{
+local ($filter) = grep { $_->{'name'} eq 'filter' } @{$_[0]};
+if ($filter->{'defaults'} ~~ /^f2b-|^fail2ban-/) {
+        print "<b><center>",
+              &text('index_fail2ban', "$gconfig{'webprefix'}/fail2ban/"),
+              "</b></center><p>\n";
+        }
 }
 

--- a/firewall/lang/de
+++ b/firewall/lang/de
@@ -191,6 +191,7 @@ index_ecommand=Der Befehl $1 wurde nicht auf Ihrem System gefunden. Webmin ben&#
 index_editing=Regel Datei $1
 index_ekernel=Ein Fehler ist beim &#220;berpr&#252;fen Ihrer aktuellen IPtables-Konfiguration aufgetreten : $1 Dies k&#246;nnte darauf hindeuten, dass Ihr Kernel IPtables nicht unterst&#252;tzt.
 index_existing=Webmin hat erkannt, dass $1 IPtables Firewall-Regel(n) derzeit in Benutzung sind, die nicht in der Datei $2 gespeichert wurden. Diese Regeln wurden vermutlich von einem Skript einrichtet, jedoch dieses Modul nicht in der Lage ist, dieses zu lesen und zu bearbeiten.<p>Wenn Sie dieses Modul benutzen wollen, um Ihre IPtables-Firewall verwalten zu lassen, klicken Sie auf die Schaltfl&#228;che unten, um die bestehenden Regeln zu einer Sicherungsdatei zu konvertieren und anschlie&#223;end Ihr bestehendes Firewall-Skript zu deaktivieren.
+index_fail2ban=Warnung! Es scheint, dass Fail2ban verwendet wird, um das Firewall-System zu generieren. Vielleicht sollten Sie die <a href='$1'>Fail2Ban-Modul</a> verwenden.
 index_firewalld=Warnung! Es scheint, dass FirewallD verwendet wird, um das Firewall-System zu generieren. Vielleicht sollten Sie die <a href='$1'>FirewallD Firewall-Modul</a> verwenden.
 index_header=Firewall Konfiguration von $1
 index_headerex=Bestehende Firewall Konfiguration

--- a/firewall/lang/en
+++ b/firewall/lang/en
@@ -69,6 +69,7 @@ index_auto=Setup Firewall
 index_add=Add
 index_shorewall=Warning! It appears that Shorewall is being used to generate your system's firewall. Maybe you should use the <a href='$1'>Shoreline Firewall module</a> instead.
 index_firewalld=Warning! It appears that FirewallD is being used to generate your system's firewall. Maybe you should use the <a href='$1'>FirewallD module</a> instead.
+index_fail2ban=Warning! It appears that Fail2Ban is being used to generate your system's firewall. Maybe you should use the <a href='$1'>Fail2Ban module</a> instead.
 index_reset=Reset Firewall
 index_resetdesc=Click this button to clear all existing firewall rules and set up new rules for a basic initial configuration.
 index_cluster=Cluster Servers


### PR DESCRIPTION
I permanantly ban hosts and networks often found by fail2ban plus a huge list of networks loaded from different sources. the list contains nearly 5000 entrys:

```
 rrr ~/ #./fail2ban-stat.sh
So 7. Mai 21:05:47 CEST 2017 start fail2ban-stat.sh 22785
Fail2Ban stats: 265 attacks, 11 ignored matches and 165 banned hosts this Month
Currently banned: temporary 5 hosts, permanent 345 hosts and 4623 networks...

```
I wanted to filter out my BAN-forever chain from firewall because of 2 reassons:

1. its a quite long list to display in the browser
2. processing the list takes very long and I have to klick away 3-5 browser warnings about a long running script

So I implemented a regexfilter to skip chains in get_iptables_saved() and a config option filter_chain to enter the regex with a default of "forever" , its a simple oneliner :-)
`next if ($config{'filter_chain'} && s/$config{'filter_chain'}//);`

pls consider merging or implement a similar solution