### PR TITLE
Unset LANG in status monitor script like @ /etc/webmin/start script

### DIFF
--- a/status/monitor.pl
+++ b/status/monitor.pl
@@ -6,6 +6,7 @@ $no_acl_check++;
 delete($ENV{'FOREIGN_MODULE_NAME'});
 delete($ENV{'SCRIPT_NAME'});
 delete($ENV{'SERVER_ROOT'});
+delete($ENV{'LANG'});
 require './status-lib.pl';
 
 # Check if the monitor should be run now


### PR DESCRIPTION
Non-US/EN default system locale affects float point format "," or "." (e.g. in uptime monitor, which goes down on wrong locale when parsing 1,5,15 mins load)