### PR TITLE
Add explicit notify type to Bind DNS zone config options

### DIFF
--- a/bind8/conf_zonedef.cgi
+++ b/bind8/conf_zonedef.cgi
@@ -133,6 +133,7 @@ print &ignore_warn_fail($text{'zonedef_cresponse'}, 'response',
 			$check{'response'});
 print &choice_input($text{'zonedef_notify'}, "notify", $mems,
 		    $text{'yes'}, "yes", $text{'no'}, "no",
+		    $text{'explicit'}, "explicit",
 		    $text{'default'}, undef);
 
 print &ui_table_end();

--- a/bind8/edit_options.cgi
+++ b/bind8/edit_options.cgi
@@ -30,6 +30,7 @@ print &choice_input($text{'master_check'}, "check-names", $zconf,
 		    $text{'ignore'}, "ignore", $text{'default'}, undef);
 print &choice_input($text{'master_notify'}, "notify", $zconf,
 		    $text{'yes'}, "yes", $text{'no'}, "no",
+		    $text{'explicit'}, "explicit",
 		    $text{'default'}, undef);
 
 print &address_input($text{'master_update'}, "allow-update", $zconf);

--- a/bind8/edit_soptions.cgi
+++ b/bind8/edit_soptions.cgi
@@ -49,6 +49,7 @@ print &choice_input($text{'slave_check'}, "check-names", $zconf,
 		    $text{'ignore'}, "ignore", $text{'default'}, undef);
 print &choice_input($text{'slave_notify'}, "notify", $zconf,
 		    $text{'yes'}, "yes", $text{'no'}, "no",
+		    $text{'explicit'}, "explicit",
 		    $text{'default'}, undef);
 
 print &addr_match_input($text{'slave_update'}, "allow-update", $zconf);


### PR DESCRIPTION
Per comments on issue #1536.

Adding the 'explicit' notify type to the zone config defaults and edit options for Bind for use in hidden-masters and other mixed horizon DNS setups.