### PR TITLE
squid module: support for -n option for ACL

### DIFF
--- a/squid/edit_acl.cgi
+++ b/squid/edit_acl.cgi
@@ -36,7 +36,7 @@ if (@acl) {
 		push(@cols, &ui_link("acl.cgi?index=$a->{'index'}",
 				     &html_escape($v[0])));
 		push(@cols, $acl_types{$v[1]});
-		if ($v[2] =~ /^"(.*)"$/ || $v[3] =~ /^"(.*)"$/) {
+		if ($v[2] =~ /^"(.*)"$/ || $v[3] =~ /^"(.*)"$/ || $v[4] =~ /^"(.*)"$/) {
 			push(@cols, &text('eacl_file', "<tt>$1</tt>"));
 			}
 		else {

--- a/squid/lang/en
+++ b/squid/lang/en
@@ -87,6 +87,7 @@ acl_eusers=External Auth Users
 acl_eusersall=All users
 acl_euserssel=Only those listed..
 acl_case=Ignore case?
+acl_nodns=Disable lookups?
 acl_eusersre=External Auth User Regexps
 acl_asnum=AS Numbers
 acl_rtime=Refresh Time

--- a/squid/squid-lib.pl
+++ b/squid/squid-lib.pl
@@ -14,6 +14,7 @@ our $auth_program = "$module_config_directory/squid-auth.pl";
 our $auth_database = "$module_config_directory/users";
 our @caseless_acl_types = ( "url_regex", "urlpath_regex", "proxy_auth_regex",
 			    "srcdom_regex", "dstdom_regex", "ident_regex" );
+our @nodns_acl_types = ( "dst", "dstdomain", "dstdom_regex" );
 
 # Get the squid version
 our $squid_version = &read_file_contents("$module_config_directory/version") || 0;
@@ -625,7 +626,7 @@ push(@rv, $file) if ($file);
 # Add files from ACLs
 my @acl = &find_config("acl", $conf);
 foreach my $a (@acl) {
-	if ($a->{'values'}->[2] =~ /^"(.*)"$/ || $a->{'values'}->[3] =~ /^"(.*)"$/) {
+	if ($a->{'values'}->[2] =~ /^"(.*)"$/ || $a->{'values'}->[3] =~ /^"(.*)"$/ || $a->{'values'}->[4] =~ /^"(.*)"$/) {
 		push(@rv, $1);
 		}
 	}


### PR DESCRIPTION
This PR adds support for -n option for Squid ACLs that support it. (dst, dstdomain, dstdom_regex).

ACL parsing code is currently very vague when it comes to ACL options. So I have tried to handle ACL options in a little better way. (by replacing vals variable with aclopts variable). It no more assumes that "-i" option will always be first (index 0) option.

However the new code does not change main logic which parses the ACL options. Parsing is still inefficient and may need changing in future when more squid ACL options are introduced.

Please check. Thank you.