### PR TITLE
Log if no_pam and pam_only both are set

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -161,6 +161,7 @@ elsif (!$config{'no_pam'}) {
 if ($config{'pam_only'} && !$use_pam) {
 	print STDERR $startup_msg[0],"\n";
 	print STDERR "PAM use is mandatory, but could not be enabled!\n";
+	print STDERR "no_pam and pam_only both are set!\n" if ($config{no_pam});
 	exit(1);
 	}
 elsif ($pam_msg && !$use_pam) {


### PR DESCRIPTION
Some old config has no_pam set to 1. Now if administrator enables pam_only too then both are conflicting. Which makes webmin to exit with PAM error. But administrator can not figure out why? This logs additional line so that administrator know the reason.