### PR TITLE
init: Add extra set of reboot/shutdown buttons to top

### DIFF
--- a/init/index.cgi
+++ b/init/index.cgi
@@ -8,6 +8,22 @@ require './hostconfig-lib.pl';
 &ui_print_header(&text('index_mode', $text{'mode_'.$init_mode}),
 		 $text{'index_title'}, "", undef, 1, 1);
 
+print &ui_buttons_start();
+if ($init_mode eq 'init' && $access{'bootup'} == 1) {
+	print &ui_buttons_row("change_rl.cgi", $text{'index_rlchange'},
+			      $text{'index_rlchangedesc'}, undef,
+			      &ui_select("level", $boot[0], \@runlevels));
+	}
+if ($access{'reboot'}) {
+	print &ui_buttons_row("reboot.cgi", $text{'index_reboot'},
+			      $text{'index_rebootmsg'});
+	}
+if ($access{'shutdown'}) {
+	print &ui_buttons_row("shutdown.cgi", $text{'index_shutdown'},
+			      $text{'index_shutdownmsg'});
+	}
+print &ui_buttons_end();
+
 if ($init_mode eq "osx" && $access{'bootup'}) {
 	# This hostconfig if block written by Michael A Peters <mpeters@mac.com>
 	# for OSX/Darwin.

--- a/init/index.cgi
+++ b/init/index.cgi
@@ -8,6 +8,7 @@ require './hostconfig-lib.pl';
 &ui_print_header(&text('index_mode', $text{'mode_'.$init_mode}),
 		 $text{'index_title'}, "", undef, 1, 1);
 
+# reboot/shutdown buttons
 print &ui_buttons_start();
 if ($init_mode eq 'init' && $access{'bootup'} == 1) {
 	print &ui_buttons_row("change_rl.cgi", $text{'index_rlchange'},


### PR DESCRIPTION
A user requested having the reboot/shutdown buttons at the top and bottom of the page (because it's so long). That seemed reasonable to me, so I did it. There are probably better ways to make this page more usable, but it'll probably do for now.