### PR TITLE
Create home directory in filemin if not exist

### DIFF
--- a/filemin/filemin-lib.pl
+++ b/filemin/filemin-lib.pl
@@ -46,10 +46,21 @@ sub get_paths {
         @remote_user_info = getpwnam($access{'work_as_user'});
         @remote_user_info ||
             &error("Unix user $access{'work_as_user'} does not exist!");
+        if(!-e $remote_user_info[7]) {
+            mkdir($remote_user_info[7]) or &error("$text{'error_creating_conf'}: $!");
+            chmod(0700, $remote_user_info[7]);
+            chown($remote_user_info[2], $remote_user_info[3], $remote_user_info[7]);
+        }
         &switch_to_unix_user(\@remote_user_info);
     }
     else {
         # The Webmin user we are connected as
+        @remote_user_info = getpwnam($remote_user);
+        if(!-e $remote_user_info[7]) {
+            mkdir($remote_user_info[7]) or &error("$text{'error_creating_conf'}: $!");
+            chmod(0700, $remote_user_info[7]);
+            chown($remote_user_info[2], $remote_user_info[3], $remote_user_info[7]);
+        }
         &switch_to_remote_user();
     }
 


### PR DESCRIPTION
Filemin stores the user configuration in the home directory of the user itself. But it creates the config directory after switching to the desired user account.

If PAM is configured with makehomedir plugin, home directories may not exist until the user first login and cannot be created by the switched Webmin user.
On use of filemin as replacement for interactive login, this is not possible before creating home directory by root or PAM module with suid rights.. When using Webmin on multiple servers in a LDAP domain, this cannot be handled.

This patch creates the home directory of the user to switch to before switching to the user in case not existing and apply access right defaults for home directories.
Afterwards handling of filemin config files can process as before.