### PR TITLE
script for move desc out of module.info

### DIFF
--- a/chinese-to-utf8.pl
+++ b/chinese-to-utf8.pl
@@ -80,45 +80,62 @@ foreach $m (@modules) {
 	local %minfo;
 	&read_file("$m/module.info", \%minfo);
 	local %ominfo = %minfo;
-	if ($minfo{'desc_zh_TW.Big5'}) {
+	if ( ! -d "$m/lang" ) {
+	  if ($minfo{'desc_zh_TW.Big5'}) {
 		$minfo{'desc_zh_TW.UTF-8'} = &Big5ToUTF8($minfo{'desc_zh_TW.Big5'});
 		}
-	if ($minfo{'desc_zh_CN'}) {
+	  if ($minfo{'desc_zh_CN'}) {
 		$minfo{'desc_zh_CN.UTF-8'} = &GB2312ToUTF8($minfo{'desc_zh_CN'});
 		}
-	if ($minfo{'desc_ja_JP.euc'}) {
+	  if ($minfo{'desc_ja_JP.euc'}) {
 		$minfo{'desc_ja_JP.UTF-8'} = &EUCToUTF8($minfo{'desc_ja_JP.euc'});
 		}
-	if ($minfo{'desc_ko_KR.euc'}) {
+	  if ($minfo{'desc_ko_KR.euc'}) {
 		$minfo{'desc_ko_KR.UTF-8'} = &KRToUTF8($minfo{'desc_ko_KR.euc'});
 		}
-	if ($minfo{'desc_ru_SU'}) {
+	  if ($minfo{'desc_ru_SU'}) {
 		$minfo{'desc_ru.UTF-8'} = &KOI8ToUTF8($minfo{'desc_ru_SU'});
 		}
-	foreach $l (@fiveone_langs) {
+	  foreach $l (@fiveone_langs) {
 		if ($minfo{'desc_'.$l}) {
 			$minfo{'desc_'.$l.'.UTF-8'} =
 				&Windows1251ToUTF8($minfo{'desc_'.$l});
 			}
 		}
-	foreach $l (@fivenine_langs) {
+	  foreach $l (@fivenine_langs) {
 		if ($minfo{'desc_'.$l}) {
 			$minfo{'desc_'.$l.'.UTF-8'} =
 				&ISO88592ToUTF8($minfo{'desc_'.$l});
 			}
 		}
-	foreach $l (@fifteen_langs) {
+	  foreach $l (@fifteen_langs) {
 		if ($minfo{'desc_'.$l}) {
 			$minfo{'desc_'.$l.'.UTF-8'} =
 				&ISO885915ToUTF8($minfo{'desc_'.$l});
 			}
 		}
-	foreach $l (@default_langs) {
+	  foreach $l (@default_langs) {
 		if ($minfo{'desc_'.$l}) {
 			$minfo{'desc_'.$l.'.UTF-8'} =
 				&DefaultToUTF8($minfo{'desc_'.$l});
 			}
 		}
+	  } else {
+	  # copy module desc from lang files to module.info
+	  opendir(DIR, "$m/lang");
+	  foreach $lang (readdir(DIR)) {
+		local $desc='desc_'.$lang;
+		$desc='desc'.$lang =~ s/^en// if ( $lang =~  m/^en/ );
+		local %dinfo;
+		&read_file("$m/lang/$lang", \%dinfo);
+		if ($dinfo{'desc'}) {
+			$minfo{$desc} = $dinfo{'desc'};
+			}
+		if ($dinfo{'longdesc'}) {
+			$minfo{'long'.$desc} = $dinfo{'longdesc'};
+			}
+	  }
+	}
 	&write_file_diff("$m/module.info", \%minfo);
 
 	# Translate the config.info file

--- a/chinese-to-utf8.pl
+++ b/chinese-to-utf8.pl
@@ -7,7 +7,8 @@
 chdir($ARGV[0] || "/usr/local/webadmin");
 @modules = ( "." );
 opendir(DIR, ".");
-foreach $d (readdir(DIR)) {
+foreach $d ( sort readdir(DIR)) {
+	next if ($d =~ m/^\./);
 	push(@modules, $d) if (-r "$d/module.info");
 	}
 closedir(DIR);
@@ -81,6 +82,7 @@ foreach $m (@modules) {
 	&read_file("$m/module.info", \%minfo);
 	local %ominfo = %minfo;
 	if ( ! -d "$m/lang" ) {
+	  # process module info if no lang dir exist
 	  if ($minfo{'desc_zh_TW.Big5'}) {
 		$minfo{'desc_zh_TW.UTF-8'} = &Big5ToUTF8($minfo{'desc_zh_TW.Big5'});
 		}
@@ -121,9 +123,10 @@ foreach $m (@modules) {
 			}
 		}
 	  } else {
-	  # copy module desc from lang files to module.info
+	  # process lang files and copy module desc to module.info
 	  opendir(DIR, "$m/lang");
-	  foreach $lang (readdir(DIR)) {
+	  foreach $lang (sort readdir(DIR)) {
+		next if ($lang =~ m/^\./);
 		local $desc='desc_'.$lang;
 		$desc='desc'.$lang =~ s/^en// if ( $lang =~  m/^en/ );
 		local %dinfo;

--- a/move2desc.sh
+++ b/move2desc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# move descriptions out of module,info
+FILES=apache/module.info
+[ "$1" != "" ] && FILES="$*"
+
+for file in $FILES
+do
+	echo "processing $file ..."
+	# get dir
+	dir=`dirname $file`
+	[ ! -d "$dir/lang" ] && echo "skipping $dir: no lang dir" && continue
+	# move to temp file
+	sed '/desc_.*=/d' $file >$file.tmp
+	grep -a -e '^desc' -e '^longdesc' $file | sort >$file.desc
+	mv $file.tmp $file
+
+	# move desc to lang files
+	for line in `ls $dir/lang`
+	do
+		lang="_$line"
+		[ "$lang" = "_en" ] && lang=""
+		sed -n  "s/^desc$lang=/desc=/p" $file.desc >$dir/lang/$line.tmp
+		sed -n  "s/^longdesc$lang=/longdesc=/p" $file.desc >>$dir/lang/$line.tmp
+		[ ! -s "$dir/lang/$line.tmp" ] && sed -n  "/^desc=/p" $file.desc >$dir/lang/$line.tmp
+		grep -q "^longdesc" "$dir/lang/$line.tmp" || sed -n  "/^longdesc=/p" $file.desc >>$dir/lang/$line.tmp
+		cat $dir/lang/$line >>$dir/lang/$line.tmp
+		mv $dir/lang/$line.tmp $dir/lang/$line
+	done
+done
+echo "cleanup ..."
+rm -f */module.info.desc */*.tmp */*/*.tmp

--- a/update-from-repo.sh
+++ b/update-from-repo.sh
@@ -162,8 +162,9 @@ if [[ $EUID -eq 0 ]]; then
           done
 
           #prepeare unattended upgrade
-          [[ ! -f "${TEMP}/tarballs/${PROD}-${version}/setup.sh" ]] && \
-                   cp  "${TEMP}/setup.sh" "${TEMP}/tarballs/${PROD}-${version}/setup.sh"
+          cp "${TEMP}/maketemp.pl" "${TEMP}/tarballs/${PROD}-${version}"
+          cp  "${TEMP}/setup.sh" "${TEMP}/tarballs/${PROD}-${version}"
+          cp "${temp}/chinese-to-utf-8.pl" .
           echo  -en "${CYAN}search for config dir ... ${NC}"
           config_dir=`grep env_WEBMIN_CONFIG= ${MINICONF}| sed 's/.*_WEBMIN_CONFIG=//'`
           echo  -e "${ORANGE}found: ${config_dir}${NC}"


### PR DESCRIPTION
this PR provides the script to move desc from module.info to lang files and a change to chinese-to-utf8.pl to add translated desc to module.info again when creating a release.

even this seems stupid first it has some advantages:

- small and ascii only module.info while developing, no mixed charset
- only one file to translate per language, incl. desc and longdesc which was often forgotten by translator's
- saves many 100's small calls of iconv in chinese-to-utf8.pl 

to keep this PR small and allow testing, I do not include the changed lang files
these will be provided if Jamie likes the proposal

How to check everthing is working as proposed?

- check out `git clone https://github.com/gnadelwartz/webmin.git webmin-desc`
- cd to webmin-test and run `./move2lang.sh */module.info` to move desc to lang files
- check if all went well: in module.info only the english desc and longdesc should remain,
   all others are moved to lang/xx files. If no desc or longdesc is availible for a language the
   english defaults  are inserted in the lang file.
- run `./chinese-to-utf8.pl` to create UTF-8 translations and insert translated descriptions  in module.info for release.
- check if desc and longdesc for all languages are present in module.info.

please give feedback if something does not work