### PR TITLE
add macOS 10.13

### DIFF
--- a/os_list.txt
+++ b/os_list.txt
@@ -372,6 +372,7 @@ SCO OpenServer			5	openserver	5	$uname =~ /SCO_SV.*\s5\./i
 SCO OpenServer			6	openserver	6	$uname =~ /SCO_SV.*\s6\./i
 
 # Apple's OS X versions
+Mac OS X			10.13	macos		17.0	`sw_vers 2>/dev/null` =~ /ProductVersion:\s+10\.13/i
 Mac OS X			10.12	macos		16.0	`sw_vers 2>/dev/null` =~ /ProductVersion:\s+10\.12/i
 Mac OS X			10.11	macos		15.0	`sw_vers 2>/dev/null` =~ /ProductVersion:\s+10\.11/i
 Mac OS X			10.10	macos		14.0	`sw_vers 2>/dev/null` =~ /ProductVersion:\s+10\.10/i


### PR DESCRIPTION
For consistency I used "Mac OS X" as the existing entries do, however Apple has changed how they refer to their OS over time (i.e. "OS X" as of 10.7 and "macOS" as of 10.12). Can the new entry adopt such usage, and is it a bad idea if the existing entries change? [**Edit**: I now see where oschooser.pl generates a menu with one entry for each unique name, so any inconsistent entries would show up as another choice.]