### PR TITLE
Don't break the initial order

### DIFF
--- a/shell/index.cgi
+++ b/shell/index.cgi
@@ -23,7 +23,7 @@ else {
 	open(PREVFILE, $prevfile);
 	chop(@previous = <PREVFILE>);
 	close(PREVFILE);
-	@previous = &unique(@previous);
+	@previous = @previous;
 	}
 $cmd = $in{'doprev'} ? $in{'pcmd'} : $in{'cmd'};
 


### PR DESCRIPTION
Jamie, Authentic Theme utilizes `history` and `history -d` command.

Once unique is applied everything breaks, obviously.

It has to go.