### PR TITLE
hofix detecion (random) iso-8859-x charset

### DIFF
--- a/filemin/edit_file.cgi
+++ b/filemin/edit_file.cgi
@@ -13,6 +13,8 @@ my $encoding_name;
 eval "use Encode::Detect::Detector;";
 if (!$@) {
 	$encoding_name = Encode::Detect::Detector::detect($data);
+	# fix random iso-8869-* detection to be always iso-8859-1
+	if ( $encoding_name ~= /^iso-8859/ ) $encoding_name="iso-8859-1";
 	}
 if ( lc( get_charset() ) eq "utf-8" && ( $encoding_name && lc($encoding_name) ne "utf-8" ) ) {
     use Encode qw( encode decode );

--- a/filemin/edit_file.cgi
+++ b/filemin/edit_file.cgi
@@ -10,11 +10,18 @@ my $file = &simplify_path($cwd.'/'.$in{'file'});
 my $data = &read_file_contents($file);
 
 my $encoding_name;
+use Encode::Guess; 
 eval "use Encode::Detect::Detector;";
 if (!$@) {
 	$encoding_name = Encode::Detect::Detector::detect($data);
-	# fix random iso-8869-* detection to be always iso-8859-1
-	if ( $encoding_name ~= /^iso-8859/ ) $encoding_name="iso-8859-1";
+        if ( $encoding_name =~ /iso-8859/i ) {
+          # try a second guess
+  	  my $dec = guess_encoding($data, qw/iso-8859-1 iso-8859-2 iso-8859-3 iso-8859-3 iso-8859-4 iso-8859-5 iso-8859-6 iso-8859-7 iso-8859-8 iso-8859-9/);
+  	  if (!ref $dec) {
+            # can be more than one iso-encoding, fallback to iso-8859-1
+            $encoding_name = "iso-8859-1";
+  	    }
+          }
 	}
 if ( lc( get_charset() ) eq "utf-8" && ( $encoding_name && lc($encoding_name) ne "utf-8" ) ) {
     use Encode qw( encode decode );


### PR DESCRIPTION
when editing a file containg mixed iso-8859-x charsets eg module.info :-), Encode::Detect::Detector::detect returns the first guessed iso-charset. My hotfix is to use iso-8859-1.

may be it is an option to convert over to `Encode::Guess` , its also guessing, but gives an error if multiple charsets are possible.