### PR TITLE
status: Support 307 and 308 HTTP redirects

### DIFF
--- a/status/http-monitor.pl
+++ b/status/http-monitor.pl
@@ -29,7 +29,7 @@ eval {
 		}
 	&write_http_connection($con, "\r\n");
 	local $line = &read_http_connection($con);
-	$up = $line =~ /^HTTP\/1\..\s+(200|301|302|303)\s+/ ? 1 : 0;
+	$up = $line =~ /^HTTP\/1\..\s+(200|301|302|303|307|308)\s+/ ? 1 : 0;
 	if ($re && $up) {
 		# Read the headers
 		local %header;


### PR DESCRIPTION
The differences from 302 and 301 are only how methods change.

307: https://tools.ietf.org/html/rfc7231#section-6.4.7
308: https://tools.ietf.org/html/rfc7538