### PR TITLE
Add ./ to path in firewalld module

### DIFF
--- a/firewalld/create_zone.cgi
+++ b/firewalld/create_zone.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%text, %in);
 &ReadParse();
 &error_setup($text{'zone_err'});

--- a/firewalld/default_zone.cgi
+++ b/firewalld/default_zone.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%text, %in);
 &ReadParse();
 &error_setup($text{'defzone_err'});

--- a/firewalld/delete_rules.cgi
+++ b/firewalld/delete_rules.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &error_setup($text{'delete_err'});
 &ReadParse();

--- a/firewalld/delete_zone.cgi
+++ b/firewalld/delete_zone.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%text, %in);
 &ReadParse();
 &error_setup($text{'delzone_err'});

--- a/firewalld/edit_forward.cgi
+++ b/firewalld/edit_forward.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &ReadParse();
 

--- a/firewalld/edit_port.cgi
+++ b/firewalld/edit_port.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &ReadParse();
 

--- a/firewalld/edit_serv.cgi
+++ b/firewalld/edit_serv.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &ReadParse();
 

--- a/firewalld/index.cgi
+++ b/firewalld/index.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text, %config, %access, $base_remote_user);
 &ReadParse();
 if ($in{'addzone'}) {

--- a/firewalld/save_forward.cgi
+++ b/firewalld/save_forward.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &error_setup($text{'forward_err'});
 &ReadParse();

--- a/firewalld/save_ifaces.cgi
+++ b/firewalld/save_ifaces.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &error_setup($text{'ifaces_err'});
 &ReadParse();

--- a/firewalld/save_port.cgi
+++ b/firewalld/save_port.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &error_setup($text{'port_err'});
 &ReadParse();

--- a/firewalld/save_serv.cgi
+++ b/firewalld/save_serv.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%in, %text);
 &error_setup($text{'serv_err'});
 &ReadParse();

--- a/firewalld/zone_form.cgi
+++ b/firewalld/zone_form.cgi
@@ -3,7 +3,7 @@
 
 use strict;
 use warnings;
-require 'firewalld-lib.pl';
+require './firewalld-lib.pl';
 our (%text, %in);
 &ReadParse();
 &ui_print_header(undef, $text{'zone_title'}, "");


### PR DESCRIPTION
We're still getting bug reports about firewalld module not working on debian due to . not being in path. I'd thought that was resolved by . being added to path in Webmin somewhere, but this works, regardless.