### PR TITLE
LDAP Bind Credentials File Option for ldap-useradmin Webmin Module

### DIFF
--- a/ldap-useradmin/config.info
+++ b/ldap-useradmin/config.info
@@ -4,6 +4,7 @@ ldap_port=LDAP server port,3,From NSS config file or default
 ldap_tls=LDAP server uses encryption?,1,1-Yes SSL,2-Yes TLS,0-No
 login=Bind to LDAP server as,3,Bind name from NSS config file
 pass=Credentials for bind name above,12
+ldap_pass_file=Path to LDAP bind credentials file,3
 user_base=Base for users,3,From NSS config file
 group_base=Base for groups,3,From NSS config file
 other_class=Other objectClasses to add to new users,0

--- a/ldap-useradmin/install_check.pl
+++ b/ldap-useradmin/install_check.pl
@@ -14,8 +14,8 @@ if ($config{'auth_ldap'}) {
 else {
 	if ($_[0]) {
 		return 1 if (!$config{'ldap_host'} || !$config{'login'} ||
-			     !$config{'pass'} || !$config{'user_base'} ||
-			     !$config{'group_base'});
+			     ( !$config{'pass'} && !$config{'ldap_pass_file'} ) || 
+					!$config{'user_base'} || !$config{'group_base'});
 		}
 	}
 if ($_[0]) {

--- a/ldap-useradmin/lang/en
+++ b/ldap-useradmin/lang/en
@@ -24,6 +24,7 @@ imap_econn=Failed to connect to IMAP server $1
 imap_elogin=Failed to login to IMAP server $1 as $2 : $3
 conn_eldap_host=No LDAP client configuration file was found on your system, so the LDAP server must be set on the Module Config page
 conn_elogin=No LDAP client configuration file was found on your system, so the LDAP login must be set on the Module Config page
+conn_efile_open=Could not open the LDAP bind credentials file: 
 
 uedit_cap=User capabilities
 uedit_samba=Samba login?

--- a/ldap-useradmin/ldap-useradmin-lib.pl
+++ b/ldap-useradmin/ldap-useradmin-lib.pl
@@ -65,9 +65,24 @@ if (!$cfile || !-r $cfile) {
 		}
 	}
 
+# If a bind credentials file is defined, read the password from the file
+# Otherwise, read the password from the "pass" config option
+my $ldapPassword;
+if ( $config{'ldap_pass_file'} ){
+	if (open my $fh, "<", $config{'ldap_pass_file'} ){
+		local $/;
+		$ldapPassword =  <$fh>;
+		close($fh);
+	} else {
+		&error($text{'conn_efile_open'} . " " . $config{'ldap_pass_file'});
+	}
+} else {
+	$ldapPassword = $config{'pass'};
+}
+
 local $ldap = &ldap_client::generic_ldap_connect(
 		$config{'ldap_host'}, $config{'ldap_port'},
-		$config{'ldap_tls'}, $config{'login'}, $config{'pass'});
+		$config{'ldap_tls'}, $config{'login'}, $ldapPassword);
 if (ref($ldap)) { return $ldap; }
 elsif ($_[0]) { return $ldap; }
 else { &error($ldap); }


### PR DESCRIPTION
This PR includes an option to allow the ldap-useradmin (LDAP Users and Groups) Webmin module to be pointed to a system file to obtain the bind password instead of being maintained within the module configuration file. The motivation for this is on a system where the ldapsearch utility is used in concert with the "-y" parameter, the system file can be shared and the bind password only needs to be maintained in one location instead of two. Thank you for considering my request.