### PR TITLE
Add support for `yescrypt` and `sha512` upon installation; fix other bug

### DIFF
--- a/setup.pl
+++ b/setup.pl
@@ -299,9 +299,14 @@ else {
 		$crypt = $ENV{'crypt'};
 		}
 	else {
+        system("stty -echo");
 		chop($password = <STDIN>);
-		print "Password again: ";
+        system("stty echo");
+		print "\nPassword again: ";
+        system("stty -echo");
 		chop($password2 = <STDIN>);
+        system("stty echo");
+        print "\n";
 		if ($password ne $password2) {
 			&errorexit("Passwords don't match");
 			}

--- a/setup.pl
+++ b/setup.pl
@@ -435,8 +435,9 @@ else {
 		}
 
 	# Generate random
-	$salt8 = substr(time(), -8);
-	$salt2 = substr(time(), -2);
+	@saltbase = ('a'..'z', 'A'..'Z', '0'..'9', split(//, time()));
+	$salt8 = join('', map ($saltbase[rand(@saltbase)], 1..8));
+	$salt2 = join('', map ($saltbase[rand(@saltbase)], 1..2));
 
 	# Create users file
 	open(UFILE, ">$ufile");

--- a/setup.pl
+++ b/setup.pl
@@ -718,10 +718,8 @@ if (!defined($miniserv{'passwd_mode'})) {
 	$miniserv{'passwd_mode'} = 0;
 	}
 
-# If Perl crypt supports MD5, then make it the default
-if ($md5pass) {
-	$gconfig{'md5pass'} = 1;
-	}
+# Use system default for password hashing
+$gconfig{'md5pass'} = 0;
 
 # Set a special theme if none was set before
 if ($ENV{'theme'}) {

--- a/setup.pl
+++ b/setup.pl
@@ -636,8 +636,7 @@ else {
 	symlink("$config_directory/.reload-init", "$config_directory/reload");
 
 	# For systemd
-	my $systemctlcmd = `which systemctl`;
-	$systemctlcmd =~ s/\s+$//;
+	my $systemctlcmd = &has_command('systemctl');
 	if (-x $systemctlcmd) {
 
 		# Clear existing

--- a/setup.pl
+++ b/setup.pl
@@ -299,14 +299,14 @@ else {
 		$crypt = $ENV{'crypt'};
 		}
 	else {
-        system("stty -echo");
+		system("stty -echo");
 		chop($password = <STDIN>);
-        system("stty echo");
+		system("stty echo");
 		print "\nPassword again: ";
-        system("stty -echo");
+		system("stty -echo");
 		chop($password2 = <STDIN>);
-        system("stty echo");
-        print "\n";
+		system("stty echo");
+		print "\n";
 		if ($password ne $password2) {
 			&errorexit("Passwords don't match");
 			}

--- a/setup.pl
+++ b/setup.pl
@@ -435,7 +435,7 @@ else {
 		}
 
 	# Generate random
-	@saltbase = ('a'..'z', 'A'..'Z', '0'..'9', split(//, time()));
+	@saltbase = ('a'..'z', 'A'..'Z', '0'..'9');
 	$salt8 = join('', map ($saltbase[rand(@saltbase)], 1..8));
 	$salt2 = join('', map ($saltbase[rand(@saltbase)], 1..2));
 

--- a/setup.pl
+++ b/setup.pl
@@ -418,21 +418,37 @@ else {
 		}
 	&put_miniserv_config(\%miniserv);
 
-	# Test MD5 password encryption
-	if (&unix_crypt("test", "\\$1\\$A9wB3O18\\$zaZgqrEmb9VNltWTL454R/") eq "\\$1\\$A9wB3O18\\$zaZgqrEmb9VNltWTL454R/") {
+	# Test availble hashing formats
+	if (&unix_crypt('test', '$y$j9T$waHytoaqP/CEnKFroGn0S/$fxd5mVc2mBPUc3vv.cpqDckpwrWTyIm2iD4JfnVBi26') eq '$y$j9T$waHytoaqP/CEnKFroGn0S/$fxd5mVc2mBPUc3vv.cpqDckpwrWTyIm2iD4JfnVBi26') {
+		$yescryptpass = 1;
+		}
+	if (&unix_crypt('test', '$6$Tk5o/GEE$zjvXhYf/dr5M7/jan3pgunkNrAsKmQO9r5O8sr/Cr1hFOLkWmsH4iE9hhqdmHwXd5Pzm4ubBWTEjtMeC.h5qv1') eq '$6$Tk5o/GEE$zjvXhYf/dr5M7/jan3pgunkNrAsKmQO9r5O8sr/Cr1hFOLkWmsH4iE9hhqdmHwXd5Pzm4ubBWTEjtMeC.h5qv1') {
+		$sha512pass = 1;
+		}
+	if (&unix_crypt('test', '$1$A9wB3O18$zaZgqrEmb9VNltWTL454R/') eq '$1$A9wB3O18$zaZgqrEmb9VNltWTL454R/') {
 		$md5pass = 1;
 		}
+
+	# Generate random
+	$salt8 = substr(time(), -8);
+	$salt2 = substr(time(), -2);
 
 	# Create users file
 	open(UFILE, ">$ufile");
 	if ($crypt) {
 		print UFILE "$login:$crypt:0\n";
 		}
+	elsif ($yescryptpass) {
+		print UFILE $login,":",&unix_crypt($password, "\$y\$j9T\$$salt8"),"\n";
+		}
+	elsif ($sha512pass) {
+		print UFILE $login,":",&unix_crypt($password, "\$6\$$salt8"),"\n";
+		}
 	elsif ($md5pass) {
-		print UFILE $login,":",&unix_crypt($password, "\$1\$XXXXXXXX"),"\n";
+		print UFILE $login,":",&unix_crypt($password, "\$1\$$salt8"),"\n";
 		}
 	else {
-		print UFILE $login,":",&unix_crypt($password, "XX"),"\n";
+		print UFILE $login,":",&unix_crypt($password, $salt2),"\n";
 		}
 	close(UFILE);
 	chmod(0600, $ufile);

--- a/setup.sh
+++ b/setup.sh
@@ -554,7 +554,7 @@ else
 		elif [ "$md5pass" = "1" ]; then
 			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$1\$$ARGV[2]"),":0\n"' "$login" "$password" "$salt8" > $ufile
 		else
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], $ARGV[2]),":0\n"' "$login" "$password" "$salt8" > $ufile
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], $ARGV[2]),":0\n"' "$login" "$password" "$salt2" > $ufile
 		fi
 	fi
 	chmod 600 $ufile

--- a/setup.sh
+++ b/setup.sh
@@ -535,16 +535,26 @@ else
 		cat "$wadir/miniserv-conf" >>$cfile
 	fi
 
+	# Test availble hashing formats
+	yescryptpass=`$perl -e 'print crypt("test", "\\$y\\$j9T\\$waHytoaqP/CEnKFroGn0S/\\$fxd5mVc2mBPUc3vv.cpqDckpwrWTyIm2iD4JfnVBi26") eq "\\$y\\$j9T\\$waHytoaqP/CEnKFroGn0S/\\$fxd5mVc2mBPUc3vv.cpqDckpwrWTyIm2iD4JfnVBi26" ? "1\n" : "0\n"'`
+	sha512pass=`$perl -e 'print crypt("test", "\\$6\\$Tk5o/GEE\\$zjvXhYf/dr5M7/jan3pgunkNrAsKmQO9r5O8sr/Cr1hFOLkWmsH4iE9hhqdmHwXd5Pzm4ubBWTEjtMeC.h5qv1") eq "\\$6\\$Tk5o/GEE\\$zjvXhYf/dr5M7/jan3pgunkNrAsKmQO9r5O8sr/Cr1hFOLkWmsH4iE9hhqdmHwXd5Pzm4ubBWTEjtMeC.h5qv1" ? "1\n" : "0\n"'`
 	md5pass=`$perl -e 'print crypt("test", "\\$1\\$A9wB3O18\\$zaZgqrEmb9VNltWTL454R/") eq "\\$1\\$A9wB3O18\\$zaZgqrEmb9VNltWTL454R/" ? "1\n" : "0\n"'`
+
+	salt8=`tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo ''`
+	salt2=`tr -dc A-Za-z0-9 </dev/urandom | head -c 2 ; echo ''`
 
 	ufile=$config_dir/miniserv.users
 	if [ "$crypt" != "" ]; then
 		echo "$login:$crypt:0" > $ufile
 	else
-		if [ "$md5pass" = "1" ]; then
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$1\$XXXXXXXX"),":0\n"' "$login" "$password" > $ufile
+		if [ "$yescryptpass" = "1" ]; then
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$y\$j9T\$'$salt8'"),":0\n"' "$login" "$password" > $ufile
+		elif [ "$sha512pass" = "1" ]; then
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$6\$'$salt8'"),":0\n"' "$login" "$password" > $ufile
+		elif [ "$md5pass" = "1" ]; then
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$1\$'$salt8'"),":0\n"' "$login" "$password" > $ufile
 		else
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "XX"),":0\n"' "$login" "$password" > $ufile
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "'$salt2'"),":0\n"' "$login" "$password" > $ufile
 		fi
 	fi
 	chmod 600 $ufile

--- a/setup.sh
+++ b/setup.sh
@@ -784,10 +784,8 @@ if [ "$?" != "0" ]; then
 	echo passwd_mode=0 >> $config_dir/miniserv.conf
 fi
 
-# If Perl crypt supports MD5, then make it the default
-if [ "$md5pass" = "1" ]; then
-	echo md5pass=1 >> $config_dir/config
-fi
+# Use system defaults for password hashing
+echo md5pass=0 >> $config_dir/config
 
 # Set a special theme if none was set before
 if [ "$theme" = "" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -548,13 +548,13 @@ else
 		echo "$login:$crypt:0" > $ufile
 	else
 		if [ "$yescryptpass" = "1" ]; then
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$y\$j9T\$'$salt8'"),":0\n"' "$login" "$password" > $ufile
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$y\$j9T\$$ARGV[2]"),":0\n"' "$login" "$password" "$salt8" > $ufile
 		elif [ "$sha512pass" = "1" ]; then
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$6\$'$salt8'"),":0\n"' "$login" "$password" > $ufile
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$6\$$ARGV[2]"),":0\n"' "$login" "$password" "$salt8" > $ufile
 		elif [ "$md5pass" = "1" ]; then
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$1\$'$salt8'"),":0\n"' "$login" "$password" > $ufile
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "\$1\$$ARGV[2]"),":0\n"' "$login" "$password" "$salt8" > $ufile
 		else
-			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], "'$salt2'"),":0\n"' "$login" "$password" > $ufile
+			$perl -e 'print "$ARGV[0]:",crypt($ARGV[1], $ARGV[2]),":0\n"' "$login" "$password" "$salt8" > $ufile
 		fi
 	fi
 	chmod 600 $ufile

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -11001,7 +11001,7 @@ string.
 sub unix_crypt
 {
 my ($pass, $salt) = @_;
-return "" if ($salt !~ /^[a-zA-Z0-9\.\/]{2}/);   # same as real crypt
+return "" if ($salt !~ /^[\$a-zA-Z0-9\.\/]{2}/);   # same as real crypt
 my $rv = eval "crypt(\$pass, \$salt)";
 my $err = $@;
 return $rv if ($rv && !$@);

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -11001,16 +11001,15 @@ string.
 sub unix_crypt
 {
 my ($pass, $salt) = @_;
-return "" if ($salt !~ /^[\$a-zA-Z0-9\.\/]{2}/);   # same as real crypt
-my $rv = eval "crypt(\$pass, \$salt)";
-my $err = $@;
-return $rv if ($rv && !$@);
+return "" if ($salt !~ /^[\$a-zA-Z0-9]{2}/);   # same as real crypt
+my $rv = eval { crypt($pass, $salt) };
+return $rv if (!$@);
 eval "use Crypt::UnixCrypt";
 if (!$@) {
 	return Crypt::UnixCrypt::crypt($pass, $salt);
 	}
 else {
-	&error("Failed to encrypt password : $err");
+	&error("Failed to encrypt password : $@");
 	}
 }
 


### PR DESCRIPTION
This PR adds support for having default user initial password comply with system strongest hashing format available.

It also resets Webmin default hashing format to auto detect (system default), so when a new Webmin user is created or a password changed for existing Webmin user in `acl` module, it would be hashed properly.

