### PR TITLE
fix :CPU info is now displayed, even no `cpu mhz` entry is availible in `/proc/cpuinfo`

### DIFF
--- a/proc/linux-lib.pl
+++ b/proc/linux-lib.pl
@@ -308,7 +308,7 @@ if ($c{'cache size'} =~ /^(\d+)\s+KB/i) {
 elsif ($c{'cache size'} =~ /^(\d+)\s+MB/i) {
 	$c{'cache size'} = $1*1024*1024;
 	}
-if ($c{'cpu mhz'}) {
+if ($c{'model name'}) {
 	return ( $load[0], $load[1], $load[2],
 		 int($c{'cpu mhz'}), $c{'model name'}, $c{'vendor_id'},
 		 $c{'cache size'}, $c{'processor'}+1 );

--- a/proc/linux-lib.pl
+++ b/proc/linux-lib.pl
@@ -308,6 +308,10 @@ if ($c{'cache size'} =~ /^(\d+)\s+KB/i) {
 elsif ($c{'cache size'} =~ /^(\d+)\s+MB/i) {
 	$c{'cache size'} = $1*1024*1024;
 	}
+if (!$c{'cpu mhz'} && $c{'model name'}) {
+    $c{'model name'} .= " @ ".$c{'bogomips'}=~s/.$//r." bMips";
+}
+
 if ($c{'model name'}) {
 	return ( $load[0], $load[1], $load[2],
 		 int($c{'cpu mhz'}), $c{'model name'}, $c{'vendor_id'},


### PR DESCRIPTION
CPU info is now displayed, even no `cpu mhz` entry is availible in `/proc/cpuinfo`

---
original linux `os_get_cpu_info()` returns info about CPU only if `$c{'cpu mhz'}` is found, this leads to not display CPU Info at all, because  on my Synology  `/proc/cpuinfo` has no info about CPU speed!

I changed this to check for `$c{model name}` which is the minimum Info needed to show CPU Type.

![image](https://user-images.githubusercontent.com/4593242/34322078-f4a72bc6-e81d-11e7-94ec-9a7e186cfab6.png)

 