### PR TITLE
Stay with generic-linux until module not avail solved

### DIFF
--- a/os_list.txt
+++ b/os_list.txt
@@ -404,8 +404,8 @@ Sun Java Desktop System		2.0 (Linux)	suse-linux	9.2	`cat /etc/SuSE-release 2>/de
 Sun Java Desktop System		3.0 (Linux)	suse-linux	9.2	`cat /etc/SuSE-release 2>/dev/null` =~ /Java Desktop System.*\nVERSION = 3\.0/i
 Sun Java Desktop System		2.0 (Solaris)	solaris		9	$uname =~ /SunOS.*\s5\.9\s/i && `cat /etc/sun-release 2>/dev/null` =~ /Sun\s+Java\s+Desktop/
 
-# Synology NAS Linux
-Synology NAS		$1	syno-linux	$1	`grep  productversion= /etc.defaults/VERSION` =~ /productversion="([0-9]+\.[0-9+])\./ 
+# Synology NAS, Syno Linux - DSM Version 6.x+
+Synology DSM		$1	generic-linux	$1	`grep  productversion= /etc.defaults/VERSION` =~ /productversion="([0-9]+\.[0-9+])\./ 
 
 # All other Linux variants, identified by kernel version
 Generic Linux			$1	generic-linux	$1	`uname -r` =~ /^([0-9]+\.[0-9+])\./


### PR DESCRIPTION
to not break existing installations I will keep the config files, but change OS type back to generic-linux for next release.
meanwhile I'll investigate why so many modules are blocked by foreign_abailible() and friends.

See: https://github.com/webmin/webmin/issues/745