### PR TITLE
LetsEncrypt Staging URL update

### DIFF
--- a/webmin/letsencrypt-lib.pl
+++ b/webmin/letsencrypt-lib.pl
@@ -322,7 +322,7 @@ else {
 		($mode eq "web" ? "--acme-dir ".quotemeta($challenge)." "
 				: "--dns-hook $dns_hook ".
 				  "--cleanup-hook $cleanup_hook ").
-		($staging ? "--ca https://acme-staging.api.letsencrypt.org "
+		($staging ? "--ca https://acme-staging-v02.api.letsencrypt.org "
 			  : "--disable-check ").
 		"--quiet ".
 		"2>&1 >".quotemeta($cert));


### PR DESCRIPTION
LetsEncrypt staging URL changed per https://letsencrypt.org/docs/staging-environment/

The old URL `acme-staging.api.letsencrypt.org` in `letsencrypt-lib.pl` is showing as NXDOMAIN.