### PR TITLE
Upgrade for cluster-usermin/upgrade.cgi

### DIFF
--- a/cluster-usermin/upgrade.cgi
+++ b/cluster-usermin/upgrade.cgi
@@ -95,10 +95,11 @@ if (`rpm -qp $file 2>&1` =~ /(^|\n)usermin-(\d+\.\d+)/) {
 	$mode = "rpm";
 	$version = $2;
 	}
-elsif (`dpkg --info $file 2>&1` =~ /Package:\s+usermin-(\d+\.\d+)/) {
+elsif (`dpkg --info $file 2>&1` =~ /Package:\s+usermin/) {
         # Looks like a Usermin Debian package
         $mode = "deb";
-        $version = $2;
+        `dpkg --info $file 2>&1` =~ /Version:\s+(\S+)/;
+        $version = $1;
         }
 else {
         # Check if it is a usermin tar.gz file


### PR DESCRIPTION
Upgrade for cluster-usermin/upgrade.cgi
Only done and tested on Debian GNU/Linux 10 (buster).

```
root@moloch:~# dpkg --info usermin_1.834_all.deb
 new Debian package, version 2.0.
 size 11051518 bytes: control archive=19090 bytes.
   43011 bytes,   889 lines      changelog
      19 bytes,     1 lines      conffiles
     987 bytes,    14 lines      control
    1734 bytes,    39 lines      copyright
    2927 bytes,   112 lines   *  postinst             #!/bin/sh
     315 bytes,     9 lines   *  postrm               #!/bin/sh
     895 bytes,    33 lines   *  preinst              #!/bin/sh
     553 bytes,    14 lines   *  prerm                #!/bin/sh
 Package: usermin
 Version: 1.834
 Section: admin
 Priority: optional
 Architecture: all
 Depends: perl, libnet-ssleay-perl, openssl, libauthen-pam-perl, libpam-runtime, libio-pty-perl, unzip, shared-mime-info, tar
 Pre-Depends: perl
 Installed-Size: 83336
 Maintainer: Jamie Cameron <jcameron@webmin.com>
 Provides: usermin
 Replaces: usermin-at, usermin-changepass, usermin-chfn, usermin-commands, usermin-cron, usermin-cshrc, usermin-fetchmail, usermin-forward, usermin-gnupg, usermin-htaccess, usermin-htpasswd, usermin-mailbox, usermin-man, usermin-mysql, usermin-plan, usermin-postgresql, usermin-proc, usermin-procmail, usermin-quota, usermin-schedule, usermin-shell, usermin-spamassassin, usermin-ssh, usermin-tunnel, usermin-updown, usermin-usermount, usermin-filemin, usermin-authentic-theme
 Description: web-based user account administration interface for Unix systems
   After installation, enter the URL http://localhost:20000/ into your browser
   and login as any user on your system.
root@moloch:~#
```