### PR TITLE
Prevent elements with the same id

### DIFF
--- a/filemin/filemin-lib.pl
+++ b/filemin/filemin-lib.pl
@@ -269,7 +269,7 @@ sub print_interface {
     # Render current directory entries
     print &ui_form_start("", "post", undef, "id='list_form'");
     @ui_columns = (
-            '<input id="select-unselect" type="checkbox" onclick="selectUnselect(this)" />',
+            '<input class="_select-unselect_" type="checkbox" onclick="selectUnselect(this)" />',
             ''
         );
     push @ui_columns, ('<span data-head-name>' . $text{'name'} . '</span>');


### PR DESCRIPTION
In AJAX mode, the browser will always return same-id error.