### PR TITLE
fix autodetecting crontab command 

### DIFF
--- a/cluster-copy/module.info.de
+++ b/cluster-copy/module.info.de
@@ -1,2 +1,2 @@
 desc_de=Cluster - Dateien kopieren
-longdesc_de=Plane den Dateireansfer von diesem zu anderen Servern in einem Webmin-Cluster.
+longdesc_de=Plane den Dateiransfer von diesem zu anderen Servern in einem Webmin-Cluster.

--- a/cron/config.info
+++ b/cron/config.info
@@ -11,7 +11,6 @@ hourly_only=Only allow jobs to be at most hourly?,1,0-No,1-Yes
 add_file=Add new jobs to file,3,User's regular crontab file
 line2=System configuration,11
 cron_dir=Crontab Directory,0
-cron_crontab=System has <tt>crontab</tt> command availible?,1,0-No&#44; webmin processes user files itself,1-Yes&#44; use following crontab commands for users:
 cron_get_command=Command to read a user's cron job,0
 cron_edit_command=Command to edit a user's cron job,0
 cron_copy_command=Command to accept a user's cron job on stdin,0

--- a/cron/config.info.de
+++ b/cron/config.info.de
@@ -11,7 +11,6 @@ hourly_only=Cronjobs auf 1x pro Stunde begrenzen?,1,0-Nein,1-Ja
 add_file=F&#252;gt neue Jobs zu Datei hinzu,3,Regul&#228;re crontab-Datei
 line2=Systemkonfiguration,11
 cron_dir=Crontab-Verzeichnis,0
-cron_crontab=Befehl <tt>crontab</tt> ist im Sytem verf&uuml;gbar?,1,0-Nein&#44; Webmin bearbeitet Benutzer Dateien selbst,1-Ja&#44; nutze folgende Befehle f&uuml;r Benutzer:
 cron_get_command=Befehl zum Lesen der Cron-Auftr&#228;ge eines Benutzers,0
 cron_edit_command=Befehl zum Bearbeiten der Cron-Auftr&#228;ge eines Benutzers,0
 cron_copy_command=Befehl zum Akzeptieren eines Cron-Auftrags eines Benutzers auf stdin,0

--- a/cron/cron-lib.pl
+++ b/cron/cron-lib.pl
@@ -1531,7 +1531,7 @@ if ($config{'single_file'} && !-r $config{'single_file'}) {
 	}
 if (&has_crontab_cmd() && ($config{'cron_get_command'} =~ /^\s*$/ ||
     $config{'cron_edit_command'} =~ /^\s*$/)) {
-	return &text('index_ecmd', "<tt>$1</tt>");
+	return &text('index_ecmd', "<tt>$1</tt>", "/config.cgi?cron");
 	}
 # Check for directory
 local $fcron = ($config{'cron_dir'} =~ /\/fcron$/);
@@ -1620,7 +1620,7 @@ Returns 1 if the crontab command exists on this system
 =cut
 sub has_crontab_cmd
 {
-&has_command("crontab");
+return &has_command( &split_quoted_string( $config{'cron_edit_command'})) || &has_command("crontab");
 }
 
 1;

--- a/cron/cron-lib.pl
+++ b/cron/cron-lib.pl
@@ -1529,8 +1529,8 @@ sub check_cron_config
 if ($config{'single_file'} && !-r $config{'single_file'}) {
 	return &text('index_esingle', "<tt>$config{'single_file'}</tt>");
 	}
