### PR TITLE
Check for systemd before upstart #622

### DIFF
--- a/init/init-lib.pl
+++ b/init/init-lib.pl
@@ -57,13 +57,13 @@ elsif ($config{'hostconfig'}) {
 elsif ($config{'rc_dir'}) {
 	$init_mode = "rc";
 	}
-elsif ($config{'init_base'} && -d "/etc/init" && &has_command("initctl")) {
-	$init_mode = "upstart";
-	}
 elsif ($config{'init_base'} && -d "/etc/systemd" &&
        &has_command("systemctl") &&
        &execute_command("systemctl list-units") == 0) {
 	$init_mode = "systemd";
+	}
+elsif ($config{'init_base'} && -d "/etc/init" && &has_command("initctl")) {
+	$init_mode = "upstart";
 	}
 elsif ($config{'init_base'}) {
 	$init_mode = "init";


### PR DESCRIPTION
I think this will resolve the problem I reported with misdetection of systemd vs upstart in #622.