### PR TITLE
base_version() fix possible suffix in webnin version

### DIFF
--- a/webmin/webmin-lib.pl
+++ b/webmin/webmin-lib.pl
@@ -764,6 +764,8 @@ Rounds a version number down to the nearest .01
 =cut
 sub base_version
 {
+#remove waning about (possible) postfixes from update-from-repo.sh
+$_[0] =~ s/[-a-z:_].*//gi;
 return sprintf("%.2f0", $_[0]);
 }
 


### PR DESCRIPTION
In update-from-repo.sh I add - MMDD.HHMM to version, this gives 2 warnings:

Argument "1.871-1223.1116" isn't numeric in sprintf at /var/packages/webmin/target/webmin/webmin/webmin-lib.pl line 767.
Argument "1.871-1223.1116" isn't numeric in numeric gt (>) at /var/packages/webmin/target/webmin/webmin/webmin-lib.pl line 1216.

I added a small regex to filter out (possible) postfixes from version number, but does not change official version number:
 s/[-a-z:_].*//gi

only done in one place in case you say don't care about, its working, even the warning is shown :-)