### PR TITLE
Add support for displaying service ports/protocols

### DIFF
--- a/firewalld/firewalld-lib.pl
+++ b/firewalld/firewalld-lib.pl
@@ -103,7 +103,7 @@ if (-r $service_file) {
 	}
 @ports = &unique(@ports);
 @protos = &unique(@protos);
-return {'ports' => join(":", @ports), 'protocols' => uc(join('/', @protos))};
+return {'ports' => join(", ", @ports), 'protocols' => uc(join('/', @protos))};
 }
 
 # list_firewalld_services_with_ports()
@@ -124,7 +124,6 @@ foreach my $s (&list_firewalld_services()) {
 		my $sports = $sportsprotos->{'ports'};
 		my $sprotocols = $sportsprotos->{'protocols'};
 		my $sdesc;
-		$sports =~ s/:/, /g;
 		$sdesc = " ($sports $sprotocols)" if ($sports);
 		push(@rv, [ $s, "$s$sdesc" ]);
 		}

--- a/firewalld/firewalld-lib.pl
+++ b/firewalld/firewalld-lib.pl
@@ -103,7 +103,7 @@ if (-r $service_file) {
 	}
 @ports = &unique(@ports);
 @protos = &unique(@protos);
-return {'ports' => join(" $service:", @ports), 'protocols' => uc(join('/', @protos))};
+return {'ports' => join(":", @ports), 'protocols' => uc(join('/', @protos))};
 }
 
 # list_firewalld_services_with_ports()
@@ -120,7 +120,13 @@ foreach my $s (&list_firewalld_services()) {
 		push(@rv, [ $s, $s." (".$n[2]." ".uc($n[3]).")" ]);
 		}
 	else {
-		push(@rv, [ $s, $s ]);
+		my $sportsprotos = &list_firewalld_service_desc($s);
+		my $sports = $sportsprotos->{'ports'};
+		my $sprotocols = $sportsprotos->{'protocols'};
+		my $sdesc;
+		$sports =~ s/:/, /g;
+		$sdesc = " ($sports $sprotocols)" if ($sports);
+		push(@rv, [ $s, "$s$sdesc" ]);
 		}
 	}
 return @rv;

--- a/firewalld/firewalld-lib.pl
+++ b/firewalld/firewalld-lib.pl
@@ -76,6 +76,36 @@ $out =~ s/\r|\n//g;
 return split(/\s+/, $out);
 }
 
+# list_firewalld_service_desc(service)
+# Returns a hashref of ports and protocols 
+# for in-built FirewallD service
+sub list_firewalld_service_desc
+{
+my ($service) = @_;
+$service =~ s/[^A-Za-z0-9\-]//g;
+# This is native way but too slow
+# my $out = &backquote_command("$config{'firewall_cmd'} --service=".quotemeta($service)." --get-ports --permanent </dev/null 2>&1");
+
+# Check for file in directory containing all services as xml files
+my $services_dir = "/usr/lib/firewalld/services/";
+my $service_file = "$services_dir/$service.xml";
+my @ports;
+my @protos;
+if (-r $service_file) {
+	my $lref = &read_file_lines($service_file, 1);
+	foreach my $l (@{$lref}) {
+		$l =~ /<port\s+protocol=["'](?<proto>\S+)["']\s+port=["'](?<port>\d+)["']\/>/;
+		my $port = "$+{port}";
+		my $proto = "$+{proto}";
+		push(@ports, $port) if ($port);
+		push(@protos, $proto) if ($port && $proto);
+		}
+	}
+@ports = &unique(@ports);
+@protos = &unique(@protos);
+return {'ports' => join(" $service:", @ports), 'protocols' => uc(join('/', @protos))};
+}
+
 # list_firewalld_services_with_ports()
 # Returns an array of service names and descriptions
 sub list_firewalld_services_with_ports

--- a/firewalld/index.cgi
+++ b/firewalld/index.cgi
@@ -85,7 +85,7 @@ if (@{$zone->{'services'}} || @{$zone->{'ports'}}) {
 		my $sportsprotos = &list_firewalld_service_desc($s);
 		my $sport = $sportsprotos->{'ports'};
 		my $sprotocols = $sportsprotos->{'protocols'};
-		$sport = "<span>:$sport</span>" if ($sport);
+		$sport = " ($sport)" if ($sport);
 		print &ui_checked_columns_row([
 			&ui_link($url, $text{'index_tservice'}),
 			&ui_link($url, "$s$sport"),

--- a/firewalld/index.cgi
+++ b/firewalld/index.cgi
@@ -99,7 +99,7 @@ if (@{$zone->{'services'}} || @{$zone->{'ports'}}) {
 		print &ui_checked_columns_row([
 			&ui_link($url, $text{'index_tport'}),
 			&ui_link($url, $port),
-			&ui_link($url, uc($proto)),
+			uc($proto),
 			], \@tds, "d", "port/".$p);
 		}
 	foreach my $f (@{$zone->{'forward-ports'}}) {

--- a/firewalld/index.cgi
+++ b/firewalld/index.cgi
@@ -82,10 +82,14 @@ if (@{$zone->{'services'}} || @{$zone->{'ports'}}) {
 	foreach my $s (@{$zone->{'services'}}) {
 		my $url = "edit_serv.cgi?id=".&urlize($s).
 			  "&zone=".&urlize($zone->{'name'});
+		my $sportsprotos = &list_firewalld_service_desc($s);
+		my $sport = $sportsprotos->{'ports'};
+		my $sprotocols = $sportsprotos->{'protocols'};
+		$sport = "<span>:$sport</span>" if ($sport);
 		print &ui_checked_columns_row([
 			&ui_link($url, $text{'index_tservice'}),
-			&ui_link($url, $s),
-			"",
+			&ui_link($url, "$s$sport"),
+			$sprotocols || "",
 			], \@tds, "d", "service/".$s);
 		}
 	foreach my $p (@{$zone->{'ports'}}) {


### PR DESCRIPTION
This improvement will make it clear what ports and protocols are implied for each service.

**Example:**

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/4426533/162592216-9118d9dd-8de1-4c55-a5c3-d6af265da2fc.png">
