### PR TITLE
 provide setup.bat for windows installation

### DIFF
--- a/makedist.pl
+++ b/makedist.pl
@@ -14,7 +14,7 @@ $zipdir = "zips";
 
 @files = ("config.cgi", "config-*-linux",
 	  "config-solaris", "images", "index.cgi", "mime.types",
-	  "miniserv.pl", "os_list.txt", "perlpath.pl", "setup.sh", "setup.pl",
+	  "miniserv.pl", "os_list.txt", "perlpath.pl", "setup.sh", "setup.pl, setup.bat",
 	  "version", "web-lib.pl", "web-lib-funcs.pl", "README",
 	  "config_save.cgi", "chooser.cgi", "miniserv.pem",
 	  "config-aix", "update-from-repo.sh",

--- a/makedist.pl
+++ b/makedist.pl
@@ -14,7 +14,7 @@ $zipdir = "zips";
 
 @files = ("config.cgi", "config-*-linux",
 	  "config-solaris", "images", "index.cgi", "mime.types",
-	  "miniserv.pl", "os_list.txt", "perlpath.pl", "setup.sh", "setup.pl, setup.bat",
+	  "miniserv.pl", "os_list.txt", "perlpath.pl", "setup.sh", "setup.pl", "setup.bat",
 	  "version", "web-lib.pl", "web-lib-funcs.pl", "README",
 	  "config_save.cgi", "chooser.cgi", "miniserv.pem",
 	  "config-aix", "update-from-repo.sh",

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,90 @@
+@ECHO off
+ECHO Helper Script to install Webmin on Windows
+ECHO (c) gnadelwartz https:://gitbub.com/gnadelwartz
+ECHO .
+
+:: prepare unautenticated Setup
+SET WEBMIN_download=https://sourceforge.net/projects/webadmin/
+SET WRT_download=https://www.microsoft.com/download/details.aspx?id=17657
+SET PERL_download=https://www.activestate.com/activeperl/
+SET perl_path32=C:\Perl
+SET perl_path64=C:\Perl64
+SET inst_dir=C:\webmin
+SET tmp_dir=C:\tmp
+SET wa_dir=%inst_dir%\webmin
+SET config_directory=%inst_dir%\config
+SET var_dir=%inst_dir%\var
+SET port=10000
+SET admin=10000
+SET ssl=0
+::SET atboot=n
+::SET nostart=y
+SET login=admin
+SET password=admin
+SET INSTALL=setup.pl
+
+:: check if we are in webmin dir
+IF NOT EXIST %INSTALL% (
+	ECHO Webmin installation script not found!
+	ECHO setup.bat must be executed inside the webmin source dir.
+	ECHO .
+	ECHO you can download latest Webmin Version from
+	ECHO https://sourceforge.net/projects/webadmin/
+	start "" %WEBMIN_download%
+	ECHO .
+	PAUSE
+	EXIT
+)
+
+:: check if perl is installed
+IF EXIST %perl_path32% (
+    SET perl_path=%perl_path32%
+    ECHO Perl detected
+) ELSE (
+   IF EXIST %perl_path64% (
+	SET perl_path=%perl_path64%
+	echo Perl64 detected
+    ) ELSE (
+	ECHO Perl is not installed! Please download it from
+	ECHO %PERL_download% and install it!
+	start "" %PERL_download%
+	ECHO .
+	SET INSTALL=false
+    )
+)
+
+:: check if rescource kit is installed
+WHERE sc >nul 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+	ECHO Windows Resource Toolkit is not installed! Please download it from
+	ECHO %WRT_download% and install it!
+	start "" %WRT_download%
+	ECHO .
+	SET INSTALL=false
+)
+
+:: check if needed dir exist
+IF NOT EXIST %tmp_dir% (
+	ECHO Create Webmin temp dir
+	MD %tmp_dir%
+)
+IF NOT EXIST %inst_dir% (
+	ECHO Create Webmin Main dir
+	MD %inst_dir%
+)
+
+
+
+IF EXIST %INSTALL% (
+    :: install perl module win::deamon if not installed
+    IF NOT EXIST %perl_path%\site\lib\Win32\Daemon.pm (
+	ppm install Win32-Daemon
+    )
+    SET perl_path=%perl_path%\bin\perl.exe
+    perl %INSTALL% %wa_dir%
+) ELSE (
+	ECHO Webmin can not installed becasue of missing depedencies!
+)
+ECHO .
+PAUSE
+

--- a/setup.bat
+++ b/setup.bat
@@ -6,6 +6,7 @@ ECHO .
 :: prepare unautenticated Setup
 SET WEBMIN_download=https://sourceforge.net/projects/webadmin/
 SET WRT_download=https://www.microsoft.com/download/details.aspx?id=17657
+SET PROCESS_download=http://retired.beyondlogic.org/solutions/processutil/processutil.htm
 SET PERL_download=https://www.activestate.com/activeperl/
 SET perl_path32=C:\Perl
 SET perl_path64=C:\Perl64
@@ -17,8 +18,6 @@ SET var_dir=%inst_dir%\var
 SET port=10000
 SET admin=10000
 SET ssl=0
-::SET atboot=n
-::SET nostart=y
 SET login=admin
 SET password=admin
 SET INSTALL=setup.pl
@@ -51,6 +50,16 @@ IF EXIST %perl_path32% (
 	ECHO .
 	SET INSTALL=false
     )
+)
+
+:: check if process.exe is installed
+WHERE process >nul 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+	ECHO Required process.exe is not installed! Please download it from
+	ECHO %PROCESS_download% and xopy it to C:\Windows!
+	start "" %PROCESS_download%
+	ECHO .
+	SET INSTALL=false
 )
 
 :: check if rescource kit is installed

