### PR TITLE
fix firewall6 module.info after firewall6 is a symlink

### DIFF
--- a/firewall6
+++ b/firewall6
@@ -1,1 +1,0 @@
-firewall

--- a/firewall6/CHANGELOG
+++ b/firewall6/CHANGELOG
@@ -1,0 +1,1 @@
+../firewall/CHANGELOG

--- a/firewall6/acl_security.pl
+++ b/firewall6/acl_security.pl
@@ -1,0 +1,1 @@
+../firewall/acl_security.pl

--- a/firewall6/apply.cgi
+++ b/firewall6/apply.cgi
@@ -1,0 +1,1 @@
+../firewall/apply.cgi

--- a/firewall6/backup_config.pl
+++ b/firewall6/backup_config.pl
@@ -1,0 +1,1 @@
+../firewall/backup_config.pl

--- a/firewall6/bootup.cgi
+++ b/firewall6/bootup.cgi
@@ -1,0 +1,1 @@
+../firewall/bootup.cgi

--- a/firewall6/cgi_args.pl
+++ b/firewall6/cgi_args.pl
@@ -1,0 +1,1 @@
+../firewall/cgi_args.pl

--- a/firewall6/cluster.cgi
+++ b/firewall6/cluster.cgi
@@ -1,0 +1,1 @@
+../firewall/cluster.cgi

--- a/firewall6/cluster_add.cgi
+++ b/firewall6/cluster_add.cgi
@@ -1,0 +1,1 @@
+../firewall/cluster_add.cgi

--- a/firewall6/cluster_delete.cgi
+++ b/firewall6/cluster_delete.cgi
@@ -1,0 +1,1 @@
+../firewall/cluster_delete.cgi

--- a/firewall6/coherent-linux-lib.pl
+++ b/firewall6/coherent-linux-lib.pl
@@ -1,0 +1,1 @@
+../firewall/coherent-linux-lib.pl

--- a/firewall6/config
+++ b/firewall6/config
@@ -1,0 +1,1 @@
+../firewall/config

--- a/firewall6/config.info
+++ b/firewall6/config.info
@@ -1,0 +1,1 @@
+../firewall/config.info

--- a/firewall6/config.info.ca
+++ b/firewall6/config.info.ca
@@ -1,0 +1,1 @@
+../firewall/config.info.ca

--- a/firewall6/config.info.cz
+++ b/firewall6/config.info.cz
@@ -1,0 +1,1 @@
+../firewall/config.info.cz

--- a/firewall6/config.info.de
+++ b/firewall6/config.info.de
@@ -1,0 +1,1 @@
+../firewall/config.info.de

--- a/firewall6/config.info.fr
+++ b/firewall6/config.info.fr
@@ -1,0 +1,1 @@
+../firewall/config.info.fr

--- a/firewall6/config.info.ja_JP.euc
+++ b/firewall6/config.info.ja_JP.euc
@@ -1,0 +1,1 @@
+../firewall/config.info.ja_JP.euc

--- a/firewall6/config.info.nl
+++ b/firewall6/config.info.nl
@@ -1,0 +1,1 @@
+../firewall/config.info.nl

--- a/firewall6/config.info.no
+++ b/firewall6/config.info.no
@@ -1,0 +1,1 @@
+../firewall/config.info.no

--- a/firewall6/config.info.pl
+++ b/firewall6/config.info.pl
@@ -1,0 +1,1 @@
+../firewall/config.info.pl

--- a/firewall6/config.info.pt_BR
+++ b/firewall6/config.info.pt_BR
@@ -1,0 +1,1 @@
+../firewall/config.info.pt_BR

--- a/firewall6/config.info.ru_RU
+++ b/firewall6/config.info.ru_RU
@@ -1,0 +1,1 @@
+../firewall/config.info.ru_RU

--- a/firewall6/config.info.ru_SU
+++ b/firewall6/config.info.ru_SU
@@ -1,0 +1,1 @@
+../firewall/config.info.ru_SU

--- a/firewall6/config.info.sk
+++ b/firewall6/config.info.sk
@@ -1,0 +1,1 @@
+../firewall/config.info.sk

--- a/firewall6/config.info.tr
+++ b/firewall6/config.info.tr
@@ -1,0 +1,1 @@
+../firewall/config.info.tr

--- a/firewall6/convert.cgi
+++ b/firewall6/convert.cgi
@@ -1,0 +1,1 @@
+../firewall/convert.cgi

--- a/firewall6/debian-linux-lib.pl
+++ b/firewall6/debian-linux-lib.pl
@@ -1,0 +1,1 @@
+../firewall/debian-linux-lib.pl

--- a/firewall6/defaultacl
+++ b/firewall6/defaultacl
@@ -1,0 +1,1 @@
+../firewall/defaultacl

--- a/firewall6/edit_rule.cgi
+++ b/firewall6/edit_rule.cgi
@@ -1,0 +1,1 @@
+../firewall/edit_rule.cgi

