### PR TITLE
Fix login redirect from FQDM/webmin

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -4096,7 +4096,7 @@ if ($ok && (!$expired ||
 			&write_data("Set-Cookie: $sidname=$sid; path=$cpath".
 				    "$sec\r\n");
 			}
-		&write_data("Location: $prot://$hostport$in{'page'}\r\n");
+		&write_data("Location: $prot://$host$config{'cookiepath'}$in{'page'}\r\n");
 		&write_keep_alive(0);
 		&write_data("\r\n");
 		&log_request($loghost, $authuser, $reqline, 302, 0);


### PR DESCRIPTION
Login behind reverse proxy with SSL enabled results in a redirect from FQDM/webmin to localhost:1000 due to a an issue in the miniserv conf file. This change fixes that. Logins are now redirect properly.