### PR TITLE
Fix to use reload over restart when possible

### DIFF
--- a/acl/backup_config.pl
+++ b/acl/backup_config.pl
@@ -98,7 +98,7 @@ foreach my $k (keys %aclbackup) {
 	}
 &put_miniserv_config(\%miniserv);
 
-&restart_miniserv();
+&reload_miniserv();
 return undef;
 }
 

--- a/acl/convert.cgi
+++ b/acl/convert.cgi
@@ -139,7 +139,7 @@ print &ui_columns_end();
 
 # Finish off
 &modify_group($group->{'name'}, $group);
-&restart_miniserv();
+&reload_miniserv();
 
 # Print summary
 print &text('convert_done', $converted, $invalid, $exists, $skipped),"<p>\n";

--- a/acl/save_unix.cgi
+++ b/acl/save_unix.cgi
@@ -76,7 +76,7 @@ $miniserv{'pamany'} = $in{'pamany'} ? $in{'pamany_user'} : undef;
 &put_miniserv_config(\%miniserv);
 &unlock_file($ENV{'MINISERV_CONFIG'});
 if ($oldsudo != $in{'sudo'}) {
-	&restart_miniserv();
+	&reload_miniserv();
 	}
 else {
 	&reload_miniserv();

--- a/cluster-usermin/sync.cgi
+++ b/cluster-usermin/sync.cgi
@@ -119,7 +119,7 @@ foreach $host (@phosts) {
 		print "$text{'sync_restart'}<br>\n";
 		if (!$in{'test'}) {
 			&remote_foreign_call($serv->{'host'}, "acl",
-					     "restart_miniserv");
+					     "reload_miniserv");
 			}
 		print "$text{'refresh_done'}<p>\n";
 

--- a/cluster-webmin/create_group.cgi
+++ b/cluster-webmin/create_group.cgi
@@ -89,7 +89,7 @@ foreach $h (@hosts) {
 
 		# Restart the remote webmin
 		print $wh &serialise_variable([ 1 ]);
-		&remote_foreign_call($s->{'host'}, "acl", "restart_miniserv");
+		&remote_foreign_call($s->{'host'}, "acl", "reload_miniserv");
 		exit;
 		}
 	close($wh);

--- a/cluster-webmin/create_user.cgi
+++ b/cluster-webmin/create_user.cgi
@@ -123,7 +123,7 @@ foreach $h (@hosts) {
 
 		# Restart the remote webmin
 		print $wh &serialise_variable([ 1 ]);
-		&remote_foreign_call($s->{'host'}, "acl", "restart_miniserv");
+		&remote_foreign_call($s->{'host'}, "acl", "reload_miniserv");
 		exit;
 		}
 	close($wh);

--- a/cluster-webmin/delete_group.cgi
+++ b/cluster-webmin/delete_group.cgi
@@ -95,7 +95,7 @@ foreach $h (@hosts) {
 
 		# Restart the remote webmin
 		print $wh &serialise_variable([ 1 ]);
-		&remote_foreign_call($s->{'host'}, "acl", "restart_miniserv");
+		&remote_foreign_call($s->{'host'}, "acl", "reload_miniserv");
 		exit;
 		}
 	close($wh);

--- a/cluster-webmin/delete_user.cgi
+++ b/cluster-webmin/delete_user.cgi
@@ -59,7 +59,7 @@ foreach $h (@hosts) {
 
 		# Restart the remote webmin
 		print $wh &serialise_variable([ 1 ]);
-		&remote_foreign_call($s->{'host'}, "acl", "restart_miniserv");
+		&remote_foreign_call($s->{'host'}, "acl", "reload_miniserv");
 		exit;
 		}
 	close($wh);

--- a/cluster-webmin/save_group.cgi
+++ b/cluster-webmin/save_group.cgi
@@ -143,7 +143,7 @@ foreach $h (@hosts) {
 
 		# Restart the remote webmin
 		print $wh &serialise_variable([ 1 ]);
-		&remote_foreign_call($s->{'host'}, "acl", "restart_miniserv");
+		&remote_foreign_call($s->{'host'}, "acl", "reload_miniserv");
 		exit;
 		}
 	close($wh);

--- a/cluster-webmin/save_user.cgi
+++ b/cluster-webmin/save_user.cgi
@@ -179,7 +179,7 @@ foreach $h (@hosts) {
 
 		# Restart the remote webmin
 		print $wh &serialise_variable([ 1 ]);
-		&remote_foreign_call($s->{'host'}, "acl", "restart_miniserv");
+		&remote_foreign_call($s->{'host'}, "acl", "reload_miniserv");
 		exit;
 		}
 	close($wh);

--- a/itsecur-firewall/restore.cgi
+++ b/itsecur-firewall/restore.cgi
@@ -135,7 +135,7 @@ foreach $w (@what) {
 			}
 		&unlock_file("$config_directory/miniserv.users");
 		&unlock_file("$config_directory/webmin.acl");
-		&restart_miniserv();
+		&reload_miniserv();
 		}
 	elsif ($w eq "searches") {
 		# Copy searches directory

--- a/itsecur-firewall/save_user.cgi
+++ b/itsecur-firewall/save_user.cgi
@@ -108,7 +108,7 @@ else {
 		}
 	&save_module_acl(\%uaccess, $in{'name'});
 	}
-&acl::restart_miniserv();
+&acl::reload_miniserv();
 &unlock_itsecur_files();
 &remote_webmin_log($in{'delete'} ? "delete" : $in{'new'} ? "create" : "update",
 	    "user", $user->{'name'}, $user);

--- a/time/save_timezone.cgi
+++ b/time/save_timezone.cgi
@@ -8,7 +8,7 @@ $access{'timezone'} || &error($text{'timezone_ecannot'});
 &error_setup($text{'timezone_err'});
 $in{'zone'} || &error($text{'timezone_enone'});
 &set_current_timezone($in{'zone'});
-&restart_miniserv();
+&reload_miniserv();
 &webmin_log("timezone", undef, $in{'zone'});
 &redirect("index.cgi?mode=zone");
 

--- a/webmin/backup_config.pl
+++ b/webmin/backup_config.pl
@@ -77,7 +77,7 @@ foreach my $k (keys %oldconfig) {
 &write_file("$config_directory/config", \%gconfig);
 
 unlink("$config_directory/module.infos.cache");
-&restart_miniserv();
+&reload_miniserv();
 return undef;
 }
 


### PR DESCRIPTION
Using restart required for changing binds and re-reading `userfile` and `keyfile`.

Re-reading ACLs, user files and etc works with _reload_.