### PR TITLE
Fix reverse proxy redirect for prefixed URL - miniserv.pl

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1533,6 +1533,9 @@ $portstr = $redirport == 80 && !$ssl ? "" :
 $redirhost = $config{'redirect_host'} || $host;
 $hostport = &check_ip6address($redirhost) ? "[".$redirhost."]".$portstr
 				          : $redirhost.$portstr;
+# If the redirect_prefix exists change redirect base to include the prefix
+$hostport = exists($config{'redirect_prefix'}) ?
+		$hostport.$config{'redirect_prefix'} : $hostport;
 $prot = $ssl ? "https" : "http";
 
 undef(%in);


### PR DESCRIPTION
Fix problem where when behind a reverse proxy running as a prefixed url (eg https://abc.com/webmin) that the logon does not redirect correctly to the /webmin part.

This is to complement the other redirect_xxx values that were added in 1.940 per @iliarostovtsev in comment https://github.com/webmin/webmin/issues/1135#issuecomment-565818024