### PR TITLE
fix longdesc / longdecsc_de

### DIFF
--- a/filemin/module.info
+++ b/filemin/module.info
@@ -7,6 +7,6 @@ desc=File Manager
 desc_ca=Gestor de Fitxers
 longdesc_ca=Gestor de fitxers lleuger i ràpid escrit en perl.
 desc_de=Datei Manager
-longdesc=Schneller, kleiner Datei Manager geschrieben in Perl.
+longdesc_de=Schneller, kleiner Datei Manager geschrieben in Perl.
 desc_de.UTF-8=Datei Manager
 longdesc_de.UTF-8=Schneller, kleiner Datei Manager geschrieben in Perl. 


### PR DESCRIPTION
Ilia pints out that I use a second longdes= for german, fixed