### PR TITLE
Call it certbot rather than native client

### DIFF
--- a/webmin/lang/en
+++ b/webmin/lang/en
@@ -1146,7 +1146,7 @@ letsencrypt_echain=Failed to download chained certificate : $1
 letsencrypt_echain2=Chained certificate downloaded from $1 is empty
 letsencrypt_ecsr=Failed to generate CSR : $1
 letsencrypt_ekeygen=Failed to generate private key : $1
-letsencrypt_enative=The native Let's Encrypt client was used previously on this system, and must be used for all future certificate requests
+letsencrypt_enative=The native Let's Encrypt client (certbot) was used previously on this system, and must be used for all future certificate requests
 
 announce_hide=Hide This Announcement
 

--- a/webmin/letsencrypt-lib.pl
+++ b/webmin/letsencrypt-lib.pl
@@ -113,7 +113,7 @@ elsif ($mode eq "dns") {
 	# Make sure all the DNS zones exist
 	if ($wildcard && !$letsencrypt_cmd) {
 		return (0, "Wildcard hostname $wildcard can only be ".
-			   "validated when the native Let's Encrypt client ".
+			   "validated when the certbot Let's Encrypt client ".
 			   "is installed");
 		}
 	&foreign_require("bind8");


### PR DESCRIPTION
Saying "native client" can be confusing, so let's call it the same thing the package and command is called so folks will know what they need to install for wildcards.