### PR TITLE
Search date sort

### DIFF
--- a/webminlog/search.cgi
+++ b/webminlog/search.cgi
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/libexec/webmin/perl-wrapper -X
 # search.cgi
 # Find webmin actions
 
@@ -72,6 +72,9 @@ my %index;
 &build_log_index(\%index);
 open(LOG, $webmin_logfile);
 while(my ($id, $idx) = each %index) {
+	if ($id =~ /^last/) {
+	    next;
+	}
 	my ($pos, $time, $user, $module, $sid) = split(/\s+/, $idx);
 	$time ||= 0;
 	$module ||= "";
@@ -169,7 +172,7 @@ if ($in{'csv'}) {
 		if ($config{'host_search'}) {
 			push(@cols, $act->{'webmin'});
 			}
-		push(@cols, &make_date($act->{'time'}));
+		push(@cols, &make_date($act->{'time'},0 , "yyyy-mm-dd"));
 		print join(",", map { "\"$_\"" } @cols),"\n";
 		}
 	}
@@ -225,7 +228,7 @@ elsif (@match) {
 		if ($config{'host_search'}) {
 			push(@cols, $act->{'webmin'});
 			}
-		push(@cols, split(/\s+/, &make_date($act->{'time'})));
+		push(@cols, split(/\s+/, &make_date($act->{'time'}, 0, "yyyy/mm/dd")));
 		print &ui_columns_row(\@cols);
 		}
 	print &ui_columns_end();

--- a/webminlog/search.cgi
+++ b/webminlog/search.cgi
@@ -1,4 +1,4 @@
-#!/usr/libexec/webmin/perl-wrapper -X
+#!/usr/local/bin/perl
 # search.cgi
 # Find webmin actions
 


### PR DESCRIPTION
The date in log search and csv export are in standard webmin format.
This means they are not alphabetically sorted, which makes parsing and copying of specific part hard to identify.
This patch modifies the date output (only the output, not the log itself) to be alphabetically (ASCII) sorted.
Additionally it filter the "last" record, which is sometimes inserted.