### PR TITLE
fix update-from-repo version postfix typo from . to -

### DIFF
--- a/update-from-repo.sh
+++ b/update-from-repo.sh
@@ -139,7 +139,7 @@ if [[ $EUID -eq 0 ]]; then
 
         ####################
         # start processing pulled source
-        version="`head -c -1 ${TEMP}/version`.`cd ${TEMP}; ${GIT} log -1 --format=%cd --date=format:'%m%d.%H%M'`" 
+        version="`head -c -1 ${TEMP}/version`-`cd ${TEMP}; ${GIT} log -1 --format=%cd --date=format:'%m%d.%H%M'`" 
         if [[ "${LANG}" != "YES" ]]; then
           ###############
           # FULL update


### PR DESCRIPTION
in update-from-repo.sh I add a postfix from latest commit date to version number so you know its not the offical version and whats the latest commit in.  I wanted to use - as seperator but used . by accident.