### PR TITLE
Fix for restore job locking when using SQLite

### DIFF
--- a/bacula-backup/restore.cgi
+++ b/bacula-backup/restore.cgi
@@ -62,6 +62,8 @@ else {
 	@clients = ( [ $in{'client'}, $in{'job'} ] );
 	}
 
+$dbh->disconnect();
+
 foreach $clientjob (@clients) {
 	$client = $clientjob->[0];
 	$job = $clientjob->[1];


### PR DESCRIPTION
The SQLite db handle left open prevents the job from starting and permanently freezes "s dir" command in bconsole. Not tested with mysql and postgresql (but it shouldn't hurt)