### PR TITLE
Add RBAC and Two-Factor to module acl

### DIFF
--- a/acl/acl_security.pl
+++ b/acl/acl_security.pl
@@ -81,5 +81,5 @@ sub list_acl_yesno_fields
 {
 return ('create', 'delete', 'rename', 'acl', 'cert', 'others', 'chcert',
 	'lang', 'cats', 'theme', 'ips', 'perms', 'sync', 'unix', 'sessions',
-	'switch', 'times', 'pass', 'sql');
+	'switch', 'times', 'pass', 'sql', 'rbacenable', 'twofactor');
 }

--- a/acl/defaultacl
+++ b/acl/defaultacl
@@ -25,3 +25,4 @@ minsize=1
 nochange=1
 pass=1
 sql=1
+twofactor=1

--- a/acl/index.cgi
+++ b/acl/index.cgi
@@ -196,9 +196,11 @@ if (uc($ENV{'HTTPS'}) eq "ON" && $miniserv{'ca'}) {
 	push(@links, "cert_form.cgi");
 	push(@titles, $text{'index_cert'});
 	}
-push(@icons, "images/twofactor.gif");
-push(@links, "twofactor_form.cgi");
-push(@titles, $text{'index_twofactor'});
+if ($access{'twofactor'}) {
+	push(@icons, "images/twofactor.gif");
+	push(@links, "twofactor_form.cgi");
+	push(@titles, $text{'index_twofactor'});
+	}
 if ($access{'rbacenable'}) {
 	push(@icons, "images/rbac.gif");
 	push(@links, "edit_rbac.cgi");

--- a/acl/lang/en
+++ b/acl/lang/en
@@ -216,6 +216,8 @@ acl_switch=Can switch to other users?
 acl_times=Can change allowed login times?
 acl_pass=Can change password restrictions?
 acl_sql=Can configure user and group database?
+acl_rbacenable=Can setup RBAC?
+acl_twofactor=Can configure Two-Factor Authentication?
 
 log_modify=Modified Webmin user $1
 log_rename=Renamed Webmin user $1 to $2


### PR DESCRIPTION
- make RBAC and Two-Factor auth configurable options of Webmin User module (acl)
- add English text for the new options

Since I wanted to create users with minimal permissions on user management, I missed the option to hide the "Setup RBAC" and "Two-Factor Authentication" Functions in the Webmin User Module.
"rbacenable" was already partial implemented but twofactor auth was not. And both options where missing in the UI.