### PR TITLE
Freeze and thaw zone when re-signing.

### DIFF
--- a/bind8/resign.pl
+++ b/bind8/resign.pl
@@ -67,7 +67,9 @@ foreach my $z (@zones) {
 	print STDERR "  Age in days $old\n" if ($debug);
 	if ($old > $period) {
 		# Too old .. signing
+		before_editing($z);
 		my $err = &resign_dnssec_key($z);
+		after_editing($z);
 		if ($err) {
 			print STDERR "  Re-signing of $z->{'name'} failed : $err\n";
 			$errcount++;


### PR DESCRIPTION
When re-signing a zone that has a journal, it *must* be frozen first and thawed afterwards.  The comment in the library (bind8-lib.pl) states "before_editing(&zone) -Must be called before reading a zone file with intent to edit".