### PR TITLE
Always define STATUS_* variables in status monitoring messages

### DIFF
--- a/status/monitor.pl
+++ b/status/monitor.pl
@@ -518,7 +518,7 @@ if ($tmpl && $tmpl->{$type}) {
 		}
 	if ($stat) {
 		foreach my $k ('value', 'nice_value', 'desc') {
-			$hash{'STATUS_'.uc($k)} = $stat->{$k} if ($stat->{$k});
+			$hash{'STATUS_'.uc($k)} = $stat->{$k} ? $stat->{$k} : "";
 			}
 		}
 	foreach my $k (keys %$serv) {


### PR DESCRIPTION
The corresponding IF- variables also wouldn't be defined either so there was no way to avoid literal STATUS_* output for monitors which didn't provide useful values for these variables.