### PR TITLE
Prevent elements with the same id

### DIFF
--- a/filemin/unauthenticated/js/legacy.js
+++ b/filemin/unauthenticated/js/legacy.js
@@ -16,7 +16,7 @@ $( document ).ready(function() {
     $('tr').removeAttr('onmouseover');
     $('tr').removeAttr('onmouseout');
     $('input').removeAttr('onclick');
-    $('#select-unselect').change(function() { selectUnselect($(this)); });
+    $('._select-unselect_').change(function() { selectUnselect($(this)); });
 
     // BUTTONS
     $('.fg-button').hover(


### PR DESCRIPTION
In AJAX mode, the browser will always return same-id error.