### PR TITLE
Fix to consider Webmin privileged user

### DIFF
--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -12125,8 +12125,9 @@ sub webmin_user_is_admin
 my ($user) = @_;
 $user ||= $base_remote_user;
 my %access = &get_module_acl($user, "");
-return 1 if ($access{'rpc'} >= 1);	# Can make arbitary RPC calls
-return 0 if ($access{'rpc'} == 0);	# Cannot make RPCs
+return 1 if ($access{'rpc'} >= 1);   # Can make arbitary RPC calls
+return 0 if ($access{'rpc'} == 0);   # Cannot make RPCs
+return 0 if ($access{'_safe'} == 1); # Safe user explicitly not allowed
 
 # Assume that standard admin usernames are root-capable as a fallback
 return $user eq 'admin' || $user eq 'root' || $user eq 'sysadm';

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -12125,7 +12125,7 @@ sub webmin_user_is_admin
 my ($user) = @_;
 $user ||= $base_remote_user;
 my %access = &get_module_acl($user, "");
-return 1 if ($access{'rpc'} == 1);	# Can make arbitary RPC calls
+return 1 if ($access{'rpc'} >= 1);	# Can make arbitary RPC calls
 return 0 if ($access{'rpc'} == 0);	# Cannot make RPCs
 
 # Assume that standard admin usernames are root-capable as a fallback


### PR DESCRIPTION
This is a better way of doing this. [Previous PR](https://github.com/webmin/webmin/pull/1647/files) is probably less secure, unless you added `_safe` flag at the same time when adding this feature?