### PR TITLE
Roll back amp change, as HTML5 allows it

### DIFF
--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -7264,8 +7264,8 @@ sub help_search_link
 if (&foreign_available("man") && !$tconfig{'nosearch'}) {
 	my $for = &urlize(shift(@_));
 	return "<a href='$gconfig{'webprefix'}/man/search.cgi?".
-	       join("&amp;", map { "section=$_" } @_)."&amp;".
-	       "for=$for&amp;exact=1&amp;check=".&get_module_name()."'>".
+	       join("&", map { "section=$_" } @_)."&".
+	       "for=$for&exact=1&check=".&get_module_name()."'>".
 	       $text{'helpsearch'}."</a>\n";
 	}
 else {


### PR DESCRIPTION
The HTML5 spec allows & to be unescaped, as long as it is not immediately followed by an alphanumeric character and then at any point in the rest of the string a semicolon. As long as the browser can unambiguously determine it is not an entity, it's OK to leave it unescaped.

This makes it invalid at doctype 4.01 (even transitional), but I'll hopefully do a full conversion to HTML5 in the next couple of months and we'll be able to validate again.