### PR TITLE
Add custom mysql backup parameters option

### DIFF
--- a/mysql/backup.pl
+++ b/mysql/backup.pl
@@ -98,6 +98,7 @@ foreach $db (@dbs) {
 				"root",
 				$config{'backup_single_'.$sf},
 				$config{'backup_quick_'.$sf},
+				$config{'backup_parameters_'.$sf}
 			       );
 	if ($err) {
 		$ex = 1;

--- a/mysql/backup_db.cgi
+++ b/mysql/backup_db.cgi
@@ -92,6 +92,7 @@ if ($module_info{'usermin'}) {
 	$userconfig{'backup_drop_'.$in{'db'}} = $in{'drop'};
 	$userconfig{'backup_single_'.$in{'db'}} = $in{'single'};
 	$userconfig{'backup_quick_'.$in{'db'}} = $in{'quick'};
+	$userconfig{'backup_parameters_'.$in{'db'}} = $in{'parameters'};
 	$userconfig{'backup_tables_'.$in{'db'}} = join(" ", @tables);
 	if ($in{'save'}) {
 		&save_user_module_config();
@@ -116,6 +117,7 @@ else {
 	$config{'backup_drop_'.$in{'db'}} = $in{'drop'};
 	$config{'backup_single_'.$in{'db'}} = $in{'single'};
 	$config{'backup_quick_'.$in{'db'}} = $in{'quick'};
+	$config{'backup_parameters_'.$in{'db'}} = $in{'parameters'};
 	$config{'backup_tables_'.$in{'db'}} = join(" ", @tables);
 	if ($in{'save'}) {
 		&save_module_config();
@@ -204,7 +206,7 @@ if (!$in{'save'}) {
 			$in{'drop'}, $in{'where_def'} ? undef : $in{'where'},
 			$in{'charset_def'} ? undef : $in{'charset'},
 			\@compat, \@tables, $access{'buser'}, $in{'single'},
-			$in{'quick'});
+			$in{'quick'}, $in{'parameters'});
 		if ($err) {
 			print &text('backup_ebackup',
 				"<pre>".&html_escape($err)."</pre>"),"<p>\n";

--- a/mysql/backup_form.cgi
+++ b/mysql/backup_form.cgi
@@ -150,6 +150,11 @@ $q = $c{'backup_quick_'.$in{'db'}};
 print &ui_table_row($text{'backup_quick'},
 	&ui_yesno_radio("quick", $q ? 1 : 0));
 
+# Allow user to specify custom backup parameters
+$b = $c{'backup_parameters_'.$in{'db'}};
+print &ui_table_row($text{'backup_parameters'},
+	&ui_textbox("parameters", $b, 60));
+
 if ($cron) {
 	# Show before/after commands
 	$b = $c{'backup_before_'.$in{'db'}};

--- a/mysql/lang/en
+++ b/mysql/lang/en
@@ -621,6 +621,7 @@ backup_none=All rows
 backup_drop=Add <tt>drop table</tt> statements to backup?
 backup_single=Backup within a transaction?
 backup_quick=Dump rows one at a time?
+backup_parameters=Add custom parameters to backup command?
 backup_charset=Character set for backup
 backup_ok=Backup Now
 backup_ok1=Save and Backup Now

--- a/mysql/mysql-lib.pl
+++ b/mysql/mysql-lib.pl
@@ -1439,13 +1439,13 @@ return $two eq "\037\213" ? 1 :
 
 # backup_database(db, dest-file, compress-mode, drop-flag, where-clause,
 #                 charset, &compatible, &only-tables, run-as-user,
-#                 single-transaction-flag, quick-flag, force-flag)
+#                 single-transaction-flag, quick-flag, parameters, force-flag)
 # Backs up a database to the given file, optionally with compression. Returns
 # undef on success, or an error message on failure.
 sub backup_database
 {
 local ($db, $file, $compress, $drop, $where, $charset, $compatible,
-       $tables, $user, $single, $quick, $force) = @_;
+       $tables, $user, $single, $quick, $parameters, $force) = @_;
 if ($compress == 0) {
 	$writer = "cat >".quotemeta($file);
 	}
@@ -1459,6 +1459,7 @@ local $dropsql = $drop ? "--add-drop-table" : "";
 local $singlesql = $single ? "--single-transaction" : "";
 local $forcesql = $force ? "--force" : "";
 local $quicksql = $quick ? "--quick" : "";
+local $parameterssql = $parameters ? quotemeta($parameters) : "";
 local $wheresql = $where ? "--where=".quotemeta($in{'where'}) : "";
 local $charsetsql = $charset ?
 	"--default-character-set=".quotemeta($charset) : "";
@@ -1482,7 +1483,7 @@ if ($user && $user ne "root") {
 	# Actual writing of output is done as another user
 	$writer = &command_as_user($user, 0, $writer);
 	}
-local $cmd = "$config{'mysqldump'} $authstr $dropsql $singlesql $forcesql $quicksql $wheresql $charsetsql $compatiblesql $quotingsql $routinessql ".quotemeta($db)." $tablessql $eventssql $gtidsql | $writer";
+local $cmd = "$config{'mysqldump'} $authstr $dropsql $singlesql $forcesql $quicksql $parameterssql $wheresql $charsetsql $compatiblesql $quotingsql $routinessql ".quotemeta($db)." $tablessql $eventssql $gtidsql | $writer";
 if (&shell_is_bash()) {
 	$cmd = "set -o pipefail ; $cmd";
 	}


### PR DESCRIPTION
Our database requires dumps to not have table locks wrapping each table.

Unfortunately I couldn't find an option to add `--skip-add-locks` to the backup command so I thought a custom parameter section might be useful for this and other use cases rather than trying to cater to each individual's requirements.