### PR TITLE
Fix device name of mmc on Edit Partition.

### DIFF
--- a/fdisk/edit_part.cgi
+++ b/fdisk/edit_part.cgi
@@ -106,7 +106,9 @@ print &ui_table_row($text{'edit_location'},
 		$dinfo->{'device'});
 
 # Device name
-$dev = $dinfo->{'prefix'}.$np;
+$dev = $dinfo->{'prefix'} =~ /^\/dev\/mmcblk.*/ ?
+	$dinfo->{'prefix'}.'p'.$np :
+	$dinfo->{'prefix'}.$np;
 print &ui_table_row($text{'edit_device'}, $dev);
 
 # Partition type


### PR DESCRIPTION
The name of mmc device should be such as mmcblk0p1 but now mmcblk01.
If device name is incorrect the filesystem create will be failed.
