### PR TITLE
Add new `webmin server` command to control `miniserv`

### DIFF
--- a/bin/disable-proxy
+++ b/bin/disable-proxy
@@ -129,7 +129,7 @@ Disable proxy-related features in Webmin.
 
 =head1 SYNOPSIS
 
-disable-proxy [options]
+webmin disable-proxy [options]
 
 =head1 OPTIONS
 
@@ -146,14 +146,8 @@ C</etc/webmin>
 
 =back
 
-=head1 EXIT CODES
-
-0 on success
-
-non-0 on error
-
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2018 Jamie Cameron <jcameron@webmin.com>, Joe Cooper
-<joe@virtualmin.com>.
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>
 

--- a/bin/disable-twofactor
+++ b/bin/disable-twofactor
@@ -87,7 +87,7 @@ second factor (e.g. phone or USB key) has been lost.
 
 =head1 SYNOPSIS
 
-disable-twofactor --user username
+webmin disable-twofactor --user username
 
 =head1 OPTIONS
 
@@ -106,16 +106,13 @@ C</etc/webmin>
 
 Name of the user to disable two-factor authentication for.
 
+
+
 =back
-
-=head1 EXIT CODES
-
-0 on successfully replacing configuration options
-
-non-0 on error
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2018 Jamie Cameron <jcameron@webmin.com>, Joe Cooper
-<joe@virtualmin.com>.
 
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>
+                Ilia Rostovtsev <ilia@virtualmin.com>

--- a/bin/enable-proxy
+++ b/bin/enable-proxy
@@ -134,7 +134,7 @@ Configure the Webmin web server to be proxied through another web server, like A
 
 =head1 SYNOPSIS
 
-enable-proxy [options]
+webmin enable-proxy [options]
 
 =head1 OPTIONS
 
@@ -161,14 +161,7 @@ domain.tld)
 
 =back
 
-=head1 EXIT CODES
-
-0 on success
-
-non-0 on error
-
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2018 Jamie Cameron <jcameron@webmin.com>, Joe Cooper
-<joe@virtualmin.com>.
-
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>

