### PR TITLE
Add `link-lib.pl` for module config not to fail

### DIFF
--- a/link/link-lib.pl
+++ b/link/link-lib.pl
@@ -1,0 +1,5 @@
+# link-lib.pl
+
+BEGIN { push(@INC, ".."); };
+use WebminCore;
+&init_config();


### PR DESCRIPTION
Currently config lib seems to require module's lib file to load and fails with an error: **`Require link/link-lib.pl failed : Died at (eval 300) line 1.`**

Once it opens access to module's config, I am not sure if that's the right change, so here is the PR.