### PR TITLE
New setting to be compatible with external services monitoring cron jobs and similar periodic processes

### DIFF
--- a/status/edit_sched.cgi
+++ b/status/edit_sched.cgi
@@ -47,6 +47,7 @@ print &ui_table_row($text{'sched_warn'},
 	&ui_radio("warn", int($config{'sched_warn'}),
 		  [ [ 1, $text{'sched_warn1'} ],
 		    [ 0, $text{'sched_warn0'} ],
+		    [ 3, $text{'sched_warn3'} ],
 		    [ 2, $text{'sched_warn2'} ] ]), 3);
 
 # Send email to

--- a/status/lang/en
+++ b/status/lang/en
@@ -160,6 +160,7 @@ sched_offset=with offset
 sched_warn=Send email when
 sched_warn1=When a service changes status
 sched_warn0=When a service goes down
+sched_warn3=As long as the service is up
 sched_warn2=Any time service is down
 sched_single=Send one email per service?
 sched_hours=Run monitor during hours

--- a/status/lang/fr
+++ b/status/lang/fr
@@ -160,6 +160,7 @@ sched_offset=avec un décalage
 sched_warn=Envoyer un message électronique quand
 sched_warn1=Un service change d'état
 sched_warn0=Un service s'arrête
+sched_warn3=Tant que le service est actif
 sched_warn2=Chaque fois qu'un service s'arrête
 sched_single=Envoyer un message électronique par service ?
 sched_hours=Exécuter le moniteur aux heures suivantes

--- a/status/monitor.pl
+++ b/status/monitor.pl
@@ -168,6 +168,11 @@ foreach $serv (@services) {
 			$suffix = "isdown";
 			$out = &run_on_command($serv, $serv->{'ondown'}, $r);
 			}
+		elsif ($warn == 3 && $up == 1) {
+			# Service is up now
+			$suffix = "isup";
+			$out = &run_on_command($serv, $serv->{'onup'}, $r);
+			}
 
 		# If something happened, notify people
 		if ($suffix &&


### PR DESCRIPTION
The purpose of this PR is to make the Webmin Scheduled Monitoring compatible with external services like https://healthchecks.io or https://deadmanssnitch.com/

A new option `As long as the service is up` is added: 

![image](https://user-images.githubusercontent.com/22446243/116260195-c3546680-a776-11eb-9b7b-0d4726b31c10.png)

With this option, a `ping` is sent every minutes to say _"Yes I'm still here"_.

![image](https://user-images.githubusercontent.com/22446243/116260581-18907800-a777-11eb-9cd2-13414fa1af72.png)

The big advantage of this logic is to be sure to receive a failure notification if no  _"Yes I'm still here"_ message arrives after few minutes.