### PR TITLE
Fix sensors fans info parsing missing

### DIFF
--- a/proc/linux-lib.pl
+++ b/proc/linux-lib.pl
@@ -510,6 +510,13 @@ if (&has_command("sensors")) {
         my ($cpu_fan_num, $cpu_fan_rpm) = $_ =~ /(?|fan([\d+])\s*:\s+([0-9]+)\s+rpm|cpu(\s)fan\s*:\s+([0-9]+)\s+rpm|cpu\s+fan\s*:\s+([0-9]+)\s+rpm)/i;
         $cpu++ if ($cpu_volt || $cpu_fan_num);
 
+        # First just store fan data for any device if any
+        push(@fans,
+                {  'fan' => &trim($cpu_fan_num),
+                   'rpm' => $cpu_fan_rpm
+                }
+        ) if ($cpu_fan_num);
+
         # CPU package
         ($cpu_package) = $_ =~ /(?|(package\s+id\s+[\d]+)|(coretemp-[a-z]+-[\d]+))/i
           if (!$cpu_package);
@@ -548,13 +555,6 @@ if (&has_command("sensors")) {
             # CPU types
             ($cpu_broadcom) = $_ =~ /cpu_thermal-virtual-[\d]+/i if (!$cpu_broadcom);
             ($cpu_amd)      = $_ =~ /\w[\d]{2}temp-pci/i         if (!$cpu_amd);
-
-            # First just store fan data for any device if any
-            push(@fans,
-                 {  'fan' => &trim($cpu_fan_num),
-                    'rpm' => $cpu_fan_rpm
-                 }
-            ) if ($cpu_fan_num);
 
             # Full CPU output #1253
             if ($cpu) {


### PR DESCRIPTION
## Problem
When parsing the `sensors` command output, the fans information was not stored in the `@fans` array if `$cpu_package` is set.

## Solution
Moved the push fans data outside the `if`/`else`.

\
Example of `sensors` output that failed to store the fans info:
```
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +27.0°C  (high = +80.0°C, crit = +100.0°C)
Core 0:        +25.0°C  (high = +80.0°C, crit = +100.0°C)
Core 1:        +25.0°C  (high = +80.0°C, crit = +100.0°C)
Core 2:        +27.0°C  (high = +80.0°C, crit = +100.0°C)
Core 3:        +24.0°C  (high = +80.0°C, crit = +100.0°C)

nct6798-isa-0290
Adapter: ISA adapter
in0:                   704.00 mV (min =  +0.00 V, max =  +1.74 V)
in1:                     1.68 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in2:                     3.44 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in3:                     3.36 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in4:                     1.02 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in5:                     1.07 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in6:                     1.35 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in7:                     3.42 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in8:                     3.12 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in9:                   536.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in10:                   88.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in11:                  536.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in12:                    1.02 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in13:                    1.28 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in14:                    1.06 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
fan1:                   956 RPM  (min =    0 RPM)
fan2:                   513 RPM  (min =    0 RPM)
fan3:                     0 RPM  (min =    0 RPM)
fan4:                     0 RPM  (min =    0 RPM)
fan5:                     0 RPM  (min =    0 RPM)
fan6:                   954 RPM  (min =    0 RPM)
fan7:                  1001 RPM  (min =    0 RPM)
SYSTIN:                 +29.0°C  (high = +36.0°C, hyst = +35.0°C)  sensor = thermistor
CPUTIN:                 +28.0°C  (high = +36.0°C, hyst = +35.0°C)  sensor = thermistor
AUXTIN0:                 +8.0°C    sensor = thermistor
AUXTIN1:               +103.0°C    sensor = thermistor
AUXTIN2:                +22.0°C    sensor = thermistor
AUXTIN3:                +22.0°C    sensor = thermistor
PECI Agent 0:           +28.0°C  (high = +36.0°C, hyst = +35.0°C)
                                 (crit = +100.0°C)
PCH_CHIP_CPU_MAX_TEMP:   +0.0°C
PCH_CHIP_TEMP:           +0.0°C
PCH_CPU_TEMP:            +0.0°C
intrusion0:            ALARM
intrusion1:            ALARM
beep_enable:           disabled
```