### PR TITLE
Add Webmin to support system default hashing format

### DIFF
--- a/acl/acl-lib.pl
+++ b/acl/acl-lib.pl
@@ -1693,7 +1693,7 @@ else {
 	# Try detecting system default first
 	if (&foreign_available('useradmin')) {
 		&foreign_require('useradmin');
-		return &useradmin::encrypt_password($pass, $salt, 'force_system_detection');
+		return &useradmin::encrypt_password($pass, $salt, 1);
 		}
 	else {
 		# Use Unix DES

--- a/acl/acl-lib.pl
+++ b/acl/acl-lib.pl
@@ -1690,10 +1690,17 @@ elsif ($mode == 2) {
 	return &encrypt_sha512($pass, $salt);
 	}
 else {
-	# Use Unix DES
-	&seed_random();
-	$salt ||= chr(int(rand(26))+65).chr(int(rand(26))+65);
-	return &unix_crypt($pass, $salt);
+	# Try detecting system default first
+	if (&foreign_available('useradmin')) {
+		&foreign_require('useradmin');
+		return &useradmin::encrypt_password($pass, $salt);
+		}
+	else {
+		# Use Unix DES
+		&seed_random();
+		$salt ||= chr(int(rand(26))+65).chr(int(rand(26))+65);
+		return &unix_crypt($pass, $salt);
+		}
 	}
 }
 

--- a/acl/acl-lib.pl
+++ b/acl/acl-lib.pl
@@ -1693,7 +1693,7 @@ else {
 	# Try detecting system default first
 	if (&foreign_available('useradmin')) {
 		&foreign_require('useradmin');
-		return &useradmin::encrypt_password($pass, $salt);
+		return &useradmin::encrypt_password($pass, $salt, 'force_system_detection');
 		}
 	else {
 		# Use Unix DES

--- a/bin/passwd
+++ b/bin/passwd
@@ -5,9 +5,12 @@ use strict;
 use warnings;
 use 5.010;
 
+use File::Basename;
 use Getopt::Long;
 use Pod::Usage;
 use Term::ANSIColor qw(:constants);
+use lib (dirname(dirname($0)));
+use WebminCore;
 
 sub main
 {
@@ -47,28 +50,11 @@ sub change_password
 {
     my ($optref) = @_;
     my ($minserv_uconf_file, %lusers, @users, %uinfos, %ulines);
-    my $user             = $optref->{'user'};
-    my $pass             = $optref->{'password'};
-    my $confdif          = $optref->{'config'};
-    my $conf             = "$confdif/config";
-    my $mconf            = "$confdif/miniserv.conf";
-    my $encrypt_password = sub {
-        my ($pass, $gconfig) = @_;
-        if ($gconfig->{'md5pass'} == 1) {
-
-            # Use MD5 encryption
-            return &encrypt_md5($pass);
-        } elsif ($gconfig->{'md5pass'} == 2) {
-
-            # Use SHA512 encryption
-            return &encrypt_sha512($pass);
-        } else {
-
-            # Use Unix DES
-            srand(time() ^ $$);
-            return crypt($pass, chr(int(rand(26)) + 65) . chr(int(rand(26)) + 65));
-        }
-    };
+    my $user       = $optref->{'user'};
+    my $pass       = $optref->{'password'};
+    my $confdif    = $optref->{'config'};
+    my $conf       = "$confdif/config";
+    my $mconf      = "$confdif/miniserv.conf";
     my $conf_check = sub {
         my ($configs) = @_;
         foreach my $config (@{$configs}) {
@@ -79,11 +65,46 @@ sub change_password
             }
         }
     };
-    my $root = root($confdif, \&$conf_check);
+    my $root             = root($confdif, \&$conf_check);
+    my $encrypt_password = sub {
+        my ($pass, $gconfig, $config) = @_;
+        my $root = root($confdif, \&$conf_check);
 
-    # Load libs
-    do "$root/acl/md5-lib.pl";
-    do "$root/web-lib-funcs.pl";
+        # Use pre-defined encryption (forced by Webmin config)
+        if ($gconfig->{'md5pass'} == 1 ||
+            $gconfig->{'md5pass'} == 2)
+        {
+            do "$root/acl/md5-lib.pl";
+
+            # Use MD5 encryption
+            return &encrypt_md5($pass) if ($gconfig->{'md5pass'}) == 1;
+
+            # Use SHA512 encryption
+            return &encrypt_sha512($pass) if ($gconfig->{'md5pass'}) == 2;
+
+        } else {
+
+            # Try detecting system default first
+            my $module = 'useradmin';
+            if (-d "$root/$module") {
+                $ENV{'PERLLIB'}                = "$root";
+                $ENV{'WEBMIN_CONFIG'}          = "$confdif";
+                $ENV{'FOREIGN_ROOT_DIRECTORY'} = "$root/$module";
+                $ENV{'FOREIGN_MODULE_NAME'}    = "$module";
+                chdir("$root/$module");
+                require "$root/useradmin/user-lib.pl";
+
+                # We need to set third parameter to make sure useradmin's config
+                # won't be used for hashing format, as we need to auto detect it
+                return &encrypt_password($pass, undef, 'force_system_detection');
+            } else {
+
+                # Use old Unix DES
+                srand(time() ^ $$);
+                return crypt($pass, chr(int(rand(26)) + 65) . chr(int(rand(26)) + 65));
+            }
+        }
+    };
 
     # Check for main config and miniserv config files
     &$conf_check([$conf, $mconf]);
@@ -138,7 +159,7 @@ sub change_password
     }
 
     # Update with new password and store timestamp
-    $uinfos{$user}->[0] = &$encrypt_password($pass, \%gconfig);
+    $uinfos{$user}->[0] = &$encrypt_password($pass, \%gconfig, \%config);
     $uinfos{$user}->[5] = time() if ($uinfos{$user}->[5]);
     map {$ulines{$_} = join(":", @{ $uinfos{$_} })} keys %uinfos;
 


### PR DESCRIPTION
As discussed here https://github.com/webmin/webmin/issues/1653, we **must not use** MD5 by default. The point is to let Webmin try to use default hashing format using `crypt`.

The good thing with this patch, that each system will use for Webmin user passwords a hashing format  that it suggests. For example, Debian 10 will use _SHA512_, while Ubuntu 22.04 will use _yescrypt_ automatically.

Also, we would need to set `md5pass=0` in `/etc/webmin/config` to make it default and work automatically.