### PR TITLE
Correct yum check-update multiline output

### DIFF
--- a/software/yum-lib.pl
+++ b/software/yum-lib.pl
@@ -306,7 +306,8 @@ sub update_system_updates
 {
 local @rv;
 local %done;
-&open_execute_command(PKG, "$yum_command check-update 2>/dev/null", 1, 1);
+&open_execute_command(PKG, "$yum_command check-update 2>/dev/null | tr '\n' '#' | sed -e 's/# / /g' | tr '#' '\n'", 1, 1);
+
 while(<PKG>) {
         s/\r|\n//g;
 	if (/^(\S+)\.([^\.]+)\s+(\S+)\s+(\S+)/) {


### PR DESCRIPTION
For long package names yum check-update produce multi-line output.
This leads to incorrect display of packages and not being able to select for update.
This patch provide a way to combine the multi-line output into single line for each package.