### PR TITLE
Degrade apt-show-versions from dependency to recommendation

### DIFF
--- a/makedebian.pl
+++ b/makedebian.pl
@@ -92,8 +92,10 @@ if ($< == 0) {
 $size = int(`du -sk $tmp_dir`);
 
 # Create the control file
-@deps = ( "perl", "libnet-ssleay-perl", "openssl", "libauthen-pam-perl", "libpam-runtime", "libio-pty-perl", "apt-show-versions", "unzip", "shared-mime-info" );
+@deps = ( "perl", "libnet-ssleay-perl", "openssl", "libauthen-pam-perl", "libpam-runtime", "libio-pty-perl", "unzip", "shared-mime-info" );
 $deps = join(", ", @deps);
+@recs = ( "apt-show-versions" );
+$recs = join(", ", @recs);
 open(CONTROL, ">$control_file");
 print CONTROL <<EOF;
 Package: $product
@@ -102,6 +104,7 @@ Section: admin
 Priority: optional
 Architecture: all
 Depends: $deps
+Recommends: $recs
 Pre-Depends: perl
 Installed-Size: $size
 Maintainer: Jamie Cameron <jcameron\@webmin.com>


### PR DESCRIPTION
`apt-show-versions` is used in a single place in code only and, if not present, `apt-cache` is used instead. The `apt-show-versions` package is hence not required for Webmin which is why it is degraded to a recommendation here.

Here it is used: https://github.com/webmin/webmin/blob/067a433eecba73e48548265d8fc259ab13f5a90d/software/apt-lib.pl#L245

My motivation here was due to being hit by this bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=617856
- `apt-show-versions` does not support compressed APT list files which can be enabled via `Acquire::GzipIndexes "true";` setting.
- This causes `apt-show-versions -i` to not "see" the (compressed) list and hence it fails, which makes its install fail in postinst and additionally makes `apt(-get) update` fail from that point on.

Another issue with `apt-show-versions` is that it lacks an active maintainer for some years, so this and probably other issues are likely not going to be resolved as long as no-one else taking the project over. Since `apt-cache` basically allows to get the same information (in case with some more parsing effort and no beautiful colour), I guess the motivation is not that high.

I went the most conservative way with this commit, however I am wondering if using `apt-show-versions` in Webmin is beneficial at all since there is already an `apt-cache` fallback implemented which has several benefits:
- Native support on all APT-based distros.
- No additional cache creation on every `apt(-get) update`: `apt-show-versions` maintains an additional cache via `/etc/apt/apt.conf.d/20apt-show-versions`.
- Compressed list file support.
- Less dependencies, less code (since the fallback is already there).