### PR TITLE
Fixing path of firewalld-lib.pl

### DIFF
--- a/firewalld/index.cgi
+++ b/firewalld/index.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text, %config, %access, $base_remote_user);
 &ReadParse();
 if ($in{'addzone'}) {


### PR DESCRIPTION
To fix the following error on Debian 9 fresh install when using firewallD config in Virtualmin

```
Error - Perl execution failed

Can't locate firewalld-lib.pl in @INC (@INC contains: /usr/share/webmin /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/webmin/firewalld/index.cgi line 6.
```