### PR TITLE
Support devuan

### DIFF
--- a/os_list.txt
+++ b/os_list.txt
@@ -110,7 +110,7 @@ Ubuntu Linux			$1	debian-linux	9.0	$etc_issue =~ /Ubuntu.*\s(16\.[0-9\.]+)\s/i |
 Ubuntu Linux			$1	debian-linux	3.1	$etc_issue =~ /Ubuntu.*\s([0-9\.]+)\s/i
 Mepis Linux			$1	debian-linux	$1	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /([0-9\.]+)/
 Mepis Linux			$1	debian-linux	4.0	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /(stable)/
-Devuan Linux		1.0	debian-linux	8.0	`cat /etc/devuan_version 2>/dev/null` =~ /^(jessie)/i
+Devuan Linux		$1	debian-linux	8.0	$etc_issue =~ /Devuan/ && `cat /etc/devuan_version 2>/dev/null` =~ /^(jessie)/i
 
 # Linux Mint (Mint should be before Debian to avoid false-positive)
 Linux Mint			6	debian-linux	5.0	`cat /etc/lsb-release 2>/dev/null | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION="Linux Mint 6 Felicia"/

--- a/os_list.txt
+++ b/os_list.txt
@@ -111,6 +111,9 @@ Ubuntu Linux			$1	debian-linux	3.1	$etc_issue =~ /Ubuntu.*\s([0-9\.]+)\s/i
 Mepis Linux			$1	debian-linux	$1	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /([0-9\.]+)/
 Mepis Linux			$1	debian-linux	4.0	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /(stable)/
 Devuan Linux		$1	debian-linux	8.0	$etc_issue =~ /Devuan/ && `cat /etc/devuan_version 2>/dev/null` =~ /^(jessie)/i
+Devuan Linux		$1	debian-linux	9.0	$etc_issue =~ /Devuan/ && `cat /etc/devuan_version 2>/dev/null` =~ /^(ascii)/i
+Devuan Linux		$1	debian-linux	10.0	$etc_issue =~ /Devuan/ && `cat /etc/devuan_version 2>/dev/null` =~ /^(beowulf)/i
+Devuan Linux		$1	debian-linux	10.0	$etc_issue =~ /Devuan/ && `cat /etc/devuan_version 2>/dev/null` =~ /^(ceres)/i
 
 # Linux Mint (Mint should be before Debian to avoid false-positive)
 Linux Mint			6	debian-linux	5.0	`cat /etc/lsb-release 2>/dev/null | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION="Linux Mint 6 Felicia"/

--- a/os_list.txt
+++ b/os_list.txt
@@ -110,6 +110,7 @@ Ubuntu Linux			$1	debian-linux	9.0	$etc_issue =~ /Ubuntu.*\s(16\.[0-9\.]+)\s/i |
 Ubuntu Linux			$1	debian-linux	3.1	$etc_issue =~ /Ubuntu.*\s([0-9\.]+)\s/i
 Mepis Linux			$1	debian-linux	$1	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /([0-9\.]+)/
 Mepis Linux			$1	debian-linux	4.0	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /(stable)/
+Devuan Linux		1.0	debian-linux	8.0	`cat /etc/devuan_version 2>/dev/null` =~ /^(jessie)/i
 
 # Linux Mint (Mint should be before Debian to avoid false-positive)
 Linux Mint			6	debian-linux	5.0	`cat /etc/lsb-release 2>/dev/null | grep DISTRIB_DESCRIPTION` =~ /^DISTRIB_DESCRIPTION="Linux Mint 6 Felicia"/


### PR DESCRIPTION
Adding 4 lines to os_list.txt. This makes the webmin.deb file installable on the devuan os (https://devuan.org/) and also enables to choose the correct version in a setup.sh install.

Tested on the current version "devuan 1.0.0 codename jessie" (1st line). All 4 lines were assembled in the #devuan channel on freenode.

