### PR TITLE
Some fixes for perl 5.26

### DIFF
--- a/ldap-useradmin/ldap-useradmin-lib.pl
+++ b/ldap-useradmin/ldap-useradmin-lib.pl
@@ -417,7 +417,7 @@ if ($_[0]->get_value("uid")) {
 			'warn' => $_[0]->get_value("shadowWarning") || "",
 			'inactive' => $_[0]->get_value("shadowInactive") || "",
 		      );
-	$user{'pass'} =~ s/^(\!?){[a-z0-9]+}/$1/i;
+	$user{'pass'} =~ s/^(\!?)\{[a-z0-9]+\}/$1/i;
 	$user{'all_ldap_attrs'} = { map { lc($_), scalar($_[0]->get_value($_)) }
 					$_[0]->attributes() };
 	$user{'ldap_class'} = [ $_[0]->get_value('objectClass') ];

--- a/logrotate/logrotate-lib.pl
+++ b/logrotate/logrotate-lib.pl
@@ -49,7 +49,7 @@ open($fh, $file);
 while(<$fh>) {
 	s/\r|\n//g;
 	s/#.*$//;
-	if (/^\s*(.*){\s*$/) {
+	if (/^\s*(.*)\{\s*$/) {
 		# Start of a section
 		push(@name, &split_words($1));
 		$section = { 'name' => [ @name ],

--- a/setup.sh
+++ b/setup.sh
@@ -76,6 +76,7 @@ PERLLIB=$wadir
 if [ "$perllib" != "" ]; then
 	PERLLIB="$PERLLIB:$perllib"
 fi
+export PERLLIB
 
 # Validate source directory
 allmods=`cd "$srcdir"; echo */module.info | sed -e 's/\/module.info//g'`

--- a/system-status/enable-collection.pl
+++ b/system-status/enable-collection.pl
@@ -1,6 +1,7 @@
 #!/usr/local/bin/perl
 # Command-line script to enable status collection
 
+BEGIN { push(@INC, '.'); };
 use strict;
 use warnings;
 our (%config);

--- a/system-status/enable-collection.pl
+++ b/system-status/enable-collection.pl
@@ -1,11 +1,10 @@
 #!/usr/local/bin/perl
 # Command-line script to enable status collection
 
-BEGIN { push(@INC, '.'); };
 use strict;
 use warnings;
 our (%config);
-require 'system-status-lib.pl';
+require './system-status-lib.pl';
 my $zero = @ARGV ? $ARGV[0] : '';
 $zero eq 'none' || $zero =~ /^[1-9][0-9]*$/ && $zero <= 60 ||
 	die "usage: enable-collection.pl none|<mins>";


### PR DESCRIPTION
New perl 5.26 has few changes. Like:
1. A left brace '{' inside regex is not allowed. It should be escaped like this '\\{'
2. Current directory '.' is no more included in @ INC

These patches fix warnings and errors you get when running setup.sh. (when using new perl 5.26.0)

However, there may be more such files which require fixing?