### PR TITLE
Update init-lib.pl

### DIFF
--- a/init/init-lib.pl
+++ b/init/init-lib.pl
@@ -2279,7 +2279,8 @@ my $cfile = &get_systemd_root($name)."/".$name;
 &print_tempfile(CFILE, "Type=forking\n") if ($forks);
 &print_tempfile(CFILE, "Type=oneshot\n",
 		       "RemainAfterExit=yes\n") if ($exits);
-&print_tempfile(CFILE, "PIDFile=$pidfile\n") if ($pidfile);
+####&print_tempfile(CFILE, "PIDFile=$pidfile\n") if ($pidfile);
+&print_tempfile(CFILE, "ExecStartPost=/bin/sh -c 'umask 022; pgrep miniserv > /var/webmin/webmin.pid'") if ($pidfile);Updfs
 &print_tempfile(CFILE, "\n");
 &print_tempfile(CFILE, "[Install]\n");
 &print_tempfile(CFILE, "WantedBy=multi-user.target\n");


### PR DESCRIPTION
explained here:  https://serverfault.com/questions/817552/systemd-drop-in-fails-to-create-pid-file

```Regrettably, systemd won't create a PID file for a non-forking service even if you specify a PIDFile= line in the service's unit file. But you may be able to cheat with an ExecStartPost= line, such as:```

the second (last) solution appears to work.