--- a/bin/language-manager
+++ b/bin/language-manager
@@ -1784,7 +1784,7 @@ Manage Webmin/Usermin module language files (lang|ulang|help|config|uconfig|modu
 
 =head1 SYNOPSIS
 
-language-manager [options]
+webmin language-manager [options]
 
 =head1 OPTIONS
 
@@ -1798,35 +1798,35 @@ Examples of usage:
 
 Synchronize all language keys for Apache module, based on template language. Newly added entries to Apache template language file (def. en), will be translated and inserted into all other machine translated language files, while deleted entries will also be removed on all targets (translations), including human translated files. The value for "defines_desc" will be force re-translated and translation will be done in HTML format. 
 
- - language-manager -m=apache -kft=defines_desc -kfh=defines_desc
+ - webmin language-manager -m=apache -kft=defines_desc -kfh=defines_desc
 
 Synchronize all modules' "help/" language files. Newly added files will be translated and already translated, both human and machine translations, will be kept intact.
 
- - language-manager -w=help
+ - webmin language-manager -w=help
 
 Check for Software Packages module, all matching escaped HTML "&lt;" and "&gt;" entities in template file (def. en), and if found, make sure that translations (including machine translations) for the same key, contain exact escaped HTML entities, as on template string, rather than "<" or ">". Technically, it's possible to check and replace anything on language files using this command.
 
- - language-manager -vf="&lt;:<,&gt;:>" -m=software
+ - webmin language-manager -vf="&lt;:<,&gt;:>" -m=software
 
 Translate all available languages, using old-time encoding map, for BIND module, using as type "lang" directory, discarding human translations for Hebrew, keeping original value (not translating) for key "mass_desc", and printing verbose output.
 
- - language-manager -x=full -e=map -m=bind8 -w=lang -se=he -ke=mass_desc
+ - webmin language-manager -x=full -e=map -m=bind8 -w=lang -se=he -ke=mass_desc
 
 Transcode only and rename all modules' "help/" old-time format files. Old files, such as "ja_JP.euc.html", "ko_KR.euc.html", "zh_TW.Big5.html" and "ru_RU.html" will be automatically renamed and/or deleted.
 
- - language-manager -w=help -e=map -ot
+ - webmin language-manager -w=help -e=map -ot
 
 Only transcode language files, using old-time encoding map, from files being in different encodings, to new style, where all language files are in "utf-8" encoding, for Apache module. No translations will be made, and no ".auto" files will be created.
 
- - language-manager -x=full -e=map -m=apache -ot
+ - webmin language-manager -x=full -e=map -m=apache -ot
 
 Repare human translated language files, which stored in "utf-8" encoding already but still have HTML entities.
 
- - language-manager -m=virtual-server -t=no,es -x=transcode
+ - webmin language-manager -m=virtual-server -t=no,es -x=transcode
 
 Test translations for "index_stopmsg,trusted_warning" keys, in Russian and German languages, in BIND module, print on-screen results and exit.
 
- - language-manager -m=bind8 -t=ru,de -kt=index_stopmsg,trusted_warning
+ - webmin language-manager -m=bind8 -t=ru,de -kt=index_stopmsg,trusted_warning
 
 =item --mode, -x <sync|full|transcode>
 

--- a/bin/list-config
+++ b/bin/list-config
@@ -165,7 +165,7 @@ List one or all configuration directives for C<miniserv.conf> or a module C<conf
 
 =head1 SYNOPSIS
 
-list-config [options]
+webmin list-config [options]
 
 =head1 OPTIONS
 
@@ -192,16 +192,11 @@ Specify a single option to display. By default, the entire configuration file wi
 
 Display the description of the option from the module C<config.info> file, instead of it's current value. This option is only available for modules, as miniserv.conf does not have a config.info.
 
+
+
 =back
-
-=head1 EXIT CODES
-
-0 on success
-
-non-0 on error
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2018 Jamie Cameron <jcameron@webmin.com>, Joe Cooper
-<joe@virtualmin.com>.
-
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>

--- a/bin/passwd
+++ b/bin/passwd
@@ -209,15 +209,15 @@ sub root
 
 =head1 NAME
 
-passwd
+ passwd
 
 =head1 DESCRIPTION
 
-This program allows you to change the password of a user in the Webmin password file
+ This program allows you to change the password of a user in the Webmin password file
 
 =head1 SYNOPSIS
 
-passwd [options]
+ webmin passwd [options]
 
 =head1 OPTIONS
 
@@ -225,37 +225,31 @@ passwd [options]
 
 =item --help, -h
 
-Print this usage summary and exit.
+ Print this usage summary and exit.
 
-Examples of usage:
-
- - passwd root
-
- - passwd --user root
- 
- - passwd --user root --password ycwyMQRVAZY
- 
- - passwd --config /usr/local/etc/webmin --user root --password ycwyMQRVAZY
+ Examples of usage:
+  - webmin passwd root
+  - webmin passwd --user root
+  - webmin passwd --user root --password ycwyMQRVAZY
+  - webmin passwd --config /usr/local/etc/webmin --user root --password ycwyMQRVAZY
 
 =item --config, -c
 
-Specify the full path to the Webmin configuration directory. Defaults to C</etc/webmin>
+ Specify the full path to the Webmin configuration directory. Defaults to C</etc/webmin>
 
 =item --user, -u
 
-Existing Webmin user to change password for
+ Existing Webmin user to change password for
 
 =item --password, -p
 
 Set new user password. Using this option may be unsecure.
 
-
-
 =back
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2021 Jamie Cameron <jcameron@webmin.com>
-               Joe Cooper <joe@virtualmin.com>
-               Ilia Rostovtsev <ilia@virtualmin.com>
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>
+                Ilia Rostovtsev <ilia@virtualmin.com>
 

--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,183 @@
+#!/usr/bin/env perl
+# server - control Webmin web-server
+
+use strict;
+use warnings;
+use 5.010;
+
+use File::Basename;
+use Getopt::Long;
+use Pod::Usage;
+use Term::ANSIColor qw(:constants);
+use lib (dirname(dirname($0)));
+use WebminCore;
+
+sub main
+{
+    my %opt;
+    GetOptions('help|h'      => \$opt{'help'},
+               'command|x=s' => \$opt{'command'},
+               'config|c=s'  => \$opt{'config'});
+
+    # If username passed as regular param
+    my $cmd = scalar(@ARGV) == 1 && $ARGV[0];
+    $cmd = $opt{'command'} if ($opt{'command'});
+    if ($cmd !~ /^(status|start|stop|restart|reload|force-restart|force-reload|kill)$/) {
+        $cmd = undef;
+    }
+
+    # Show usage
+    pod2usage(0) if ($opt{'help'} || !$cmd);
+
+    # Assign defaults
+    $opt{'config'} ||= "/etc/webmin";
+    $opt{'cmd'} = $cmd;
+
+    # Catch kill signal
+    my $sigkill = sub {
+        system("stty echo");
+        print "\n^C";
+        print "\n";
+        exit 1;
+    };
+    $SIG{INT} = \&$sigkill;
+
+    # Run change password command
+    run(\%opt);
+
+    return 0;
+}
+exit main(\@ARGV) if !caller(0);
+
+sub run
+{
+    my ($o) = @_;
+    my $conf_check = sub {
+        my ($configs) = @_;
+        foreach my $config (@{$configs}) {
+            if (!-r $config) {
+                say BRIGHT_RED, "Error: ", RESET, "Failed to read Webmin essential config file: ", BRIGHT_YELLOW, $config,
+                  RESET, " doesn't exist";
+                exit 1;
+            }
+        }
+    };
+    root($o->{'config'}, \&$conf_check);
+    my $service = ($o->{'config'} =~ /usermin/ ? 'usermin' : 'webmin');
+    my $systemctlcmd = `which systemctl`;
+    $systemctlcmd =~ s/\s+$//;
+    if ($o->{'cmd'} =~ /^(start|stop|restart|reload)$/) {
+        my $rs = system("$o->{'config'}/$o->{'cmd'} $service");
+        exit $rs;
+    }
+    if ($o->{'cmd'} =~ /^(kill|force-kill)$/) {
+        my $rs;
+        if (-x $systemctlcmd) {
+            $rs = system("$systemctlcmd stop $service");
+            $rs = system("$systemctlcmd kill -s SIGTERM $service");
+        }
+        $rs = system("$o->{'config'}/.stop-init --kill >/dev/null 2>&1 $service");
+        exit $rs;
+    }
+    if ($o->{'cmd'} =~ /^(force-reload|force-restart)$/) {
+        my $rs = system("$o->{'config'}/restart-by-force-kill $service");
+        exit $rs;
+    }
+    if ($o->{'cmd'} =~ /^(status)$/) {
+        my $rs;
+        if (-x $systemctlcmd) {
+            $rs = system("$systemctlcmd status $service");
+        } else {
+            $rs = system("service $service status");
+        }
+        exit $rs;
+    }
+    exit 0;
+}
+
+sub root
+{
+    my ($config, $conf_check) = @_;
+    my $mconf = "$config/miniserv.conf";
+    $conf_check->([$mconf]);
+    open(my $CONF, "<", $mconf);
+    my $root;
+    while (<$CONF>) {
+        if (/^root=(.*)/) {
+            $root = $1;
+        }
+    }
+    close($CONF);
+
+    # Does the Webmin root exist?
+    if ($root) {
+        die BRIGHT_RED, "Error: ", BRIGHT_YELLOW, $root, RESET, " is not a directory\n" unless (-d $root);
+    } else {
+
+        # Try to guess where Webmin lives, since config file didn't know.
+        die BRIGHT_RED, "Error: ", RESET, "Unable to determine Webmin installation directory\n";
+    }
+
+    return $root;
+}
+
+1;
+
+=pod
+
+=head1 NAME
+
+ server
+
+=head1 DESCRIPTION
+
+ This program allows you to control Webmin web-server
+
+=head1 SYNOPSIS
+
+ webmin server [command]
+ webmin [command]
+
+=head1 OPTIONS
+
+=over
+
+=item --help, -h
+
+ Print this usage summary and exit.
+
+ Examples of usage:
+   - webmin server status
+   - webmin server restart
+   - webmin server --config /usr/local/etc/webmin --command start
+   - webmin status
+   - webmin restart
+
+=item --config, -c
+
+ Specify the full path to the Webmin configuration directory. Defaults to C</etc/webmin>
+
+=item --command, -x
+
+ Available commands:
+   - status
+   - start
+   - stop
+   - restart
+   - reload
+   - force-restart
+   - force-reload
+   - kill
+
+ Alias commands:
+   - force-restart | force-reload
+   - kill | force-kill
+
+=back
+
+=head1 LICENSE AND COPYRIGHT
+
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>
+                Ilia Rostovtsev <ilia@virtualmin.com>
+

--- a/bin/set-config
+++ b/bin/set-config
@@ -136,7 +136,7 @@ Set a configuration directive in either C<miniserv.conf> (the core Webmin config
 
 =head1 SYNOPSIS
 
-set-config [options] [--module] --option <option-name> --value <value>
+webmin set-config [options] [--module] --option <option-name> --value <value>
 
 =head1 OPTIONS
 
@@ -180,6 +180,5 @@ already exist in the file, and was added)
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2018 Jamie Cameron <jcameron@webmin.com>, Joe Cooper
-<joe@virtualmin.com>.
-
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>

--- a/bin/webmin
+++ b/bin/webmin
@@ -12,6 +12,8 @@ use Term::ANSIColor qw(:constants);
 use File::Spec;
 use File::Basename;
 
+my $a0 = $ARGV[0];
+
 sub main {
     my ( %opt, $subcmd );
     GetOptions(
@@ -37,6 +39,7 @@ sub main {
     );
 
     $opt{'config'} ||= "/etc/webmin";
+    $opt{'commands'} = $a0;
 
     my @remain = @ARGV;
     # List commands?
@@ -203,7 +206,7 @@ sub run_command {
         exit 1;
     }
 
-    my $command_path = get_command_path($root, $subcmd);
+    my $command_path = get_command_path($root, $subcmd, $optref);
     
     # Merge the options
     # Only handling config, right now...
@@ -223,7 +226,7 @@ sub run_command {
 }
 
 sub get_command_path {
-    my ($root, $subcmd) = @_;
+    my ($root, $subcmd, $optref) = @_;
     # Check for a root-level command (in "$root/bin")
     my $command_path;
     if ($subcmd) {
@@ -256,11 +259,13 @@ sub get_command_path {
             }
         }
     }
-
-    if ($command) {
+    if ($optref->{'commands'} && 
+        $optref->{'commands'} =~ /^(status|start|stop|restart|reload|force-restart|force-reload|kill)$/) {
+        exit system("$0 server $optref->{'commands'}");
+    } elsif ($command) {
         return $command;
     } else {
-        die RED, "Unrecognized subcommand: $subcmd", RESET;
+        die RED, "Unrecognized subcommand: $subcmd", RESET , "\n";
     }
 }
 
@@ -325,7 +330,7 @@ sub man_command {
     my ($optref, $subcmd) = @_;
 
     my $root = root($optref->{'config'});
-    my $command_path = get_command_path($root, $subcmd);
+    my $command_path = get_command_path($root, $subcmd, $optref);
 
     $ENV{'PAGER'} ||= "more";
     open(my $PAGER, "|-", "$ENV{'PAGER'}");
@@ -412,14 +417,11 @@ Returns Webmin and other modules and themes versions installed (only those for w
 
 =head1 EXIT CODES
 
-0 on success
-
-non-0 on error
+0 on success ; non-0 on error
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2022 
-        Jamie Cameron <jamie@virtualmin.com>, 
-        Joe Cooper <joe@virtualmin.com>,
-        Ilia Rostovtsev <ilia@virtualmin.com>.
+ Copyright 2022 Jamie Cameron <jcameron@webmin.com>
+                Joe Cooper <joe@virtualmin.com>
+                Ilia Rostovtsev <ilia@virtualmin.com>
 


### PR DESCRIPTION
This PR made to draw attention and doesn't need to be reviewed.

New Webmin 1.995 will have a new `webmin` CLI sub-command to control Webmin web-server, for example:

```
webmin restart
```

or 


```
webmin status
```

The full command description is available by running `webmin server -h`, i.e.:

```Bash
Usage:
     webmin server [command]
     webmin [command]

Options:
    --help, -h
         Print this usage summary and exit.

         Examples of usage:
           - webmin server status
           - webmin server restart
           - webmin server --config /usr/local/etc/webmin --command start
           - webmin status
           - webmin restart

    --config, -c
         Specify the full path to the Webmin configuration directory. Defaults to C</etc/webmin>

    --command, -x
         Available commands:
           - status
           - start
           - stop
           - restart
           - reload
           - force-restart
           - force-reload
           - kill

         Alias commands:
           - force-restart | force-reload
           - kill | force-kill
```