### PR TITLE
Wrong key printout in edit_zonekey.cgi

### DIFF
--- a/bind8/edit_zonekey.cgi
+++ b/bind8/edit_zonekey.cgi
@@ -40,7 +40,8 @@ if (@keyrecs) {
 				 ($key->{'ksk'} ? 257 : 256) } @keyrecs;
 		my $keyline = join(" ", $keyrec->{'name'}, $keyrec->{'class'},
 				     $keyrec->{'type'},
-				     join("", @{$keyrec->{'values'}}));
+				     join(" ", @{$keyrec->{'values'}}[0..2]),
+				     join("", splice( @{$keyrec->{'values'}}, 3 )));
 		print &ui_hidden_start($text{'zonekey_expand'.$kt},
 				       $kt, 0, "edit_zonekey.cgi?$in");
 		print $text{'zonekey_public'},"<br>\n";


### PR DESCRIPTION
This fixes the wrong key printout in edit_zonekey.cgi page.
https://www.virtualmin.com/node/69750


keyrec->values consist of a array with:
0: KSK(257) or ZSK (256)
1: DNSSEC Protocol (Fixed to 3)
2: Algorithm identifier
3+: Public Key spliced in multiple chunks...

The public key in chunks is because webmin inserts the key into the zonefile with spaces in between:
https://github.com/webmin/webmin/blob/2d95efa30e587a40642288c9274930f40b2b13fb/bind8/bind8-lib.pl#L3335