--- a/firewall6/firewall-lib.pl
+++ b/firewall6/firewall-lib.pl
@@ -1,0 +1,1 @@
+../firewall/firewall-lib.pl

--- a/firewall6/firewall4-lib.pl
+++ b/firewall6/firewall4-lib.pl
@@ -1,0 +1,1 @@
+../firewall/firewall4-lib.pl

--- a/firewall6/firewall6-lib.pl
+++ b/firewall6/firewall6-lib.pl
@@ -1,0 +1,1 @@
+../firewall/firewall6-lib.pl

--- a/firewall6/gentoo-linux-lib.pl
+++ b/firewall6/gentoo-linux-lib.pl
@@ -1,0 +1,1 @@
+../firewall/gentoo-linux-lib.pl

--- a/firewall6/help
+++ b/firewall6/help
@@ -1,0 +1,1 @@
+../firewall/help

--- a/firewall6/images
+++ b/firewall6/images
@@ -1,0 +1,1 @@
+../firewall/images

--- a/firewall6/index.cgi
+++ b/firewall6/index.cgi
@@ -1,0 +1,1 @@
+../firewall/index.cgi

--- a/firewall6/install_check.pl
+++ b/firewall6/install_check.pl
@@ -1,0 +1,1 @@
+../firewall/install_check.pl

--- a/firewall6/lang
+++ b/firewall6/lang
@@ -1,0 +1,1 @@
+../firewall/lang

--- a/firewall6/log_parser.pl
+++ b/firewall6/log_parser.pl
@@ -1,0 +1,1 @@
+../firewall/log_parser.pl

--- a/firewall6/mandrake-linux-lib.pl
+++ b/firewall6/mandrake-linux-lib.pl
@@ -1,0 +1,1 @@
+../firewall/mandrake-linux-lib.pl

--- a/firewall6/module.info
+++ b/firewall6/module.info
@@ -1,0 +1,9 @@
+desc=Linux IPv6 Firewall
+category=net
+longdesc=Configure a Linux firewall using ip6tables. Allows the editing of all tables, chains, rules and options.
+name=Firewall6
+desc_de=Linux IPv6 Firewall
+os_support=*-linux
+desc_ca=Tallafocs Linux IPv6
+longdesc_ca=Configura un tallafocs Linux utilitzant ip6tables. Permet l'edició de totes les taules, cadenes, regles i opcions.
+longdesc_de=Konfiguriert eine Linux-Firewall mit ip6tables. Erm&#246;glicht die Bearbeitung aller Tabellen, Ketten, Regeln und Optionen.

--- a/firewall6/move.cgi
+++ b/firewall6/move.cgi
@@ -1,0 +1,1 @@
+../firewall/move.cgi

--- a/firewall6/newchain.cgi
+++ b/firewall6/newchain.cgi
@@ -1,0 +1,1 @@
+../firewall/newchain.cgi

--- a/firewall6/open-ports.pl
+++ b/firewall6/open-ports.pl
@@ -1,0 +1,1 @@
+../firewall/open-ports.pl

--- a/firewall6/redhat-linux-lib.pl
+++ b/firewall6/redhat-linux-lib.pl
@@ -1,0 +1,1 @@
+../firewall/redhat-linux-lib.pl

--- a/firewall6/save_policy.cgi
+++ b/firewall6/save_policy.cgi
@@ -1,0 +1,1 @@
+../firewall/save_policy.cgi

--- a/firewall6/save_rule.cgi
+++ b/firewall6/save_rule.cgi
@@ -1,0 +1,1 @@
+../firewall/save_rule.cgi

--- a/firewall6/save_rule6.cgi
+++ b/firewall6/save_rule6.cgi
@@ -1,0 +1,1 @@
+../firewall/save_rule6.cgi

--- a/firewall6/setup.cgi
+++ b/firewall6/setup.cgi
@@ -1,0 +1,1 @@
+../firewall/setup.cgi

--- a/firewall6/setup6.cgi
+++ b/firewall6/setup6.cgi
@@ -1,0 +1,1 @@
+../firewall/setup6.cgi

--- a/firewall6/trustix-linux-lib.pl
+++ b/firewall6/trustix-linux-lib.pl
@@ -1,0 +1,1 @@
+../firewall/trustix-linux-lib.pl

--- a/firewall6/unapply.cgi
+++ b/firewall6/unapply.cgi
@@ -1,0 +1,1 @@
+../firewall/unapply.cgi


### PR DESCRIPTION
For now /firewall6 is a symlink to /firewall. So a "cloned" module will be created by `makedist.sh`.

After updating to newest webmin and pull the latest changes from github repo I noted that both modules show up with the the name "Linux Firewall". This is not a problem becaue everthing is working, but may irritate users.

I fixed this by replacing the single `firewall6` symlink with individual smylinks from all files/dirs from firewall6 to firewall and placing the old `module.info` file from firewall6 into the firewall6 directory.