### PR TITLE
Use new API with old `changepass.pl` for compatibility

### DIFF
--- a/changepass.pl
+++ b/changepass.pl
@@ -18,7 +18,7 @@ if ($status != 0) {
 	else {
 		print "Error: $!\n";		
 		}
-}
+	}
 exit $status;
 
 sub usage

--- a/changepass.pl
+++ b/changepass.pl
@@ -3,109 +3,11 @@
 # Script for the user to change their webmin password
 
 # Check command line arguments
-require "./acl/md5-lib.pl";
 usage() if (@ARGV != 3);
-($config, $user, $pass) = @ARGV;
-if (!-d $config) {
-	print STDERR "The config directory $config does not exist\n";
-	exit 2;
-	}
-if (!open(CONF, "<$config/miniserv.conf")) {
-	print STDERR "Failed to open $config/miniserv.conf : $!\n";
-	print STDERR "Maybe $config is not the Webmin config directory.\n";
-	exit 3;
-	}
-while(<CONF>) {
-	if (/^([^=]+)=(\S+)/) { $config{$1} = $2; }
-	}
-close(CONF);
-if (!open(CONF, "<$config/config")) {
-	print STDERR "Failed to open $config/config : $!\n";
-	print STDERR "Maybe $config is not the Webmin config directory.\n";
-	exit 3;
-	}
-while(<CONF>) {
-	if (/^([^=]+)=(\S+)/) { $gconfig{$1} = $2; }
-	}
-close(CONF);
 
-# Update the users file
-if (!open(USERS, "<".$config{'userfile'})) {
-	print STDERR "Failed to open Webmin users file $config{'userfile'} : $!\n";
-	exit 4;
-	}
-while(<USERS>) {
-	s/\r|\n//g;
-	local @user = split(/:/, $_);
-	if (@user) {
-		$users{$user[0]} = \@user;
-		push(@users, $user[0]);
-		}
-	}
-close(USERS);
-$uinfo = $users{$user};
-if (!defined($uinfo)) {
-	print STDERR "The Webmin user $user does not exist\n";
-	print STDERR "The users on your system are: ",join(" ", @users),"\n";
-	exit 5;
-	}
-$uinfo->[1] = encrypt_password($pass);
-$uinfo->[6] = time();
-if (!open(USERS, ">$config{'userfile'}")) {
-	print STDERR "Failed to open Webmin users file $config{'userfile'} : $!\n";
-	exit 6;
-	}
-foreach $v (values %users) {
-	print USERS join(":", @$v),"\n";
-	}
-close(USERS);
-print "Updated password of Webmin user $user\n";
-
-# Send a signal to have miniserv reload it's config
-if (open(PID, "<".$config{'pidfile'})) {
-	$pid = <PID>;
-	$pid =~ s/\r|\n//;
-	close(PID);
-	if (!$pid) {
-		print STDERR "Webmin is not running - cannot refresh configuration\n";
-		}
-	elsif (!kill('USR1', $pid)) {
-		print STDERR "Failed to signal process $pid - cannot refresh configuration\n";
-		}
-	}
-else {
-	print STDERR "Webmin is not running - cannot refresh configuration\n";
-	}
-
-sub encrypt_password
-{
-my ($pass) = @_;
-if ($gconfig{'md5pass'} == 1) {
-	# Use MD5 encryption
-	return &encrypt_md5($pass);
-	}
-elsif ($gconfig{'md5pass'} == 2) {
-	# Use SHA512 encryption
-	return &encrypt_sha512($pass);
-	}
-else {
-	# Use Unix DES
-	srand(time() ^ $$);
-	$salt ||= chr(int(rand(26))+65).chr(int(rand(26))+65);
-	return &unix_crypt($pass, $salt);
-	}
-}
-
-sub unix_crypt
-{
-local ($pass, $salt) = @_;
-if ($use_perl_crypt) {
-	return Crypt::UnixCrypt::crypt($pass, $salt);
-	}
-else {
-	return crypt($pass, $salt);
-	}
-}
+my ($config, $user, $pass) = @ARGV;
+my $status = system("webmin passwd --config $config --user $user --pass $pass");
+exit $status;
 
 sub usage
 {
@@ -115,9 +17,8 @@ usage: changepass.pl <config-dir> <login> <password>
 This program allows you to change the password of a user in the Webmin
 password file. For example, to change the password of the admin user
 to foo, you would run:
-	changepass.pl /etc/webmin admin foo
+  - changepass.pl /etc/webmin admin foo
 This assumes that /etc/webmin is the Webmin configuration directory.
 EOF
 exit 1;
 }
-

--- a/changepass.pl
+++ b/changepass.pl
@@ -17,7 +17,7 @@ if ($status != 0) {
 		}
 	else {
 		print "Error: $!\n";		
-	}
+		}
 }
 exit $status;
 

--- a/changepass.pl
+++ b/changepass.pl
@@ -2,11 +2,23 @@
 # changepass.pl
 # Script for the user to change their webmin password
 
+# Get Webmin directory
+my $cwd = $0;
+$cwd =~ s/(.*)\/.*/$1/;
+
 # Check command line arguments
 usage() if (@ARGV != 3);
 
 my ($config, $user, $pass) = @ARGV;
-my $status = system("/usr/bin/webmin passwd --config $config --user $user --pass $pass");
+my $status = system("$cwd/bin/webmin passwd --config $config --user $user --pass $pass");
+if ($status != 0) {
+	if ($! =~ /no such file/i) {
+		print "Error: Webmin CLI command cannot be found\n";
+		}
+	else {
+		print "Error: $!\n";		
+	}
+}
 exit $status;
 
 sub usage

--- a/changepass.pl
+++ b/changepass.pl
@@ -6,7 +6,7 @@
 usage() if (@ARGV != 3);
 
 my ($config, $user, $pass) = @ARGV;
-my $status = system("webmin passwd --config $config --user $user --pass $pass");
+my $status = system("/usr/bin/webmin passwd --config $config --user $user --pass $pass");
 exit $status;
 
 sub usage


### PR DESCRIPTION
Jamie, I suggest completely dropping old `changepass.pl` code and use new API in it:


```Bash
# webmin passwd  --help
Usage:
    passwd [options]

Options:
    --help, -h
        Print this usage summary and exit.

        Examples of usage:

         - passwd --user root
 
         - passwd --user root --password ycwyMQRVAZY
 
         - passwd --config /usr/local/etc/webmin --user root --password ycwyMQRVAZY

    --config, -c
        Specify the full path to the Webmin configuration directory.
        Defaults to "/etc/webmin"

    --user, -u
        Existing Webmin user to change password for

    --password, -p
        Set new user password. Using this option may be unsecure.
```

New API can be seen here - https://github.com/webmin/webmin/blob/master/bin/passwd