### PR TITLE
fix (ipkg) tree view

### DIFF
--- a/software/ipkg-lib.pl
+++ b/software/ipkg-lib.pl
@@ -57,9 +57,7 @@ while(<PKGINFO>) {
 			# generate categories from names, Section
 			$temp{'Package'} =~ m/^(..[^-0-9]*)/;
 			local $cat= $1;
-			if ($temp{'Section'} =~ m/^(audio|editor|media|print|games|shell|sys|utils)/) {
-				$cat=ucfirst($1);
-			} elsif ($cat =~ /^(audio|auto|core|compression|diff|lib|ffmpeg|gnu|gtk|perl|net|ncurses|py)/) {
+			if ($cat =~ /^(asterisk|audio|auto|core|compression|diff|lib|gnu|gtk|perl|net|ncurses|py)/) {
 				$cat=ucfirst($1);
 			} elsif ($cat =~ /^(amavisd|cyrus|esmtp|fetchmail|imap|mail|mini|mutt|mpop|msmtp|offlineimap|pop|postfix|postgrey|procmail|putmail|up|qpopper|sendmail|xmail)$/ ) {
 				$cat = "Mail";
@@ -73,7 +71,11 @@ while(<PKGINFO>) {
 				$cat = "Editor";
 			} elsif ($cat =~ /^(apache|cherokee|hiawatha|lighttpd|minihttpd|mod|thttpd)$|^shell/) {
 				$cat = "Web";
-			} 
+			} elsif ($temp{'Section'} =~ /^(doc|lang|lib|net|sys|text|util)/ ) {
+				$cat=ucfirst($1);
+			} else {
+				$cat=ucfirst($temp{'Section'});
+			}
 			$packages{$i,'class'} = $cat; 
 			$temp{'Installed-Time'}=undef;
 			$i++;

--- a/software/ipkg-tree.cgi
+++ b/software/ipkg-tree.cgi
@@ -47,16 +47,24 @@ for($i=0; $i<$n; $i++) {
 	push(@desc, $packages{$i,'desc'});
 	push(@inst, $packages{$i,'install'});
 	}
+
 @order = sort { lc($pack[$a]) cmp lc($pack[$b]) } (0 .. $n-1);
 $heir{""} = "";
 foreach $c (sort { $a cmp $b } &unique(@class)) {
-	# note: this is optimize for having only one level!
 	if (!$c) { next; }
-	@w = $c;
+	@w = split(/\//, $c);
 	$p = join('/', @w[0..$#w-1]);		# parent class
+	if (!defined($heir{$p})) {
+		$pp = join('/', @w[0..$#w-2]);	# grandparent class
+		$heir{$pp} .= "$p\0";
+		$ppp = join('/', @w[0..$#w-3]);	# great-grandparent class
+		if ($ppp || 1) {
+			$heir{$ppp} .= "$pp\0";
+			}
+		}
 	$heir{$p} .= "$c\0";
+	$hasclasses++;
 	}
-
 # get the current open list
 %heiropen = map { $_, 1 } &get_heiropen();
 $heiropen{""} = 1;

--- a/software/ipkg-tree.cgi
+++ b/software/ipkg-tree.cgi
@@ -63,29 +63,29 @@ $heiropen{""} = 1;
 
 # traverse the hierarchy
 print &ui_form_start("ipkg-tree.cgi");
-print &ui_submit($text{'IPKG_filter'});
+print &ui_submit($text{'index_filter'});
 print &ui_textbox("filter", $in{'filter'}, 50);
 print &ui_form_end(),"<p>\n";
 
 print &ui_link("ipkg-tree.cgi?mode=closeall", $text{'index_close'});
 print &ui_link("ipkg-tree.cgi?mode=openall", $text{'index_open'});
 if ($in{'filter'}) {
-	print &ui_link("ipkg-tree.cgi", $text{'IPKG_filterclear'});
-	print "&nbsp;&nbsp;", &text('IPKG_filtered',$n-$filter,$n+1), "\n";
+	print &ui_link("ipkg-tree.cgi", $text{'index_filterclear'});
+	print "&nbsp;&nbsp;", &text('index_filtered',$n-$filter,$n+1), "\n";
 }
 print "<table width=\"95%\">\n";
 &traverse("", 0);
 print "</table>\n";
 print &ui_form_start("ipkg-tree.cgi");
-print &ui_submit($text{'IPKG_filter'});
+print &ui_submit($text{'index_filter'});
 print &ui_textbox("filter", $in{'filter'}, 50);
 print &ui_form_end(),"<p>\n";
 
 print &ui_link("ipkg-tree.cgi?mode=closeall", $text{'index_close'});
 print &ui_link("ipkg-tree.cgi?mode=openall", $text{'index_open'});
 if ($in{'filter'}) {
-	print &ui_link("ipkg-tree.cgi", $text{'IPKG_filterclear'});
-	print "&nbsp;&nbsp;", &text('IPKG_filtered',$n-$filter,$n+1), "\n";
+	print &ui_link("ipkg-tree.cgi", $text{'index_filterclear'});
+	print "&nbsp;&nbsp;", &text('index_filtered',$n-$filter,$n+1), "\n";
 }
 print "<p>\n";
 

--- a/software/tree.cgi
+++ b/software/tree.cgi
@@ -84,7 +84,7 @@ if ($in{'filter'}) {
 print "<table width=\"95%\">\n";
 &traverse("", 0);
 print "</table>\n";
-print &ui_form_start("ipkg-tree.cgi");
+print &ui_form_start("tree.cgi");
 print &ui_submit($text{'index_filter'});
 print &ui_textbox("filter", $in{'filter'}, 50);
 print &ui_form_end(),"<p>\n";


### PR DESCRIPTION
What's in this PR:

- fix upper filter form in `tree.cgi`, pointed to ipkg-tree.cgi ...
- fix `ipkg-tree.cgi` to use correct lang strings, filter buttons displayed no text
- optimisation while generating categories in `ipkg-lib.pl`