### PR TITLE
Ubuntu 17 and 18 detection

### DIFF
--- a/os_list.txt
+++ b/os_list.txt
@@ -107,6 +107,8 @@ Ubuntu Linux			$1	debian-linux	8.0	$os_release =~ /Ubuntu\s+(13\.[0-9\.]+)/ || $
 Ubuntu Linux			$1	debian-linux	8.0	$os_release =~ /Ubuntu\s+(14\.[0-9\.]+)/ || $etc_issue =~ /Ubuntu.*\s(14\.[0-9\.]+)\s/i || $etc_issue =~ /Ubuntu\s+trusty/i
 Ubuntu Linux			$1	debian-linux	8.0	$os_release =~ /Ubuntu\s+(15\.[0-9\.]+)/ || $etc_issue =~ /Ubuntu.*\s(15\.[0-9\.]+)\s/i || $etc_issue =~ /Ubuntu\s+vidid/i
 Ubuntu Linux			$1	debian-linux	9.0	$os_release =~ /Ubuntu\s+(16\.[0-9\.]+)/ || $etc_issue =~ /Ubuntu.*\s(16\.[0-9\.]+)\s/i || $etc_issue =~ /Ubuntu\s+vidid/i
+Ubuntu Linux			$1	debian-linux	9.0	$os_release =~ /Ubuntu\s+(17\.[0-9\.]+)/ || $etc_issue =~ /Ubuntu.*\s(17\.[0-9\.]+)\s/i || $etc_issue =~ /Ubuntu\s+vidid/i
+Ubuntu Linux			$1	debian-linux	9.0	$os_release =~ /Ubuntu\s+(18\.[0-9\.]+)/ || $etc_issue =~ /Ubuntu.*\s(18\.[0-9\.]+)\s/i || $etc_issue =~ /Ubuntu\s+vidid/i
 Ubuntu Linux			$1	debian-linux	3.1	$etc_issue =~ /Ubuntu.*\s([0-9\.]+)\s/i
 Mepis Linux			$1	debian-linux	$1	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /([0-9\.]+)/
 Mepis Linux			$1	debian-linux	4.0	$etc_issue =~ /MEPIS/ && `cat /etc/debian_version 2>/dev/null` =~ /(stable)/


### PR DESCRIPTION
I think this allows Webmin to detect Ubuntu 17 and 18 correctly.

And, can we get a new devel release soon-ish, so I can roll out Ubuntu 18.04 support in Virtualmin installer? I think this is the last bit (but I may find other issues after more testing).