### PR TITLE
This one working for me and displaying info properly

### DIFF
--- a/proc/freebsd-lib.pl
+++ b/proc/freebsd-lib.pl
@@ -145,7 +145,7 @@ else {
 	return ( );
 	}
 $out = &backquote_command("sysctl hw.model hw.ncpu");
-if ($out =~ /hw.model:\s+(\S+)\s+(\S.*\S)\s+\@\s+(\S+)/) {
+if ($out =~ /hw.model:\s+(\S+)\s+(\S.*\S)\s+(\S+)/) {
 	push(@load, $3, $2, $1, undef);
 	if ($out =~ /hw.ncpu:\s+(\d+)/) {
 		push(@load, $1);


### PR DESCRIPTION
```BASH
root@debug-freebsd:~ # sysctl hw.model hw.ncpu
hw.model: Intel Core Processor (Skylake)
hw.ncpu: 8

```

However, it might not catch properly the information where output is like this:

`Intel(R) Xeon(R) CPU E5-2630 0 @ 2.30GHz, 24 cores`