### PR TITLE
Fix minor typo in twofactor help

### DIFF
--- a/webmin/help/twofactor.ca.html
+++ b/webmin/help/twofactor.ca.html
@@ -17,7 +17,7 @@ factors al mòdul d'<b>Usuaris de Webmin</b>. Els proveïdors disponibles són:
     un compte al lloc web d'Authy i enllaçar-lo al seu smartphone. <p>
 
 <dt><b>Google Authenticator</b>
-<dd>Aquesta és una aplicació que implementa el protocol estàndard TOPT.
+<dd>Aquesta és una aplicació que implementa el protocol estàndard TOTP.
     Cada usuari ha d'escanejar un codi QR utilitzant l'aplicació per enllaçar
     els seus testimonis amb el servidor Webmin. <p>
 

--- a/webmin/help/twofactor.fr.html
+++ b/webmin/help/twofactor.fr.html
@@ -11,6 +11,6 @@ Les fournisseurs à deux facteurs disponibles sont:<br>
             Chaque utilisateur doit créer un compte sur le site Web d'Authy et le lier à son smartphone.<br>
     <dt><br>
         <b>Google Authenticator</b>
-        <dd>Il s'agit d'une application pour smartphone qui implémente le protocole TOPT standard.<br>
+        <dd>Il s'agit d'une application pour smartphone qui implémente le protocole TOTP standard.<br>
             Chaque utilisateur doit scanner un code QR à l'aide de l'application pour lier ses jetons au serveur Webmin.<br>
 </dl>

--- a/webmin/help/twofactor.html
+++ b/webmin/help/twofactor.html
@@ -17,7 +17,7 @@ in the <b>Webmin Users</b> module. The available two-factor providers are :
     website and link it to their smartphone. <p>
 
 <dt><b>Google Authenticator</b>
-<dd>This is a smartphone app that implements the standard TOPT protocol. Each
+<dd>This is a smartphone app that implements the standard TOTP protocol. Each
     user must scan a QR code using the app to link their tokens with the
     Webmin server. <p>
 

--- a/webmin/help/twofactor.ms.html
+++ b/webmin/help/twofactor.ms.html
@@ -16,7 +16,7 @@ dalam modul <b>Webmin Pengguna</b>. Pembekal dua-faktor yang sedia ada ialah:
      untuk menguruskan pengguna dua-faktor. Setiap pengguna perlu mewujudkan akaun pada laman web   Authy dan menghubungkan kepada telefon pintar mereka. <p></dd>
 
 <dt><b>Pengesah Google</b></dt>
-<dd>Ini adalah satu aplikasi telefon pintar yang melaksanakan protokol TOPT standard. setiap
+<dd>Ini adalah satu aplikasi telefon pintar yang melaksanakan protokol TOTP standard. setiap
      pengguna perlu mengimbas kod QR dengan menggunakan aplikasi bagi menghubungkan token mereka dengan Pelayan Webmin. <p></dd>
 
 </dl>

--- a/webmin/help/twofactor.no.html
+++ b/webmin/help/twofactor.no.html
@@ -17,7 +17,7 @@ i <b> Webmin Brukere </ b> modulen. De tilgjengelige to-faktor-leverandører er 
      nettside og koble det til sin smarttelefon. <p>
 
 <dt><b>Google Authenticator</b>
-<dd>Dette er en smarttelefon-app som implementerer standarden TOPT protokollen. Hver
+<dd>Dette er en smarttelefon-app som implementerer standarden TOTP protokollen. Hver
      Brukeren må skanne en QR-kode ved hjelp av appen for å koble sine tokens med
      Webmin serveren.<p>
 

--- a/webmin/help/twofactor.pl.html
+++ b/webmin/help/twofactor.pl.html
@@ -20,7 +20,7 @@ Dostępni dostawcy dwustopniowego uwierzytelniania:
 
 <dt><b>Google Authenticator</b>
 <dd>Jest to aplikacja na smartfon, która implementuje standardowy protokół
-    TOPT. Każdy użytkownik musi zeskanować kod QR korzystając z aplikacji, aby
+    TOTP. Każdy użytkownik musi zeskanować kod QR korzystając z aplikacji, aby
     połączyć swój token z serwerem Webmina. <p>
 
 </dl>


### PR DESCRIPTION
Fix minor typo, correct term is TOTP?: TOPT -> TOTP