-if (&has_crontab_cmd() && $config{'cron_get_command'} =~ /^(\S+)/ &&
-    !&has_command("$1")) {
+if (&has_crontab_cmd() && ($config{'cron_get_command'} =~ /^\s*$/ ||
+    $config{'cron_edit_command'} =~ /^\s*$/)) {
 	return &text('index_ecmd', "<tt>$1</tt>");
 	}
 # Check for directory
@@ -1620,11 +1620,7 @@ Returns 1 if the crontab command exists on this system
 =cut
 sub has_crontab_cmd
 {
-my $cmd = &split_quoted_string($config{'cron_user_edit_command'});
-if (&has_command($cmd) || &has_command("crontab")) {
-	return 1;
-	}
-return 0;
+&has_command("crontab");
 }
 
 1;

--- a/cron/cron-lib.pl
+++ b/cron/cron-lib.pl
@@ -498,7 +498,6 @@ if (&read_file_contents($cron_temp_file) =~ /\S/) {
 		# We have no crontab command .. emulate by copying to user file
 		$rv = system("cat $cron_temp_file".
 			" >$config{'cron_dir'}/$_[0] 2>/dev/null");
-		system("chmod 600 $_[0] $config{'cron_dir'}/$_[0] 2>/dev/null");
 		}
 	elsif ($config{'cron_edit_command'}) {
 		# fake being an editor
@@ -1529,9 +1528,9 @@ sub check_cron_config
 if ($config{'single_file'} && !-r $config{'single_file'}) {
 	return &text('index_esingle', "<tt>$config{'single_file'}</tt>");
 	}
-if (&has_crontab_cmd() && ($config{'cron_get_command'} =~ /^\s*$/ ||
-    $config{'cron_edit_command'} =~ /^\s*$/)) {
-	return &text('index_ecmd', "<tt>$1</tt>", "/config.cgi?cron");
+if (!&has_crontab_cmd() && $config{'cron_get_command'} =~ /^(\S+)/ &&
+    !&has_command("$1")) {
+	return &text('index_ecmd', "<tt>$1</tt>");
 	}
 # Check for directory
 local $fcron = ($config{'cron_dir'} =~ /\/fcron$/);
@@ -1620,7 +1619,10 @@ Returns 1 if the crontab command exists on this system
 =cut
 sub has_crontab_cmd
 {
-return &has_command( &split_quoted_string( $config{'cron_edit_command'})) || &has_command("crontab");
+my $cmd = $config{'cron_user_edit_command'};
+$cmd =~ s/^su.*-c\s+//;
+($cmd) = &split_quoted_string($cmd);
+return &has_command($cmd) || &has_command("crontab");
 }
 
 1;

--- a/cron/cron-lib.pl
+++ b/cron/cron-lib.pl
@@ -498,6 +498,7 @@ if (&read_file_contents($cron_temp_file) =~ /\S/) {
 		# We have no crontab command .. emulate by copying to user file
 		$rv = system("cat $cron_temp_file".
 			" >$config{'cron_dir'}/$_[0] 2>/dev/null");
+		system("chmod 600 $_[0] $config{'cron_dir'}/$_[0] 2>/dev/null");
 		}
 	elsif ($config{'cron_edit_command'}) {
 		# fake being an editor
@@ -1528,7 +1529,7 @@ sub check_cron_config
 if ($config{'single_file'} && !-r $config{'single_file'}) {
 	return &text('index_esingle', "<tt>$config{'single_file'}</tt>");
 	}
-if (!&has_crontab_cmd() && $config{'cron_get_command'} =~ /^(\S+)/ &&
+if (&has_crontab_cmd() && $config{'cron_get_command'} =~ /^(\S+)/ &&
     !&has_command("$1")) {
 	return &text('index_ecmd', "<tt>$1</tt>");
 	}
@@ -1619,9 +1620,11 @@ Returns 1 if the crontab command exists on this system
 =cut
 sub has_crontab_cmd
 {
-my $cmd = $config{'cron_user_edit_command'} || "crontab";
-($cmd) = &split_quoted_string($cmd);
-return &has_command($cmd);
+my $cmd = &split_quoted_string($config{'cron_user_edit_command'});
+if (&has_command($cmd) || &has_command("crontab")) {
+	return 1;
+	}
+return 0;
 }
 
 1;

--- a/cron/lang/de
+++ b/cron/lang/de
@@ -84,7 +84,7 @@ index_comment=Beschreibung
 index_create=Einen neuen Cron-Auftrag erstellen
 index_delete=L&#246;sche ausgew&#228;hlte Auftr&#228;ge
 index_disable=Deaktiviere ausgew&#228;hlte Auftr&#228;ge
-index_ecmd=Das Kommando $1 um Cron Benutzer Konfigurationen zu bearbeiten wurde nicht gefunden. Vielleicht ist Cron nicht auf Ihrem System installiert?
+index_ecmd=Das Kommando $1 um Cron Benutzer Konfigurationen zu bearbeiten wurde nicht gefunden. Vielleicht ist Cron nicht auf Ihrem System installiert oder die <a href='$2'>Modulkonfiguration</a>  ist falsch?
 index_econfigcheck=Cron Auftr&#228;ge k&#246;nnen auf Ihrem System nicht gesteuert werden, weil die Modul-Konfiguration nicht g&#252;ltig ist.
 index_ecreate=Eine neue Umgebungsvariable erzeugen.
 index_ecrondir=Das Cron Auftr&auml;ge Verzeichnis $1 existiert nicht. Vielleicht ist die Modul-Konfiguration falsch oder Cron ist nicht installiert?

--- a/cron/lang/en
+++ b/cron/lang/en
@@ -15,7 +15,7 @@ index_return=cron list
 index_env=Environment variable
 index_move=Move
 index_run=Running?
-index_ecmd=The command $1 for managing user Cron configurations was not found. Maybe Cron is not installed on this system?
+index_ecmd=The command $1 for managing user Cron configurations was not found. Maybe Cron is not installed or you <a href='$2'>rmodule konfiguration</a> is wrong on this system?
 index_esingle=The file $1 listing Cron jobs does not exist. Maybe Cron is not installed on this system?
 index_ecrondir=The Cron jobs directory $1 does not exist. Maybe the module's configuration is incorrect, or Cron is not installed?
 index_ecrondir_create=Try to create jobs directory $1 ?

--- a/error403.cgi
+++ b/error403.cgi
@@ -1,0 +1,14 @@
+#!/usr/local/bin/perl
+
+BEGIN { push(@INC, ".."); };
+use WebminCore;
+
+&init_config();
+&ReadParse();
+
+$msg="error_$in{'code'}";
+&ui_print_header(undef, "$text{'error'} $in{'code'}: $text{$msg}", "", undef, undef, 1, 1);
+print ui_alert_box("<br>$in{'message'}<p>$in{'body'}", "warn");
+
+&ui_print_footer("/", $text{'error_previous'});
+

--- a/lang/en
+++ b/lang/en
@@ -48,6 +48,7 @@ create=Create
 delete=Delete
 find=Find
 error=Error
+error_403=Access denied!
 error_previous=previous page
 error_stack=Call Stack Trace
 error_file=File

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -2669,7 +2669,9 @@ if ($eh) {
 	$querystring = "code=$_[0]&message=".&urlize($_[1]).
 		       "&body=".&urlize($_[2]);
 	$error_handler_recurse++;
-	$ok_code = $_[0];
+	# return 200 to statisfy PCI scanners, see
+	# https://github.com/webmin/webmin/issues/833
+	$ok_code = 200; # $_[0];
 	$ok_message = $_[1];
 	goto rerun;
 	}


### PR DESCRIPTION
whats in this PR:

- `$config{'cron_user_edit_command'}` does not exist, checking for `has_command('crontab');` is enough
- instead change logic for complaining about missing config for  crontab commands:
   - if crontab exist, commands for list and edit must be given
   - if crontab not exist values for list and edit are ignored
- remove no more needed option "is crontab availible"
- fix permissions of manually created user crontab