### PR TITLE
shorter german menu entry for "Language and Theme"

### DIFF
--- a/backup-config/module.info.de
+++ b/backup-config/module.info.de
@@ -1,2 +1,2 @@
-desc_de=Sicherung von Konfigurationsdateien
+desc_de=Konfigurations sichern
 longdesc_de=F&uuml;hre einmalige oder geplante Backups und Restore der Webmin Konfiguration durch.

--- a/backup-config/module.info.de
+++ b/backup-config/module.info.de
@@ -1,2 +1,2 @@
-desc_de=Konfigurations sichern
+desc_de=Konfiguration sichern
 longdesc_de=F&uuml;hre einmalige oder geplante Backups und Restore der Webmin Konfiguration durch.

--- a/change-user/module.info.de
+++ b/change-user/module.info.de
@@ -1,2 +1,2 @@
-desc_de=Sprache und Design &aumll,ndern
+desc_de=Sprache und Design &auml;ndern
 longdesc_de=Sprache, Design und Passwort des aktuellen Webmin Benutzers &auml;ndern.

--- a/change-user/module.info.de
+++ b/change-user/module.info.de
@@ -1,2 +1,2 @@
-desc_de=&#196;ndern der Sprache und des Designs
-longdesc_de=&Auml;ndern von Sprache, Design und Passwort des aktuellen Webmin Benutzers.
+desc_de=Sprache und Design &aumll,ndern
+longdesc_de=Sprache, Design und Passwort des aktuellen Webmin Benutzers &auml;ndern.

--- a/webmin/lang/de
+++ b/webmin/lang/de
@@ -484,7 +484,7 @@ newmod_def=Standard-Verhalten - Ordne neue Module <tt>root</tt> oder <tt>admin</
 newmod_desc=Wenn Webmin aktualisiert wird, so werden neue Module automatisch einem oder mehreren Benutzern zugeordnet und f&#252;r die Nutzung freigegeben. Hier k&#246;nnen Sie einstellen, welchen Benutzern neue Module zugeordnet werden. Diese Einstellung ist sowohl f&#252;r die Aktualisierung &#252;ber das obige Formular, als auch f&#252;r die Kommandozeile g&#252;ltig.
 newmod_header=Zuordnung neuer Module
 newmod_users=Ordne neue Module folgendem/folgenden Benutzer(n) zu :
-notif_changenow=Sie k&#246;nnen unter '&#196;ndern der Sprache und des Designs' <a href='$1'>Ihr Passwort jetzt &#228;ndern</a>.
+notif_changenow=Sie k&#246;nnen unter 'Sprache und Designs &auml;ndern' <a href='$1'>Ihr Passwort jetzt &#228;ndern</a>.
 notif_passchange=Ihr Webmin Passwort wurde zuletzt am $1 ge&#228;ndert, und muss in $2 Tage gewechselt werden.
 notif_passexpired=Ihr Webmin Passwort ist abgelaufen! Sie werden gezwungen, es bei der n&#228;chsten Anmeldung &#228;ndern.
 notif_passlock=Ihr Webmin Passwort wurde zuletzt am $1 ge&#228;ndert, und Ihr Konto wird in $2 Tage gesperrt werden, wenn es nicht ge&#228;ndert wird.


### PR DESCRIPTION
The actual menu entry need two lines, this is shorter and the same.
Changed also a reference where the menu entry is mentioned.
