### PR TITLE
De-uglify multiselect move arrows with fUnicode!

### DIFF
--- a/ui-lib.pl
+++ b/ui-lib.pl
@@ -1002,9 +1002,9 @@ if (defined($opts_title)) {
 $rv .= "<tr class='ui_multi_select_row'>";
 $rv .= "<td>".&ui_select($name."_opts", [ ], $leftover,
 			 $size, 1, 0, $dis, $wstyle)."</td>\n";
-$rv .= "<td>".&ui_button("->", $name."_add", $dis,
+$rv .= "<td>".&ui_button("▶", $name."_add", $dis,
 		 "onClick='multi_select_move(\"$name\", form, 1)'")."<br>".
-	      &ui_button("<-", $name."_remove", $dis,
+	      &ui_button("◀", $name."_remove", $dis,
 		 "onClick='multi_select_move(\"$name\", form, 0)'")."</td>\n";
 $rv .= "<td>".&ui_select($name."_vals", [ ], $values,
 			 $size, 1, 0, $dis, $wstyle)."</td>\n";


### PR DESCRIPTION
This changes the ugly '->' and '<-' arrows to Unicode pointy shapes that look much nicer. These glyphs have been part of the Unicode standard for many years and are available in the fonts used in all of our themes. I can't think of any obvious compatibility issues. I've tested across all of the browsers I have access to.