### PR TITLE
 Allow posixAccount/posixGroup Object Classes to be Overridden in ldap-useradmin Module

### DIFF
--- a/ldap-useradmin/CHANGELOG
+++ b/ldap-useradmin/CHANGELOG
@@ -77,3 +77,6 @@ The list of groups now includes descriptions, if any are set.
 Added Module Config options for additional LDAP filters to find users and groups, in addition to the posixAccount / posixGroup object class filters.
 ---- Changes since 1.610 ----
 The userPassword attribute is now removed for users or groups that don't have a password set.
+---- Changes since 1.954 ----
+Added the option to point the ldap-useradmin to a system file for the LDAP bind credentials
+Allow the default posixAccount/posixGroup object classes to be overridden

--- a/ldap-useradmin/config.info
+++ b/ldap-useradmin/config.info
@@ -25,6 +25,8 @@ multi_fields=Allow multiple values for extra properties?,1,1-Yes,0-No
 noclash=Attributes for which duplicates are disallowed,0
 person=Give all Unix users the <tt>person</tt> object class?,1,1-Yes,0-No
 gecos=Set <tt>gecos</tt> attribute to match real name?,1,1-Yes,0-No
+custom_user_obj_class=Custom primary user objectClass (default posixAccount),3
+custom_group_obj_class=Custom primary group objectClass (default posixGroup),3
 user_filter=Additional LDAP filter for users,3,None,,,,Attribute=value
 group_filter=Additional LDAP filter for groups,3,None,,,,Attribute=value
 

--- a/ldap-useradmin/ldap-useradmin-lib.pl
+++ b/ldap-useradmin/ldap-useradmin-lib.pl
@@ -233,7 +233,7 @@ sub create_user
 local $ldap = &ldap_connect();
 local $base = &get_user_base();
 $_[0]->{'dn'} = "uid=$_[0]->{'user'},$base";
-local @classes = ( "posixAccount", "shadowAccount",
+local @classes = ( &def_user_obj_class(), "shadowAccount",
 		   split(/\s+/, $config{'other_class'}),
 		   @{$_[0]->{'ldap_class'}} );
 local $schema = $ldap->schema();
@@ -356,7 +356,7 @@ sub create_group
 local $ldap = &ldap_connect();
 local $base = &get_group_base();
 $_[0]->{'dn'} = "cn=$_[0]->{'group'},$base";
-local @classes = ( "posixGroup" );
+local @classes = ( &def_group_obj_class() );
 push(@classes, split(/\s+/, $config{'gother_class'}));
 @classes = &uniquelc(@classes);
 local @attrs = &group_to_dn($_[0]);
@@ -1244,7 +1244,7 @@ return undef;
 # Returns an LDAP filter expression to find users
 sub user_filter
 {
-my $rv = "(objectClass=posixAccount)";
+my $rv = "(objectClass=".&def_user_obj_class().")";
 if ($config{'user_filter'}) {
 	$rv = "(&".$rv."(".$config{'user_filter'}."))";
 	}
@@ -1255,11 +1255,35 @@ return $rv;
 # Returns an LDAP filter expression to find groups
 sub group_filter
 {
-my $rv = "(objectClass=posixGroup)";
+my $rv = "(objectClass=".&def_group_obj_class().")";
 if ($config{'group_filter'}) {
 	$rv = "(&".$rv."(".$config{'group_filter'}."))";
 	}
 return $rv;
+}
+
+# def_user_obj_class()
+# Returns the objectClass to use for LDAP users
+# Default is "posixAccount" if not overridden
+sub def_user_obj_class
+{
+my $userObjClass = "posixAccount";
+if ($config{'custom_user_obj_class'}){
+	$userObjClass = $config{'custom_user_obj_class'};
+}
+return $userObjClass;
+}
+
+# def_group_obj_class()
+# Returns the objectClass to use for LDAP groups
+# Default is "posixGroup" if not overridden
+sub def_group_obj_class
+{
+my $groupObjClass = "posixGroup";
+if ($config{'custom_group_obj_class'}){
+	$groupObjClass = $config{'custom_group_obj_class'};
+}
+return $groupObjClass;
 }
 
 1;

--- a/ldap-useradmin/save_group.cgi
+++ b/ldap-useradmin/save_group.cgi
@@ -284,7 +284,7 @@ else {
 	# Add to the LDAP database
 	$base = &get_group_base();
 	$newdn = "cn=$group,$base";
-	@classes = ( "posixGroup" );
+	@classes = ( &def_group_obj_class() );
 	push(@classes, split(/\s+/, $config{'gother_class'}));
 	if ($in{'samba'}) {
 		push(@classes, $samba_group_class);

--- a/ldap-useradmin/save_user.cgi
+++ b/ldap-useradmin/save_user.cgi
@@ -341,7 +341,7 @@ else {
 		$shadow = &shadow_fields();
 
 		# Add to the ldap database
-		@classes = ( "posixAccount", "shadowAccount" );
+		@classes = ( &def_user_obj_class(), "shadowAccount" );
 		if ($schema && $schema->objectclass("person") && $config{'person'}) {
 			push(@classes, "person");
 			}


### PR DESCRIPTION
I'm using the ldap-useradmin module in an Active Directory environment where the currently hard-coded "posixAccount" and "posixGroup" LDAP object classes are not used therefore LDAP queries fail. This PR includes updates to the ldap-useradmin module to allow these object classes to be overridden via the GUI instead of editing the perl scripts. Thank you for considering my request. 

![image](https://user-images.githubusercontent.com/30388381/90345367-f8a49400-dfed-11ea-8308-8b98c4eddd92.png)
