### PR TITLE
Typo: Scalar should be used

### DIFF
--- a/ppp-client/save.cgi
+++ b/ppp-client/save.cgi
@@ -137,7 +137,7 @@ if (defined($_[1])) {
 	}
 else {
 	delete($dialer->{'values'}->{$n});
-	delete(dialer->{'onames'}->{$n});
+	delete($dialer->{'onames'}->{$n});
 	}
 }
 


### PR DESCRIPTION
Fixes the typo of an not used scalar