### PR TITLE
certmgr: Fix signcsr not using configured openssl.cnf

### DIFF
--- a/certmgr/certmgr-lib.pl
+++ b/certmgr/certmgr-lib.pl
@@ -60,7 +60,8 @@ sub print_sign_form {
     print &ui_table_start($text{'signcsr_header'}, undef, 2);
     print &ui_table_row($text{'signcsr_csrfile'}, &ui_textbox("csrfile", $in{'csrfile'}, 40), undef, $valign_middle);
     print &ui_table_row($text{'signcsr_signfile'}, &ui_textbox("signfile", $in{'signfile'}, 40), undef, $valign_middle);
-    print &ui_table_row($text{'signcsr_keyfile'}, &ui_textbox("keycertfile", $in{'keycertfile'}, 40), undef, $valign_middle);
+    print &ui_table_row($text{'signcsr_keycertfile'}, &ui_textbox("cacertfile", $in{'cacertfile'}, 40), undef, $valign_middle);
+    print &ui_table_row($text{'signcsr_keyfile'}, &ui_textbox("cakeyfile", $in{'cakeyfile'}, 40), undef, $valign_middle);
     print &ui_table_row(&ui_link("/help.cgi/certmgr/signcsr_ca_pass",
                     "<b>$text{'signcsr_ca_passphrase'}</b>", undef,
                     "onClick='window.open(\"/help.cgi/certmgr/signcsr_ca_pass\", \"help\", \"toolbar=no,menubar=no,scrollbars=yes,width=400,height=300,resizable=yes\"); return false;'"), 

--- a/certmgr/lang/de
+++ b/certmgr/lang/de
@@ -109,6 +109,7 @@ signcsr_days=Anzahl der Tage der Zertifizierung f&#252;r
 signcsr_desc=Auf dieser Seite k&#246;nnen Sie eine signiertes CSR von jemand anderem mit einem eigenen privaten Schl&#252;ssel signieren.
 signcsr_e_nocsrfile=Keinen CSR Dateinamen eingegeben
 signcsr_e_nokeyfile=Kein CA privater Schl&#252;ssel oder Zertifikats-Datei eingegeben
+signcsr_e_nopassword=Es wurde kein CA-Kennwort eingegeben
 signcsr_e_nosignfile=Kein signiertes Zertifikats-Dateiname eingegeben
 signcsr_e_signfailed=Fehler, signiertes Zertifikat nicht generiert
 signcsr_generate=Signiere Zertifikat

--- a/certmgr/lang/en
+++ b/certmgr/lang/en
@@ -135,6 +135,7 @@ signcsr_generate=Sign Certificate
 signcsr_e_nocsrfile=No CSR filename entered
 signcsr_e_nosignfile=No signed certificate filename entered
 signcsr_e_nokeyfile=No CA private key file or certificate file entered
+signcsr_e_nopassword=No CA private key password entered
 signcsr_e_signfailed=Error, signed certificate not generated
 signcsr_worked=Signed certificate generated
 signcsr_saved_cert=The certificate was saved as

--- a/certmgr/lang/es
+++ b/certmgr/lang/es
@@ -114,3 +114,5 @@ import_upload_cert=Upload Certificate
 import_key_file=Key file to upload
 import_key_destination=Destination directory of key
 import_upload_key=Upload Key
+
+signcsr_e_nopassword=No CA private key password entered


### PR DESCRIPTION
signcsr.cgi was hard-coding the config file used in the openssl command to sign CSRs. Changed to use the openssl.cnf defined in the certmgr module config (ssl_cnf_file). Otherwise, one is forced to use /etc/webmin/acl/openssl.cnf for signing, as opposed to the cnf defined in the module config.

Also added check for encrypted CA signing key, because failure to enter a password in the form would cause the openssl command to hang. (openssl will prompt if -passin flag is not given.)