### PR TITLE
Provide an ability for user to open link from outside @authentic-theme#841

### DIFF
--- a/package-updates/update.pl
+++ b/package-updates/update.pl
@@ -46,7 +46,7 @@ if ($tellcount) {
 	&get_miniserv_config(\%miniserv);
 	$proto = $miniserv{'ssl'} ? 'https' : 'http';
 	$port = $miniserv{'port'};
-	$url = $proto."://".&get_system_hostname().":".$port."/$module_name/";
+	$url = $proto."://".&get_system_hostname().":".$port."/$module_name/?xnavigation=1";
 	$body .= "Updates can be installed at $url\n\n";
 	}
 
@@ -67,4 +67,3 @@ if ($config{'sched_email'} && $body) {
 		print STDERR $body;
 		}
 	}
-

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -4702,8 +4702,27 @@ if ($module_name && !$main::no_acl_check &&
 	}
 
 # Check for trigger URL to simply redirect to root: required for Authentic Theme 19.00+
-if ($ENV{'REQUEST_URI'} =~ /xnavigation=1/) {
-	redirect("/");
+if ($current_theme =~ /authentic-theme/ && $ENV{'REQUEST_URI'} =~ /xnavigation=1/) {
+
+  # Redirect user to the entered URL upon next page load; store URL into temporary file
+  if ($main::session_id && $remote_user) {
+      my $xnav = "xnavigation=1";
+
+      my $protocol = lc($ENV{'HTTPS'}) eq 'on' ? "https" : "http";
+      my $url = "$protocol://$ENV{'HTTP_HOST'}$ENV{'REQUEST_URI'}";
+      $url =~ s/[?|&]$xnav//g;
+      $url =~ s/[^\p{L}\p{N},;:.%&#=_@\+\?\-\/]//g;
+
+      my $tmp  = 'tmp';
+      my $salt = encode_base64($main::session_id);
+      $salt =~ tr/A-Za-z0-9//cd;
+
+      my %var;
+      my $key = 'goto';
+      $var{$key} = $url;
+      write_file((tempname_dir() . '/.' . $tmp . '_' . $salt . '_' . get_product_name() . '_' . $key . '_' . $remote_user), \%var);
+  		}
+  redirect("/");
 	}
 
 # Check the Referer: header for nasty redirects


### PR DESCRIPTION
I don't see the other way to make this work. At the moment, user can open any module without navigation menu.

When opening link from the outside (like email notification), referre is not set and the warning message appears.

We use supplied URL, filter it and store it on the disk; in a split second, when theme checks for goto tmp variable, it does checking and then tried to open the link using AJAX call.