### PR TITLE
Probably fix upstart vs systemd detection #648

### DIFF
--- a/init/init-lib.pl
+++ b/init/init-lib.pl
@@ -57,13 +57,15 @@ elsif ($config{'hostconfig'}) {
 elsif ($config{'rc_dir'}) {
 	$init_mode = "rc";
 	}
+elsif ($config{'init_base'} && -d "/etc/init" &&
+       &has_command("initctl") &&
+       &execute_command("/sbin/init --version") == 0) {
+	$init_mode = "upstart";
+	}
 elsif ($config{'init_base'} && -d "/etc/systemd" &&
        &has_command("systemctl") &&
        &execute_command("systemctl list-units") == 0) {
 	$init_mode = "systemd";
-	}
-elsif ($config{'init_base'} && -d "/etc/init" && &has_command("initctl")) {
-	$init_mode = "upstart";
 	}
 elsif ($config{'init_base'}) {
 	$init_mode = "init";


### PR DESCRIPTION
This fixes #648.

My "fix" from before actually broke detection for upstart systems that also have systemd installed (while fixing it for systemd systems that also had upstart installed).


Ubuntu 14+ have *all three* init systems installed in some form, so detection has been broken for some subset of Ubuntu versions ever since the switch to systemd. I believe this gets it right for all currently supported versions of Ubuntu.
