### PR TITLE
Some Cross-Site-Scripting (XSS) fixes

### DIFF
--- a/net/cygwin-lib.pl
+++ b/net/cygwin-lib.pl
@@ -422,7 +422,7 @@ sub parse_routing
 		    if ($gateway != $_->{'gateway'} ||
 			$gwmetric != $_->{'gwmetric'}) {
 			&check_ipaddress($gateway) ||
-			    &error(&text('routes_egateway', $gateway));
+			    &error(&text('routes_egateway', &html_escape($gateway)));
 			my $cmd = "netsh interface ip set address name = \"" .
 			    $_->{'name'} . "\" gateway = $gateway " .
 				"gwmetric = $gwmetric";

--- a/net/debian-linux-lib.pl
+++ b/net/debian-linux-lib.pl
@@ -689,7 +689,7 @@ sub parse_routing
 local ($dev, $gw);
 if (!$in{'gateway_def'}) {
 	&check_ipaddress($in{'gateway'}) ||
-		&error(&text('routes_egateway', $in{'gateway'}));
+		&error(&text('routes_egateway', &html_escape($in{'gateway'})));
 	$gw = $in{'gateway'};
 	$dev = $in{'gatewaydev'};
 	}
@@ -702,7 +702,7 @@ if (@ifaces6) {
 	local ($dev6, $gw6);
 	if (!$in{'gateway6_def'}) {
 		&check_ip6address($in{'gateway6'}) ||
-			&error(&text('routes_egateway6', $in{'gateway6'}));
+			&error(&text('routes_egateway6', &html_escape($in{'gateway6'})));
 		$gw6 = $in{'gateway6'};
 		$dev6 = $in{'gatewaydev6'};
 		}
@@ -718,11 +718,11 @@ for($i=0; defined($dev = $in{"dev_$i"}); $i++) {
 	local $net = $in{"net_$i"};
 	local $netmask = $in{"netmask_$i"};
 	local $gw = $in{"gw_$i"};
-	$dev =~ /^\S+$/ || &error(&text('routes_edevice', $dev));
-	&to_ipaddress($net) || &error(&text('routes_enet', $net));
+	$dev =~ /^\S+$/ || &error(&text('routes_edevice', &html_escape($dev)));
+	&to_ipaddress($net) || &error(&text('routes_enet', &html_escape($net)));
 	&check_ipaddress_any($netmask) ||
-		&error(&text('routes_emask', $netmask));
-	&to_ipaddress($gw) || &error(&text('routes_egateway', $gw));
+		&error(&text('routes_emask', &html_escape($netmask)));
+	&to_ipaddress($gw) || &error(&text('routes_egateway', &html_escape($gw)));
 	local $prefix = &mask_to_prefix($netmask);
 	push(@{$st{$dev}}, [ "up", "ip route add $net/$prefix via $gw" ]);
 	}
@@ -731,12 +731,12 @@ for($i=0; defined($dev = $in{"ldev_$i"}); $i++) {
 	local $net = $in{"lnet_$i"};
 	local $netmask = $in{"lnetmask_$i"};
 	next if (!$dev && !$net);
-	$dev =~ /^\S+$/ || &error(&text('routes_edevice', $dev));
+	$dev =~ /^\S+$/ || &error(&text('routes_edevice', &html_escape($dev)));
 	&to_ipaddress($net) ||
 	    $net =~ /^(\S+)\/(\d+)$/ && &to_ipaddress("$1") ||
-		&error(&text('routes_enet', $net));
+		&error(&text('routes_enet', &html_escape($net)));
 	&check_ipaddress_any($netmask) ||
-		&error(&text('routes_emask', $netmask));
+		&error(&text('routes_emask', &html_escape($netmask)));
 	local $prefix = &mask_to_prefix($netmask);
 	push(@{$hr{$dev}}, [ "up", "ip route add $net/$prefix dev $dev" ]);
 	}
@@ -841,7 +841,7 @@ while (defined $line) {
 		push(@ret, [$name, $addrfam, $method, \@iface_options]);
 		}
 	else {
-		error("Error reading file $pathname: unexpected line '$line'");
+		error("Error reading file $network_interfaces_config: unexpected line '$line'");
 		}
 	}
 close(CFGFILE);

--- a/net/freebsd-lib.pl
+++ b/net/freebsd-lib.pl
@@ -614,11 +614,11 @@ sub parse_routing
 {
 &lock_file("/etc/rc.conf");
 $in{'defr_def'} || &check_ipaddress($in{'defr'}) ||
-	&error(&text('routes_edefault', $in{'defr'}));
+	&error(&text('routes_edefault', &html_escape($in{'defr'})));
 &save_rc_conf('defaultrouter', $in{'defr_def'} ? 'NO' : $in{'defr'});
 if (&supports_address6()) {
 	$in{'defr6_def'} || &check_ip6address($in{'defr6'}) ||
-		&error(&text('routes_edefault6', $in{'defr6'}));
+		&error(&text('routes_edefault6', &html_escape($in{'defr6'})));
 	&save_rc_conf('ipv6_defaultrouter',
 		      $in{'defr6_def'} ? 'NO' : $in{'defr6'});
 	}

--- a/net/gentoo-linux-lib.pl
+++ b/net/gentoo-linux-lib.pl
@@ -303,7 +303,7 @@ if ($in{'route_def'}) {
 	}
 else {
 	&check_ipaddress($in{'gw'}) ||
-		&error(&text('routes_edefault', $in{'gw'}));
+		&error(&text('routes_edefault', &html_escape($in{'gw'})));
 	&set_default_gateway($in{'gw'}, $in{'dev'});
 	}
 }

--- a/net/macos-lib.pl
+++ b/net/macos-lib.pl
@@ -422,7 +422,7 @@ elsif ($in{'router_mode'} == 1) {
 	}
 else {
 	$r = $in{'router'};
-	&check_ipaddress($r) || &error(&text('routes_edefault', $r));
+	&check_ipaddress($r) || &error(&text('routes_edefault', &html_escape($r)));
 	}
 &lock_file($hostconfig_file);
 &set_hostconfig("ROUTER", $r);

--- a/net/netplan-lib.pl
+++ b/net/netplan-lib.pl
@@ -444,7 +444,7 @@ sub parse_routing
 my ($dev, $gw);
 if (!$in{'gateway_def'}) {
 	&check_ipaddress($in{'gateway'}) ||
-		&error(&text('routes_egateway', $in{'gateway'}));
+		&error(&text('routes_egateway', &html_escape($in{'gateway'})));
 	$gw = $in{'gateway'};
 	$dev = $in{'gatewaydev'};
 	}
@@ -454,7 +454,7 @@ if (!$in{'gateway_def'}) {
 my ($dev6, $gw6);
 if (!$in{'gateway6_def'}) {
 	&check_ip6address($in{'gateway6'}) ||
-		&error(&text('routes_egateway6', $in{'gateway6'}));
+		&error(&text('routes_egateway6', &html_escape($in{'gateway6'})));
 	$gw6 = $in{'gateway6'};
 	$dev6 = $in{'gatewaydev6'};
 	}

--- a/net/open-linux-lib.pl
+++ b/net/open-linux-lib.pl
@@ -195,9 +195,9 @@ local %ifcs = map { $_->{'fullname'}, 1 } &all_interfaces();
 
 if (!$in{'gateway_def'}) {
 	&to_ipaddress($in{'gateway'}) ||
-		&error(&text('routes_edefault', $in{'gateway'}));
+		&error(&text('routes_edefault', &html_escape($in{'gateway'})));
 	$ifcs{$in{'gatewaydev'}} ||
-		&error(&text('routes_edevice', $in{'gatewaydev'}));
+		&error(&text('routes_edevice', &html_escape($in{'gatewaydev'})));
 	}
 
 &set_default_gateway($in{'gateway_def'} ? ( ) :

--- a/net/openbsd-lib.pl
+++ b/net/openbsd-lib.pl
@@ -477,7 +477,7 @@ print &ui_table_row($text{'routes_routed'},
 sub parse_routing
   {
       $in{'defr_def'} || &check_ipaddress($in{'defr'}) ||
-	&error(&text('routes_edefault', $in{'defr'}));
+	&error(&text('routes_edefault', &html_escape($in{'defr'})));
 
       &read_routing;
 

--- a/net/redhat-linux-lib.pl
+++ b/net/redhat-linux-lib.pl
@@ -703,13 +703,13 @@ if (!$supports_dev_gateway) {
 	# Just update a single file
 	if ($in{'gateway_def'}) { delete($conf{'GATEWAY'}); }
 	elsif (!&to_ipaddress($in{'gateway'})) {
-		&error(&text('routes_edefault', $in{'gateway'}));
+		&error(&text('routes_edefault', &html_escape($in{'gateway'})));
 		}
 	else { $conf{'GATEWAY'} = $in{'gateway'}; }
 
 	if ($in{'gatewaydev_def'}) { delete($conf{'GATEWAYDEV'}); }
 	elsif ($in{'gatewaydev'} !~ /^\S+$/) {
-		&error(&text('routes_edevice', $in{'gatewaydev'}));
+		&error(&text('routes_edevice', &html_escape($in{'gatewaydev'})));
 		}
 	else { $conf{'GATEWAYDEV'} = $in{'gatewaydev'}; }
 	}
@@ -742,7 +742,7 @@ else {
 			local ($b) = grep { $_->{'fullname'} eq
 					    $in{"gatewaydev$r"} } @boot;
 			$b->{'gateway'} && &error(&text('routes_eclash2',
-							$in{"gatewaydev$r"}));
+							&html_escape($in{"gatewaydev$r"})));
 			$b->{'gateway'} = $in{"gateway$r"};
 			$b->{'gateway6'} = $in{"gateway6$r"};
 			}
@@ -763,10 +763,10 @@ else {
 for($i=0; defined($dev = $in{"dev_$i"}); $i++) {
 	next if (!$dev);
 	$net = $in{"net_$i"}; $netmask = $in{"netmask_$i"}; $gw = $in{"gw_$i"};
-	$dev =~ /^\S+$/ || &error(&text('routes_edevice', $dev));
-	&to_ipaddress($net) || &error(&text('routes_enet', $net));
-	&check_ipaddress($netmask) || &error(&text('routes_emask', $netmask));
-	&to_ipaddress($gw) || &error(&text('routes_egateway', $gw));
+	$dev =~ /^\S+$/ || &error(&text('routes_edevice', &html_escape($dev)));
+	&to_ipaddress($net) || &error(&text('routes_enet', &html_escape($net)));
+	&check_ipaddress($netmask) || &error(&text('routes_emask', &html_escape($netmask)));
+	&to_ipaddress($gw) || &error(&text('routes_egateway', &html_escape($gw)));
 	if ($netmask eq "255.255.255.255") {
 		push(@st, "$dev host $net gw $gw\n");
 		}
@@ -778,11 +778,11 @@ for($i=0; defined($dev = $in{"dev_$i"}); $i++) {
 for($i=0; defined($dev = $in{"ldev_$i"}); $i++) {
 	$net = $in{"lnet_$i"}; $netmask = $in{"lnetmask_$i"};
 	next if (!$dev && !$net);
-	$dev =~ /^\S+$/ || &error(&text('routes_edevice', $dev));
+	$dev =~ /^\S+$/ || &error(&text('routes_edevice', &html_escape($dev)));
 	&to_ipaddress($net) ||
 	    $net =~ /^(\S+)\/(\d+)$/ && &to_ipaddress("$1") ||
-		&error(&text('routes_enet', $net));
-	&check_ipaddress($netmask) || &error(&text('routes_emask', $netmask));
+		&error(&text('routes_enet', &html_escape($net)));
+	&check_ipaddress($netmask) || &error(&text('routes_emask', &html_escape($netmask)));
 	if ($netmask eq "255.255.255.255") {
 		push(@st, "$dev host $net\n");
 		}

--- a/net/save_aifc.cgi
+++ b/net/save_aifc.cgi
@@ -31,12 +31,12 @@ else {
 		$in{'virtual'} =~ /^\d+$/ ||
 			&error($text{'aifc_evirt'});
 		$in{'virtual'} >= $min_virtual_number ||
-			&error(&text('aifc_evirtmin', $min_virtual_number));
+			&error(&text('aifc_evirtmin', &html_escape($min_virtual_number)));
 		foreach $ea (@acts) {
 			if ($ea->{'name'} eq $in{'name'} &&
 			    $ea->{'virtual'} eq $in{'virtual'}) {
 				&error(&text('aifc_evirtdup',
-				       "$in{'name'}:$in{'virtual'}"));
+				       &html_escape("$in{'name'}:$in{'virtual'}")));
 				}
 			}
 		$a->{'name'} = $in{'name'};
@@ -50,11 +50,11 @@ else {
 		foreach $ea (@acts) {
 			if ($ea->{'name'} eq $1 &&
 			    $ea->{'virtual'} eq $3) {
-				&error(&text('aifc_evirtdup', $in{'name'}));
+				&error(&text('aifc_evirtdup', &html_escape($in{'name'})));
 				}
 			}
 		$3 >= $min_virtual_number ||
-			&error(&text('aifc_evirtmin', $min_virtual_number));
+			&error(&text('aifc_evirtmin', &html_escape($min_virtual_number)));
 		$a->{'name'} = $1;
 		$a->{'virtual'} = $3;
 		$a->{'fullname'} = $a->{'name'}.":".$a->{'virtual'};
@@ -65,7 +65,7 @@ else {
 		# creating a real interface
 		foreach $ea (@acts) {
 			if ($ea->{'name'} eq $in{'name'}) {
-				&error(&text('aifc_edup', $in{'name'}));
+				&error(&text('aifc_edup', &html_escape($in{'name'})));
 				}
 			}
 		$a->{'name'} = $in{'name'};
@@ -79,7 +79,7 @@ else {
 
 	# Validate and store inputs
 	&check_ipaddress_any($in{'address'}) ||
-		&error(&text('aifc_eip', $in{'address'}));
+		&error(&text('aifc_eip', &html_escape($in{'address'})));
 	$a->{'address'} = $in{'address'};
 
 	# Check for address clash
@@ -88,7 +88,7 @@ else {
 	if (!$allow_clash &&
 	    ($in{'new'} || $olda->{'address'} ne $a->{'address'})) {
 		($clash) = grep { $_->{'address'} eq $a->{'address'} } @acts;
-		$clash && &error(&text('aifc_eclash', $clash->{'fullname'}));
+		$clash && &error(&text('aifc_eclash', &html_escape($clash->{'fullname'})));
 		}
 
 	if ($virtual_netmask && $a->{'virtual'} ne "") {
@@ -103,7 +103,7 @@ else {
 		}
 	elsif (!$in{'netmask_def'}) {
 		&check_netmask($in{'netmask'},$a->{'address'}) ||
-			&error(&text('aifc_emask', $in{'netmask'}));
+			&error(&text('aifc_emask', &html_escape($in{'netmask'})));
 		$a->{'netmask'} = $in{'netmask'};
 		}
 
@@ -115,7 +115,7 @@ else {
 		}
 	elsif (!$in{'broadcast_def'}) {
 		&check_ipaddress_any($in{'broadcast'}) ||
-			&error(&text('aifc_ebroad', $in{'broadcast'}));
+			&error(&text('aifc_ebroad', &html_escape($in{'broadcast'})));
 		$a->{'broadcast'} = $in{'broadcast'};
 		}
 
@@ -126,7 +126,7 @@ else {
 		}
 	elsif (!$in{'mtu_def'}) {
 		$in{'mtu'} =~ /^\d+$/ ||
-			&error(&text('aifc_emtu', $in{'mtu'}));
+			&error(&text('aifc_emtu', &html_escape($in{'mtu'})));
 		$a->{'mtu'} = $in{'mtu'} if ($olda->{'mtu'} ne $in{'mtu'});
 		}
 
@@ -156,7 +156,7 @@ else {
 			&check_ip6address($in{'address6_'.$i}) ||
 				&error(&text('aifc_eaddress6', $i+1));
 			$c = $clash6{$in{'address6_'.$i}};
-			$c && &error(&text('aifc_eclash6', $i+1, $c->{'name'}));
+			$c && &error(&text('aifc_eclash6', $i+1, &html_escape($c->{'name'})));
 			push(@address6, $in{'address6_'.$i});
 			$in{'netmask6_'.$i} =~ /^\d+$/ &&
 			    $in{'netmask6_'.$i} > 0 &&
@@ -178,7 +178,7 @@ else {
 	if (!$in{'ether_def'} && $a->{'virtual'} eq "" &&
 	    &iface_hardware($a->{'name'})) {
 		$in{'ether'} =~ /^[A-Fa-f0-9:]+$/ ||
-			&error(&text('aifc_ehard', $in{'ether'}));
+			&error(&text('aifc_ehard', &html_escape($in{'ether'})));
 		$a->{'ether'} = $in{'ether'}
 			if ($olda->{'ether'} ne $in{'ether'});
 		}

--- a/net/save_bifc.cgi
+++ b/net/save_bifc.cgi
@@ -45,12 +45,12 @@ else {
 		$in{'virtual'} =~ /^\d+$/ ||
 			&error($text{'bifc_evirt'});
 		$in{'virtual'} >= $min_virtual_number ||
-			&error(&text('aifc_evirtmin', $min_virtual_number));
+			&error(&text('aifc_evirtmin', &html_escape($min_virtual_number)));
 		foreach $eb (@boot) {
 			if ($eb->{'name'} eq $in{'name'} &&
 			    $eb->{'virtual'} eq $in{'virtual'}) {
 				&error(&text('bifc_evirtdup',
-				       "$in{'name'}:$in{'virtual'}"));
+				       &html_escape("$in{'name'}:$in{'virtual'}")));
 				}
 			}
 		$b->{'name'} = $in{'name'};
@@ -65,11 +65,11 @@ else {
 		foreach $eb (@boot) {
 			if ($eb->{'name'} eq $2 &&
 			    $eb->{'virtual'} eq $4) {
-				&error(&text('bifc_evirtdup', $in{'name'}));
+				&error(&text('bifc_evirtdup', &html_escape($in{'name'})));
 				}
 			}
 		$4 >= $min_virtual_number ||
-			&error(&text('aifc_evirtmin', $min_virtual_number));
+			&error(&text('aifc_evirtmin', &html_escape($min_virtual_number)));
 		$b->{'name'} = $1;
 		$b->{'virtual'} = $4;
 		$b->{'fullname'} = $b->{'name'}.":".$b->{'virtual'};
@@ -109,7 +109,7 @@ else {
 		# Check for clash
 		foreach $eb (@boot) {
 			if ($eb->{'fullname'} eq $b->{'fullname'}) {
-				&error(&text('bifc_edup', $in{'name'}));
+				&error(&text('bifc_edup', &html_escape($in{'name'})));
 				}
 			}
 		}
@@ -121,7 +121,7 @@ else {
 	    ($in{'new'} || $oldb->{'address'} ne $in{'address'})) {
 		($clash) = grep { $_->{'address'} eq $in{'address'} &&
 				  $_->{'up'} } @boot;
-		$clash && &error(&text('aifc_eclash', $clash->{'fullname'}));
+		$clash && &error(&text('aifc_eclash', &html_escape($clash->{'fullname'})));
 		}
 
 	# Validate and store inputs
@@ -139,7 +139,7 @@ else {
 		}
 	else {
 		&valid_boot_address($in{'address'}) ||
-			&error(&text('bifc_eip', $in{'address'}));
+			&error(&text('bifc_eip', &html_escape($in{'address'})));
 		$b->{'address'} = $in{'address'};
 		}
 
@@ -169,7 +169,7 @@ else {
 	elsif (&can_edit("netmask", $b) && $access{'netmask'}) {
 		$auto && !$in{'netmask'} ||
 		    &check_netmask($in{'netmask'}, $in{'address'}) ||
-			&error(&text('bifc_emask', $in{'netmask'}));
+			&error(&text('bifc_emask', &html_escape($in{'netmask'})));
 		$b->{'netmask'} = $in{'netmask'};
 		}
 
@@ -188,7 +188,7 @@ else {
 		# Manually entered broadcast
 		($auto && !$in{'broadcast'}) ||
 			&check_ipaddress($in{'broadcast'}) ||
-			&error(&text('bifc_ebroad', $in{'broadcast'}));
+			&error(&text('bifc_ebroad', &html_escape($in{'broadcast'})));
 		$b->{'broadcast'} = $in{'broadcast'};
 		}
 
@@ -202,14 +202,14 @@ else {
 		$auto && !$in{'mtu'} ||
 			$in{'mtu_def'} ||
 			$in{'mtu'} =~ /^\d+$/ ||
-			&error(&text('bifc_emtu', $in{'mtu'}));
+			&error(&text('bifc_emtu', &html_escape($in{'mtu'})));
 		$b->{'mtu'} = $in{'mtu_def'} ? undef : $in{'mtu'};
 		}
 
 	# MAC address
 	if (defined($in{'ether'}) && !$in{'ether_def'}) {
 		$in{'ether'} =~ /^[A-Fa-f0-9:]+$/ ||
-			&error(&text('aifc_ehard', $in{'ether'}));
+			&error(&text('aifc_ehard', &html_escape($in{'ether'})));
 		$b->{'ether'} = $in{'ether'};
 		}
 	else {
@@ -252,7 +252,7 @@ else {
 				&check_ip6address($in{'address6_'.$i}) ||
 					&error(&text('aifc_eaddress6', $i+1));
 				$c = $clash6{$in{'address6_'.$i}};
-				$c && &error(&text('aifc_eclash6', $i+1, $c->{'name'}));
+				$c && &error(&text('aifc_eclash6', $i+1, &html_escape($c->{'name'})));
 				push(@address6, $in{'address6_'.$i});
 				$in{'netmask6_'.$i} =~ /^\d+$/ &&
 				    $in{'netmask6_'.$i} > 0 &&

--- a/net/save_dns.cgi
+++ b/net/save_dns.cgi
@@ -9,14 +9,14 @@ $access{'dns'} == 2 || &error($text{'dns_ecannot'});
 $old_hostname = &get_system_hostname();
 
 $in{'hostname'} =~ /^[A-z0-9\.\-]+$/ ||
-	&error(&text('dns_ehost', $in{'hostname'}));
+	&error(&text('dns_ehost', &html_escape($in{'hostname'})));
 $dns = { };
 for($i=0; defined($ns = $in{"nameserver_$i"}); $i++) {
 	$ns = $in{"nameserver_$i"};
 	$ns =~ s/^\s+//; $ns =~ s/\s+$//;
 	if ($ns) {
 		&check_ipaddress_any($ns) ||
-			&error(&text('dns_ens', $ns));
+			&error(&text('dns_ens', &html_escape($ns)));
 		push(@{$dns->{'nameserver'}}, $ns);
 		}
 	}
@@ -32,7 +32,7 @@ if ($in{'name0'}) {
 	    $ns =~ s/^\s+//; $ns =~ s/\s+$//;
 	    if ($ns) {
 		&check_ipaddress_any($ns) ||
-		    &error(&text('dns_ens', $ns));
+		    &error(&text('dns_ens', &html_escape($ns)));
 		push(@{$dns->{$nskey}}, $ns);
 	    }
 	}
@@ -44,7 +44,7 @@ if (!$in{'domain_def'}) {
 	@dlist = split(/\s+/, $in{'domain'});
 	foreach $d (@dlist) {
 		$d =~ /^[A-z0-9\.\-]+$/ ||
-			&error(&text('dns_edomain', $d));
+			&error(&text('dns_edomain', &html_escape($d)));
 		push(@{$dns->{'domain'}}, $d);
 		}
 	@dlist || &error($text{'dns_esearch'});

--- a/net/save_host.cgi
+++ b/net/save_host.cgi
@@ -16,11 +16,11 @@ else {
 	# saving or updating a host
 	$whatfailed = "Failed to save host";
 	&check_ipaddress_any($in{'address'}) ||
-		&error("'$in{'address'}' is not a valid IP address");
+		&error("'".&html_escape($in{'address'})."' is not a valid IP address");
 	@h = split(/\s+/, $in{'hosts'});
 	foreach $h (@h) {
 		$h =~ /^[A-z0-9\-\.]+$/ ||
-			&error("'$h' is not a valid hostname");
+			&error("'".&html_escape($h)."' is not a valid hostname");
 		}
 	@h>0 || &error("You must enter at least one hostname");
 	if ($in{'new'}) {

--- a/net/save_host.cgi
+++ b/net/save_host.cgi
@@ -14,7 +14,6 @@ if ($in{'delete'}) {
 	}
 else {
 	# saving or updating a host
-	$whatfailed = "Failed to save host";
 	&check_ipaddress_any($in{'address'}) ||
 		&error("'".&html_escape($in{'address'})."' is not a valid IP address");
 	@h = split(/\s+/, $in{'hosts'});

--- a/net/save_ipnode.cgi
+++ b/net/save_ipnode.cgi
@@ -17,11 +17,11 @@ else {
 	$whatfailed = "Failed to save ipnode";
 	&check_ipaddress($in{'address'}) ||
 	   &check_ip6address($in{'address'}) ||
-		&error("'$in{'address'}' is not a valid IPv4 or v6 address");
+		&error("'".&html_escape($in{'address'})."' is not a valid IPv4 or v6 address");
 	@h = split(/\s+/, $in{'ipnodes'});
 	foreach $h (@h) {
 		$h =~ /^[A-z0-9\-\.]+$/ ||
-			&error("'$h' is not a valid ipnodename");
+			&error("'".&html_escape($h)."' is not a valid ipnodename");
 		}
 	@h>0 || &error("You must enter at least one ipnodename");
 	if ($in{'new'}) {

--- a/net/slackware-linux-9.1-ALL-lib.pl
+++ b/net/slackware-linux-9.1-ALL-lib.pl
@@ -298,7 +298,7 @@ sub parse_routing
 local $gw = "";
 if (!$in{'gw_def'}) {
 	&check_ipaddress($in{'gw'}) ||
-		&error(&text('routes_edefault', $in{'gw'}));
+		&error(&text('routes_edefault', &html_escape($in{'gw'})));
 	$gw = $in{'gw'};
 	}
 &lock_file($inet_conf);

--- a/net/slackware-linux-lib.pl
+++ b/net/slackware-linux-lib.pl
@@ -260,7 +260,7 @@ sub parse_routing
 local $gw = "";
 if (!$in{'gw_def'}) {
 	&check_ipaddress($in{'gw'}) ||
-		&error(&text('routes_edefault', $in{'gw'}));
+		&error(&text('routes_edefault', &html_escape($in{'gw'})));
 	$gw = $in{'gw'};
 	}
 &lock_file($rc_init);

--- a/net/solaris-lib.pl
+++ b/net/solaris-lib.pl
@@ -63,7 +63,7 @@ if (!$already) {
 	if ($a->{'virtual'} eq "") {
 		local $out = &backquote_logged(
 		 "ifconfig $a->{'name'} plumb 2>&1");
-		if ($out) { &error(&text('aifc_eexist', $a->{'name'})); }
+		if ($out) { &error(&text('aifc_eexist', &html_escape($a->{'name'}))); }
 		}
 	elsif ($gconfig{'os_version'} >= 8) {
 		&system_logged(
@@ -532,7 +532,7 @@ sub parse_routing
 # Save IPv4 default routers
 local @defrt = split(/\s+/, $in{'defrt'});
 foreach my $d (@defrt) {
-	&to_ipaddress($d) || &error(&text('routes_edefault', $d));
+	&to_ipaddress($d) || &error(&text('routes_edefault', &html_escape($d)));
 	}
 &lock_file("/etc/defaultrouter");
 if (@defrt) {
@@ -548,7 +548,7 @@ else {
 # Save IPv6 default routers
 local @defrt6 = split(/\s+/, $in{'defrt6'});
 foreach my $d (@defrt6) {
-	&to_ip6address($d) || &error(&text('routes_edefault6', $d));
+	&to_ip6address($d) || &error(&text('routes_edefault6', &html_escape($d)));
 	}
 &lock_file("/etc/defaultrouter6");
 if (@defrt6) {

--- a/net/suse-linux-9.0-lib.pl
+++ b/net/suse-linux-9.0-lib.pl
@@ -246,11 +246,11 @@ sub parse_routing
 local (@routes, $r, $i);
 if (!$in{'gateway_def'}) {
 	&to_ipaddress($in{'gateway'}) ||
-		&error(&text('routes_edefault', $in{'gateway'}));
+		&error(&text('routes_edefault', &html_escape($in{'gateway'})));
 	local @def = ( "default", $in{'gateway'}, undef, undef );
 	if (!$in{'gatewaydev_def'}) {
 		$in{'gatewaydev'} =~ /^\S+$/ ||
-			&error(&text('routes_edevice', $in{'gatewaydev'}));
+			&error(&text('routes_edevice', &html_escape($in{'gatewaydev'})));
 		$def[3] = $in{'gatewaydev'};
 		}
 	push(@routes, \@def);
@@ -259,14 +259,14 @@ for($i=0; defined($in{"dev_$i"}); $i++) {
 	next if (!$in{"net_$i"});
 	&check_ipaddress($in{"net_$i"}) ||
 		$in{"net_$i"} =~ /^(\S+)\/(\d+)$/ && &check_ipaddress($1) ||
-		&error(&text('routes_enet', $in{"net_$i"}));
-	$in{"dev_$i"} =~ /^\S*$/ || &error(&text('routes_edevice', $dev));
+		&error(&text('routes_enet', &html_escape($in{"net_$i"})));
+	$in{"dev_$i"} =~ /^\S*$/ || &error(&text('routes_edevice', &html_escape($dev)));
 	!$in{"netmask_$i"} || &check_ipaddress($in{"netmask_$i"}) ||
-		&error(&text('routes_emask', $in{"netmask_$i"}));
+		&error(&text('routes_emask', &html_escape($in{"netmask_$i"})));
 	!$in{"gw_$i"} || &check_ipaddress($in{"gw_$i"}) ||
-		&error(&text('routes_egateway', $in{"gw_$i"}));
+		&error(&text('routes_egateway', &html_escape($in{"gw_$i"})));
 	$in{"type_$i"} =~ /^\S*$/ ||
-		&error(&text('routes_etype', $in{"type_$i"}));
+		&error(&text('routes_etype', &html_escape($in{"type_$i"})));
 	push(@routes, [ $in{"net_$i"}, $in{"gw_$i"}, $in{"netmask_$i"},
 			$in{"dev_$i"}, $in{"type_$i"} ] );
 	}

--- a/net/suse-linux-9.2-ALL-lib.pl
+++ b/net/suse-linux-9.2-ALL-lib.pl
@@ -333,11 +333,11 @@ sub parse_routing
 local (@routes, $r, $i);
 if (!$in{'gateway_def'}) {
 	&to_ipaddress($in{'gateway'}) ||
-		&error(&text('routes_edefault', $in{'gateway'}));
+		&error(&text('routes_edefault', &html_escape($in{'gateway'})));
 	local @def = ( "default", $in{'gateway'}, undef, undef );
 	if (!$in{'gatewaydev_def'}) {
 		$in{'gatewaydev'} =~ /^\S+$/ ||
-			&error(&text('routes_edevice', $in{'gatewaydev'}));
+			&error(&text('routes_edevice', &html_escape($in{'gatewaydev'})));
 		$def[3] = $in{'gatewaydev'};
 		}
 	push(@routes, \@def);
@@ -346,14 +346,14 @@ for($i=0; defined($in{"dev_$i"}); $i++) {
 	next if (!$in{"net_$i"});
 	&check_ipaddress($in{"net_$i"}) ||
 		$in{"net_$i"} =~ /^(\S+)\/(\d+)$/ && &check_ipaddress($1) ||
-		&error(&text('routes_enet', $in{"net_$i"}));
-	$in{"dev_$i"} =~ /^\S*$/ || &error(&text('routes_edevice', $dev));
+		&error(&text('routes_enet', &html_escape($in{"net_$i"})));
+	$in{"dev_$i"} =~ /^\S*$/ || &error(&text('routes_edevice', &html_escape($dev)));
 	!$in{"netmask_$i"} || &check_ipaddress($in{"netmask_$i"}) ||
-		&error(&text('routes_emask', $in{"netmask_$i"}));
+		&error(&text('routes_emask', &html_escape($in{"netmask_$i"})));
 	!$in{"gw_$i"} || &check_ipaddress($in{"gw_$i"}) ||
-		&error(&text('routes_egateway', $in{"gw_$i"}));
+		&error(&text('routes_egateway', &html_escape($in{"gw_$i"})));
 	$in{"type_$i"} =~ /^\S*$/ ||
-		&error(&text('routes_etype', $in{"type_$i"}));
+		&error(&text('routes_etype', &html_escape($in{"type_$i"})));
 	push(@routes, [ $in{"net_$i"}, $in{"gw_$i"}, $in{"netmask_$i"},
 			$in{"dev_$i"}, $in{"type_$i"} ] );
 	}

--- a/net/suse-linux-lib.pl
+++ b/net/suse-linux-lib.pl
@@ -268,25 +268,25 @@ for($i=0; defined($dev = $in{"lr_dev_$i"}); $i++) {
 	$net = $in{"lr_net_$i"}; $mask = $in{"lr_mask_$i"};
 	next if (!$dev && !$net && !$mask);
 	&to_ipaddress($net) ||
-		&error(&text('routes_enet', $net));
+		&error(&text('routes_enet', &html_escape($net)));
 	&check_ipaddress($mask) ||
-		&error(&text('routes_emask', $mask));
+		&error(&text('routes_emask', &html_escape($mask)));
 	$route .= "$net\t\t0.0.0.0\t\t$mask\t\t$dev\n";
 	}
 for($i=0; defined($gw = $in{"sr_gw_$i"}); $i++) {
 	$net = $in{"sr_net_$i"}; $mask = $in{"sr_mask_$i"};
 	next if (!$gw && !$net && !$mask);
 	&to_ipaddress($gw) ||
-		&error(&text('routes_egateway', $gw));
+		&error(&text('routes_egateway', &html_escape($gw)));
 	&to_ipaddress($net) ||
-		&error(&text('routes_enet', $net));
+		&error(&text('routes_enet', &html_escape($net)));
 	&check_ipaddress($mask) ||
-		&error(&text('routes_emask', $mask));
+		&error(&text('routes_emask', &html_escape($mask)));
 	$route .= "$net\t\t$gw\t\t$mask\n";
 	}
 if (!$in{'default_def'}) {
 	&to_ipaddress($in{'default'}) ||
-		&error(&text('routes_edefault', $in{'default'}));
+		&error(&text('routes_edefault', &html_escape($in{'default'})));
 	$route .= "default\t\t$in{'default'}\n";
 	}
 &open_tempfile(ROUTE, ">$route_conf");

--- a/net/united-linux-lib.pl
+++ b/net/united-linux-lib.pl
@@ -211,11 +211,11 @@ sub parse_routing
 local (@routes, $r, $i);
 if (!$in{'gateway_def'}) {
 	&to_ipaddress($in{'gateway'}) ||
-		&error(&text('routes_edefault', $in{'gateway'}));
+		&error(&text('routes_edefault', &html_escape($in{'gateway'})));
 	local @def = ( "default", $in{'gateway'}, undef, undef );
 	if (!$in{'gatewaydev_def'}) {
 		$in{'gatewaydev'} =~ /^\S+$/ ||
-			&error(&text('routes_edevice', $in{'gatewaydev'}));
+			&error(&text('routes_edevice', &html_escape($in{'gatewaydev'})));
 		$def[3] = $in{'gatewaydev'};
 		}
 	push(@routes, \@def);
@@ -224,14 +224,14 @@ for($i=0; defined($in{"dev_$i"}); $i++) {
 	next if (!$in{"net_$i"});
 	&check_ipaddress($in{"net_$i"}) ||
 		$in{"net_$i"} =~ /^(\S+)\/(\d+)$/ && &check_ipaddress($1) ||
-		&error(&text('routes_enet', $in{"net_$i"}));
-	$in{"dev_$i"} =~ /^\S*$/ || &error(&text('routes_edevice', $dev));
+		&error(&text('routes_enet', &html_escape($in{"net_$i"})));
+	$in{"dev_$i"} =~ /^\S*$/ || &error(&text('routes_edevice', &html_escape($dev)));
 	!$in{"netmask_$i"} || &check_ipaddress($in{"netmask_$i"}) ||
-		&error(&text('routes_emask', $in{"netmask_$i"}));
+		&error(&text('routes_emask', &html_escape($in{"netmask_$i"})));
 	!$in{"gw_$i"} || &check_ipaddress($in{"gw_$i"}) ||
-		&error(&text('routes_egateway', $in{"gw_$i"}));
+		&error(&text('routes_egateway', &html_escape($in{"gw_$i"})));
 	$in{"type_$i"} =~ /^\S*$/ ||
-		&error(&text('routes_etype', $in{"type_$i"}));
+		&error(&text('routes_etype', &html_escape($in{"type_$i"})));
 	push(@routes, [ $in{"net_$i"}, $in{"gw_$i"}, $in{"netmask_$i"},
 			$in{"dev_$i"}, $in{"type_$i"} ] );
 	}

--- a/net/unixware-lib.pl
+++ b/net/unixware-lib.pl
@@ -42,7 +42,7 @@ sub activate_interface
 local $a = $_[0];
 if ($a->{'virtual'} eq "") {
 	local $out = &backquote_logged("ifconfig $a->{'name'} plumb 2>&1");
-	if ($out) { &error("Interface '$a->{'name'}' does not exist"); }
+	if ($out) { &error("Interface '".&html_escape($a->{'name'})."' does not exist"); }
 	}
 local $cmd = "ifconfig $a->{'name'}";
 if ($a->{'virtual'} ne "") { $cmd .= ":$a->{'virtual'}"; }
@@ -370,7 +370,7 @@ sub parse_routing
 {
 local @defrt = split(/\s+/, $in{'defrt'});
 foreach my $d (@defrt) {
-	&to_ipaddress($d) || &error(&text('routes_edefault', $d));
+	&to_ipaddress($d) || &error(&text('routes_edefault', &html_escape($d)));
 	}
 &lock_file("/etc/defaultrouter");
 if (@defrt) {

--- a/time/apply.cgi
+++ b/time/apply.cgi
@@ -35,7 +35,7 @@ if ($in{'action'} eq $text{'action_sync'}) {
   &error( $text{ 'acl_nosys' } ) if( $access{ 'sysdate' } );
   $err = &set_system_time($in{ 'second' }, $in{'minute'}, $in{'hour'},
 		   $in{'date'}, $in{'month'}-1, $in{'year'}-1900);
-  &error($err) if ($err);
+  &error(&html_escape($err)) if ($err);
   &webmin_log("set", "date", time(), \%in);
 
 } elsif ($in{'action'} eq $text{'action_save'} || $in{'mode'} eq 'hwdate' ) {
@@ -43,7 +43,7 @@ if ($in{'action'} eq $text{'action_sync'}) {
   &error( $text{ 'acl_nohw' } ) if( $access{ 'hwdate' } );
   $err = &set_hardware_time($in{ 'second' }, $in{'minute'}, $in{'hour'},
 		   $in{'date'}, $in{'month'}-1, $in{'year'}-1900);
-  &error( &text( 'error_hw', $err ) ) if ($err);
+  &error( &text( 'error_hw', &html_escape($err) ) ) if ($err);
   local $hwtime = timelocal($in{'second'}, $in{'minute'}, $in{'hour'},
 			    $in{'date'}, $in{'month'}-1, $in{'year'} < 200 ?
 			    $in{'year'} : $in{'year'}-1900);
@@ -54,7 +54,7 @@ if ($in{'action'} eq $text{'action_sync'}) {
   $access{'ntp'} || &error($text{'acl_nontp'});
   $in{'timeserver'} =~ /\S/ || &error($text{'error_etimeserver'});
   $err = &sync_time($in{'timeserver'}, $in{'hardware'});
-  &error($err) if ($err);
+  &error(&html_escape($err)) if ($err);
 
   # Save settings in module config
   &lock_file($module_config_file);

--- a/time/apply.cgi
+++ b/time/apply.cgi
@@ -54,7 +54,7 @@ if ($in{'action'} eq $text{'action_sync'}) {
   $access{'ntp'} || &error($text{'acl_nontp'});
   $in{'timeserver'} =~ /\S/ || &error($text{'error_etimeserver'});
   $err = &sync_time($in{'timeserver'}, $in{'hardware'});
-  &error(&html_escape($err)) if ($err);
+  &error("<pre>".&html_escape($err)."</pre>") if ($err);
 
   # Save settings in module config
   &lock_file($module_config_file);

--- a/time/time-lib.pl
+++ b/time/time-lib.pl
@@ -52,7 +52,7 @@ else {
 	}
 if ($? && $config{'ntp_only'}) {
 	# error using ntp, but nothing else is allowed
-	return &text('error_entp', "<tt>$out</tt>");
+	return &text('error_entp', "$out");
 	}
 elsif ($?) {
 	# error using ntp. use timeservice


### PR DESCRIPTION
Here are some fixes for XSS.

If you add some bad strings `<<script>alert("xss");//<</script>` into the network module, you can run JavaScript:
![image](https://user-images.githubusercontent.com/7994753/80106317-ff5c5680-8579-11ea-9971-28ba08794890.png)
![image](https://user-images.githubusercontent.com/7994753/80106388-156a1700-857a-11ea-91f8-b744567c3e83.png)

If you deactivate the referers with `referers_none=0`, than you can exploit with an URL:
https://192.168.2.1:10000/net/save_host.cgi?new=1&idx=&address=%3C%3Cscript%3Ealert(%22xss%22)%3B%2F%2F%3C%3C%2Fscript%3E