--- a/setup.pl
+++ b/setup.pl
@@ -104,7 +104,7 @@ if (-r "$config_directory/config") {
 # We can now load the main Webmin library
 $ENV{'WEBMIN_CONFIG'} = $config_directory;
 $ENV{'WEBMIN_VAR'} = "/var/webmin";	# not really used
-require "$src/web-lib-funcs.pl";
+require "$srcdir/web-lib-funcs.pl";
 
 # Check if upgrading from an old version
 if ($upgrading) {

--- a/setup.pl
+++ b/setup.pl
@@ -104,7 +104,7 @@ if (-r "$config_directory/config") {
 # We can now load the main Webmin library
 $ENV{'WEBMIN_CONFIG'} = $config_directory;
 $ENV{'WEBMIN_VAR'} = "/var/webmin";	# not really used
-require "$wadir/web-lib.pl";
+require "$src/web-lib-funcs.pl";
 
 # Check if upgrading from an old version
 if ($upgrading) {
@@ -758,7 +758,7 @@ if ($wadir ne $srcdir) {
 		}
 	else {
 		# Looks like Windows .. use xcopy command
-		system("xcopy \"$srcdir\" \"$wadir\" /Y /E /I");
+		system("xcopy \"$srcdir\" \"$wadir\" /Y /E /I /Q");
 		}
 	print "..done\n";
 	print "\n";


### PR DESCRIPTION


Installation instructions for Windows and Installer seems to be old and (possibly) no more working.
see https://sourceforge.net/p/webadmin/discussion/55378/thread/c86e083e/?limit=25

To understand what's needed to install Webmin on Windows I went to install it manually.
The result of this journey is a` setup.bat` script for windows  to guide the user and install  webmin  in one rush if all prerequsites are fulfilled.

what's in this PR:

- windows batch file `setup.bat` to make installation on windows easier
   checks installation of  `perl`, `process.exe`, `sc.exe` and run `setup.pl` with parameters needed for windows setup
- fix to `setup.pl` to include `web-lib-funcs.pl` from source dir because it will not exist in wadir before installation.   add parameter `/Q` to windows `xcopy` to not display thousands of copied files
- add `setup.bat` to `makedist.pl` to include it in new releases

whats' not in this PR:
- fix to run as Windows Service:
  I can run webmin manually from start script, but Webmin seems not be installed from`setup.pl `as a windows service

---
Prerequisites for Webmin on Windows:
(all of them will be checked from batch file)

- Download webmin source an unpack in a temporary location
https://sourceforge.net/projects/webadmin/
- Download and installl Perl
https://www.activestate.com/activeperl/
- Download Process.exe and place it in C:\Windows
http://retired.beyondlogic.org/solutions/processutil/processutil.htm
- Download and Install Windows Resource Kit (in case `sc.exe` is not on your system)
https://www.microsoft.com/download/details.aspx?id=17657

Webmin Installation:

- go to temporary webmin location and run `setup.bat` by a double click ...

Result:

- Webmin is installed in C:\webmin
   ![image](https://user-images.githubusercontent.com/4593242/38097448-b6a753ca-3375-11e8-996b-f76a4c540c6c.png)
