### PR TITLE
Run stat() for files that are bundled with module

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -2608,7 +2608,7 @@ else {
 	print DEBUG "handle_request: outputting file $full\n";
 	$gzfile = $full.".gz";
 	$gzipped = 0;
-	if ($config{'gzip'} ne '0' && -r $gzfile && $acceptenc{'gzip'}) {
+	if (!length($config{'gzip'}) && -r $gzfile && $acceptenc{'gzip'}) {
 		# Using gzipped version
 		@stopen = stat($gzfile);
 		if ($stopen[9] >= $stfull[9] && open(FILE, $gzfile)) {


### PR DESCRIPTION
This will increase the initial load by 2x times (when gzip third option is enabled and bundled version of the file is included)

Test case. 

Git version of the theme, where some files have their .gz variants, like `bundle.min.js.gz`, `bundle.min.css.gz` and some other.
Buffer size 1024.

Web Server Options and load time before/after the patch.

1. Only if pre-compressed .gz file exists - Load time: 1.46s/1.46s (same)
2. Never - Load time: 4.2s/4.2s (same)
3. Use pre-compressed file and compress dynamically - Load time: 1.40s/700ms (**big difference**)

When .gz files already exist on the theme/module side, miniserv tries to stat them first when 3 option is enabled, and that takes quite a lot of the time. It's much faster, just to gzip them instead.