### PR TITLE
Dont log just first message, log everything.

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -159,7 +159,9 @@ elsif (!$config{'no_pam'}) {
 		}
 	}
 if ($config{'pam_only'} && !$use_pam) {
-	print STDERR $startup_msg[0],"\n";
+	foreach $msg (@startup_msg) {
+	     print STDERR $msg,"\n";
+	}
 	print STDERR "PAM use is mandatory, but could not be enabled!\n";
 	print STDERR "no_pam and pam_only both are set!\n" if ($config{no_pam});
 	exit(1);


### PR DESCRIPTION
Say administrator does not want IPv6 support and hence does not have Socket6 module installed. He wants PAM support but forgot to install Authen::PAM.

Since currently webmin prints just $startup_msg[0] (first message) - it will never print that "Perl module Authen::PAM needed for PAM". It will keep printing that "IPv6 support cannot be enabled". So administrator would never know what is the real error (that he needs to install "Authen::PAM")

This patch logs everything instead of just first line. So administrator would know that Authen::PAM is missing.