### PR TITLE
Fix open theme's link in new tab

### DIFF
--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -4702,9 +4702,28 @@ if ($module_name && !$main::no_acl_check &&
 	}
 
 # Check for trigger URL to simply redirect to root: required for Authentic Theme 19.00+
-if ($ENV{'REQUEST_URI'} =~ /xnavigation=1/) {
-	redirect("/");
+if ($current_theme =~ /authentic-theme/ && $ENV{'REQUEST_URI'} =~ /xnavigation=1/) {
+
+  # Redirect user to the entered URL upon next page load; store URL into temporary file
+  if ($main::session_id && $remote_user) {
+      my $xnav = "xnavigation=1";
+
+      my $url = "$gconfig{'webprefix'}$ENV{'REQUEST_URI'}";
+      $url =~ s/[?|&]$xnav//g;
+      $url =~ s/[^\p{L}\p{N},;:.%&#=_@\+\?\-\/]//g;
+
+      my $tmp  = 'tmp';
+      my $salt = encode_base64($main::session_id);
+      $salt =~ tr/A-Za-z0-9//cd;
+
+      my %var;
+      my $key = 'goto';
+      $var{$key} = $url;
+			write_file(tempname('.theme_' . $salt . '_' . get_product_name() . '_' . $key . '_' . $remote_user), \%var);
+  		}
+  redirect("/");
 	}
+
 
 # Check the Referer: header for nasty redirects
 my @referers = split(/\s+/, $gconfig{'referers'});


### PR DESCRIPTION
This one works correctly.

Just copy past any URL and hit enter. As long as URL has `xnavigation=1` query it will work.

In the future, I will try to modify clipboard when user copies the link using right click, so it would also be pasted with `xnavigation=1` trigger.

Tell me if you like it and I could skip doing lots of reworking.