### PR TITLE
Redirect function already deals with prefix

### DIFF
--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -4689,7 +4689,7 @@ if ($module_name && !$main::no_acl_check &&
 	
 # Check for trigger URL to simply redirect to root: required for Authentic Theme 19.00+
 if ($ENV{'REQUEST_URI'} =~ /xnavigation=1/) {
-	redirect($gconfig{'webprefix'} || "/");
+	redirect("/");
 	}
 
 # Check the Referer: header for nasty redirects


### PR DESCRIPTION
`$gconfig{'webprefix'}` is not needed and will result in its duplicate in case it's set.