### PR TITLE
Automatically broadcast for debian-linux at bootup configuration

### DIFF
--- a/net/debian-linux-lib.pl
+++ b/net/debian-linux-lib.pl
@@ -98,11 +98,6 @@ foreach $iface (@ifaces) {
 		$cfg->{'edit'} = ($cfg->{'name'} !~ /^ppp|lo/);
 		$cfg->{'index'} = scalar(@rv);	
 		$cfg->{'file'} = $network_interfaces_config;
-		if (!$cfg->{'broadcast'} &&
-		    $cfg->{'address'} && $cfg->{'netmask'}) {
-			$cfg->{'broadcast'} = &compute_broadcast(
-				$cfg->{'address'}, $cfg->{'netmask'});
-			}
 		push(@rv, $cfg);
 		}
 	elsif ($addrfam eq "inet6") {

--- a/net/edit_bifc.cgi
+++ b/net/edit_bifc.cgi
@@ -51,11 +51,6 @@ else {
 	$b = $boot[$in{'idx'}];
 	&can_iface($b) || &error($text{'ifcs_ecannot_this'});
 	&ui_print_header(undef, $text{'bifc_edit'}, "");
-	if (!$b->{'dhcp'} && !$b->{'bootp'} && !$b->{'broadcast'}) {
-		# Fill in broadcast if missing
-		$b->{'broadcast'} = &compute_broadcast(
-			$b->{'address'}, $b->{'netmask'});
-		}
 	}
 
 # Start of the form
@@ -154,11 +149,20 @@ elsif ($b && $b->{'netmask'}) {
 	push(@grid, $text{'ifcs_mask'}, "<tt>$b->{'netmask'}</tt>");
 	}
 if (&can_edit("broadcast", $b) && $access{'broadcast'}) {
+	$radio_def = undef;
+	# Fill automatically broadcast if missing
+	if ($b && !$b->{'dhcp'} && !$b->{'bootp'} && !$b->{'broadcast'} &&
+		$b->{'address'} && $b->{'netmask'}) {
+		$radio_def = 1;
+		$b->{'broadcast'} = &compute_broadcast(
+			$b->{'address'}, $b->{'netmask'});
+		}
+
 	# Can edit broadcast address
 	push(@grid, $text{'ifcs_broad'},
-	    &ui_opt_textbox("broadcast",
+		&ui_opt_textbox("broadcast",
 		$b ? $b->{'broadcast'} : $config{'def_broadcast'},
-		15, $text{'ifcs_auto'}));
+		15, $text{'ifcs_auto'}, undef, undef, undef, undef, undef, $radio_def));
 	}
 elsif ($b && $b->{'broadcast'}) {
 	# Broadcast is fixed

--- a/net/save_bifc.cgi
+++ b/net/save_bifc.cgi
@@ -178,11 +178,8 @@ else {
 		delete($b->{'broadcast'});
 		}
 	elsif (!$access{'broadcast'} || $in{'broadcast_def'}) {
-		# Work out broadcast
-		if ($in{'new'}) {
-			$b->{'broadcast'} = &compute_broadcast(
-				$b->{'address'}, $b->{'netmask'});
-			}
+		# remove broadcast if automatically
+		undef $b->{'broadcast'};
 		}
 	elsif (&can_edit("broadcast", $b)) {
 		# Manually entered broadcast

--- a/ui-lib.pl
+++ b/ui-lib.pl
@@ -1326,7 +1326,7 @@ return &ui_textbox($name, $value, 60, $dis, undef, $tags)." ".
        &group_chooser_button($name, 1, $form);
 }
 
-=head2 ui_opt_textbox(name, value, size, option1, [option2], [disabled?], [&extra-fields], [max])
+=head2 ui_opt_textbox(name, value, size, option1, [option2], [disabled?], [&extra-fields], [max], [tags], [option_select?])
 
 Returns HTML for a text field that is optional, implemented by default as
 a field with radio buttons next to it. The parameters are :
@@ -1349,16 +1349,18 @@ a field with radio buttons next to it. The parameters are :
 
 =item tags - Additional HTML attributes for the text box
 
+=item option_select - If defined, the option that is preselected regardless of the value. Use 1 for option1 and 0 for option2.
+
 =cut
 sub ui_opt_textbox
 {
 return &theme_ui_opt_textbox(@_) if (defined(&theme_ui_opt_textbox));
-my ($name, $value, $size, $opt1, $opt2, $dis, $extra, $max, $tags) = @_;
+my ($name, $value, $size, $opt1, $opt2, $dis, $extra, $max, $tags, $option_select) = @_;
 my $dis1 = &js_disable_inputs([ $name, @$extra ], [ ]);
 my $dis2 = &js_disable_inputs([ ], [ $name, @$extra ]);
 my $rv;
 $size = &ui_max_text_width($size);
-$rv .= &ui_radio($name."_def", $value eq '' ? 1 : 0,
+$rv .= &ui_radio($name."_def", !defined($option_select) && $value eq '' || $option_select ? 1 : 0,
 		 [ [ 1, $opt1, "onClick='$dis1'" ],
 		   [ 0, $opt2 || " ", "onClick='$dis2'" ] ], $dis)."\n";
 $rv .= "<input class='ui_opt_textbox' type='text' ".


### PR DESCRIPTION
If you edit the bootup configuration of an interface, the automatic broadcast calculation will not work. Furthermore, Debian also supports the omission of the broadcast configuration.

An example of the first problem, the `/etc/network/interfaces` contain follow lines:

```
iface ens256 inet static
        address 192.168.2.2
        netmask 255.255.192.0
        broadcast 192.168.63.255
        network 192.168.0.0
```
Then change the netmask from 255.255.192.0 to 255.255.255.0, broadcast to automatic and save (on `Edit Bootup Interface`: https://192.168.2.2:10000/net/edit_bifc.cgi?idx=2)

After saving the file `/etc/network/interfaces` contains the following lines (with wrong broadcast). The broadcast should be `192.168.2.255`.

```
iface ens256 inet static
        address 192.168.2.2
        netmask 255.255.255.0
        broadcast 192.168.63.255
        network 192.168.2.0
```

But (Debian) Linux supports skipping the broadcast configuration and calculates this automatically. This patch supports skipping the broadcast configuration and leaves it to the operating system as far as possible. If the `/etc/network/interfaces` contain the following lines and you configure the bootup interface, you will see the following screenshot (broadcast calculated by Webmin is greyed out):

```
iface ens256 inet static
        address 192.168.2.2
        netmask 255.255.192.0
        network 192.168.2.0
```
![grafik](https://user-images.githubusercontent.com/7994753/89621717-19ecde00-d892-11ea-9ce1-dabb559a90a7.png)
