### PR TITLE
hostname update revised

### DIFF
--- a/net/save_dns.cgi
+++ b/net/save_dns.cgi
@@ -6,11 +6,17 @@ require './net-lib.pl';
 $access{'dns'} == 2 || &error($text{'dns_ecannot'});
 &error_setup($text{'dns_err'});
 &ReadParse();
-$old_hostname = &get_system_hostname();
+$old_fqdn = &get_system_hostname(); # Fully-Qualified Domain Name
+$old_pqdn = &get_system_hostname(1); # Partially Qualified Domain Name (short name)
+$old_hostname = &get_hostname();
 
-$in{'hostname'} =~ /^[A-z0-9\.\-]+$/ ||
+$in{'hostname'} =~ /^[A-Za-z0-9\.\-]+$/ ||
 	&error(&text('dns_ehost', &html_escape($in{'hostname'})));
 $dns = { };
+
+$new_pqdn = $in{'hostname'};
+$new_pqdn =~ s/\..*$//;
+
 for($i=0; defined($ns = $in{"nameserver_$i"}); $i++) {
 	$ns = $in{"nameserver_$i"};
 	$ns =~ s/^\s+//; $ns =~ s/\s+$//;
@@ -43,8 +49,9 @@ if ($in{'name0'}) {
 if (!$in{'domain_def'}) {
 	@dlist = split(/\s+/, $in{'domain'});
 	foreach $d (@dlist) {
-		$d =~ /^[A-z0-9\.\-]+$/ ||
+		$d =~ /^[A-Za-z0-9\.\-]+$/ ||
 			&error(&text('dns_edomain', &html_escape($d)));
+		$new_fqdn = "$new_pqdn.$d" if !$new_fqdn;
 		push(@{$dns->{'domain'}}, $d);
 		}
 	@dlist || &error($text{'dns_esearch'});
@@ -53,14 +60,22 @@ if (!$in{'domain_def'}) {
 &save_dns_config($dns);
 &save_hostname($in{'hostname'});
 
-if ($in{'hosts'} && $in{'hostname'} ne $old_hostname) {
-	# Update hostname in /etc/hosts too
+if ($in{'hosts'} && ($in{'hostname'} ne $old_hostname || $new_fqdn ne $old_fqdn)) {
+	# Update hostname/fqdn/pqdn in /etc/hosts too
 	@hosts = &list_hosts();
 	foreach $h (@hosts) {
 		local $found = 0;
 		foreach $n (@{$h->{'hosts'}}) {
 			if (lc($n) eq lc($old_hostname)) {
 				$n = $in{'hostname'};
+				$found++;
+				}
+			elsif (lc($n) eq lc($old_fqdn) && $new_fqdn) {
+				$n = $new_fqdn;
+				$found++;
+				}
+			elsif (lc($n) eq lc($old_pqdn)) {
+				$n = $new_pqdn;
 				$found++;
 				}
 			}
@@ -74,6 +89,14 @@ if ($in{'hosts'} && $in{'hostname'} ne $old_hostname) {
 		foreach $n (@{$h->{'ipnodes'}}) {
 			if (lc($n) eq lc($old_hostname)) {
 				$n = $in{'hostname'};
+				$found++;
+				}
+			elsif (lc($n) eq lc($old_fqdn) && $new_fqdn) {
+				$n = $new_fqdn;
+				$found++;
+				}
+			elsif (lc($n) eq lc($old_pqdn)) {
+				$n = $new_pqdn;
 				$found++;
 				}
 			}
@@ -92,13 +115,9 @@ if (&foreign_installed("postfix") && $in{'hostname'} ne $old_hostname) {
 		&postfix::set_current_value("mydestination",
 					    join(", ", @mydests));
 		}
-	$old_shorthostname = $old_hostname;
-	$old_shorthostname =~ s/\..*$//;
-	$shorthostname = $in{'hostname'};
-	$shorthostname =~ s/\..*$//;
-	$idx = &indexoflc($old_shorthostname, @mydests);
+	$idx = &indexoflc($old_pqdn, @mydests);
 	if ($idx >= 0) {
-		$mydests[$idx] = $shorthostname;
+		$mydests[$idx] = $new_pqdn;
 		&postfix::set_current_value("mydestination",
 					    join(", ", @mydests));
 		}


### PR DESCRIPTION
If you activate `Update hostname in host addresses if changed?` at `Hostname and DNS Client` (https://192.168.2.1:10000/net/list_dns.cgi) the hostname wasn't update always in `/etc/hosts`. This pull request is fix that and change also FQDN and PQDN if possible.

Example: Hostname was `server1` and Search domains was `example.local`. `/etc/hosts` has the line `127.0.1.1       server1`. If you change the hostname from `server1` to `server2` the line in hosts file wasn't update.


Also the hostname and domain validation had a bug, because the characters [\]^_` are not allowed. This is also fixed in this pull request.