### PR TITLE
Fix Webmin updates from UI

### DIFF
--- a/makedebian.pl
+++ b/makedebian.pl
@@ -299,7 +299,7 @@ noperlpath=1
 nouninstall=1
 nostart=1
 nostop=1
-export config_dir var_dir perl autoos port login crypt host ssl nochown autothird noperlpath nouninstall nostart nostop allow atboot makeboot
+export config_dir var_dir perl autoos port login crypt host ssl nochown autothird noperlpath nouninstall nostart allow atboot makeboot nostop
 tempdir=/tmp/.webmin
 if [ ! -d \$tempdir ]; then
 	tempdir=/tmp

--- a/makedebian.pl
+++ b/makedebian.pl
@@ -264,13 +264,11 @@ justinstalled=1
 if [ -e "/etc/$baseproduct" ]; then
 	justinstalled=0
 fi
-supportupdprepost=0
 inetd=`grep "^inetd=" /etc/$baseproduct/miniserv.conf 2>/dev/null | sed -e 's/inetd=//g'`
 if [ "\$1" = "configure" ]; then
 	# Upgrading the package, so stop the old Webmin properly
 	if [ "\$inetd" != "1" ]; then
 		if [ -e "/etc/$baseproduct/.pre-install" ]; then
-			supportupdprepost=1
 			/etc/$baseproduct/.pre-install >/dev/null 2>&1 </dev/null
 		fi
 	fi
@@ -322,13 +320,11 @@ if [ "$inetd" != "1" ]; then
 		if [ "\$?" != "0" ]; then
 			echo "E: Webmin server cannot be started. It is advised to start it manually\n   by running \\"webmin force-restart\\" command"
 		fi
-	elif [ "\$supportupdprepost" = "1" ]; then
-			/etc/$baseproduct/.post-install >/dev/null 2>&1 </dev/null
+	else
+		/etc/$baseproduct/.post-install >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
 			echo "W: Webmin server cannot be restarted. It is advised to restart it manually\n   by running \\"webmin force-restart\\" command when upgrade process is finished"
 		fi
-	else
-		echo "W: Webmin server will not be restarted. It is advised to restart it manually\n   by running \\"webmin force-restart\\" command when upgrade process is finished"
 	fi
 fi
 

--- a/makedebian.pl
+++ b/makedebian.pl
@@ -318,12 +318,12 @@ if [ "$inetd" != "1" ]; then
 	if [ "\$justinstalled" = "1" ]; then
 		/etc/$baseproduct/start >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
-			echo "E: Webmin server cannot be started. It is advised to start it manually\n   by running \\"webmin force-restart\\" command"
+			echo "E: Webmin server cannot be started. It is advised to start it manually\n   by running \\"/etc/webmin/restart-by-force-kill\\" command"
 		fi
 	else
 		/etc/$baseproduct/.post-install >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
-			echo "W: Webmin server cannot be restarted. It is advised to restart it manually\n   by running \\"webmin force-restart\\" command when upgrade process is finished"
+			echo "W: Webmin server cannot be restarted. It is advised to restart it manually\n   by running \\"/etc/webmin/restart-by-force-kill\\" command when upgrade process is finished"
 		fi
 	fi
 fi

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -216,7 +216,7 @@ chmod 600 \$tempdir/webmin-setup.out
 rm -f /var/lock/subsys/webmin
 cd /usr/libexec/webmin
 if [ "\$inetd" != "1" ]; then
-  if [ "\$1" == 1 ]; then
+	if [ "\$1" == 1 ]; then
 		/etc/webmin/start >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
 			echo "error: Webmin server cannot be started. It is advised to start it manually\n       by running \\"webmin force-restart\\" command"
@@ -300,7 +300,7 @@ if [ ! -r /etc/webmin/miniserv.conf -a -d /etc/.webmin-backup -a "\$1" = 2 ]; th
 	mv /etc/webmin /etc/.webmin-broken
 	mv /etc/.webmin-backup /etc/webmin
 	if [ -r /etc/webmin/.post-install ]; then
-			/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
+		/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
 	fi
 else
 	rm -rf /etc/.webmin-backup

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -217,12 +217,12 @@ if [ "\$inetd" != "1" ]; then
 	if [ "\$1" == 1 ]; then
 		/etc/webmin/start >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
-			echo "error: Webmin server cannot be started. It is advised to start it manually\n       by running \\"webmin force-restart\\" command"
+			echo "error: Webmin server cannot be started. It is advised to start it manually\n       by running \\"/etc/webmin/restart-by-force-kill\\" command"
 		fi
 	else
 		/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
-			echo "warning: Webmin server cannot be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
+			echo "warning: Webmin server cannot be restarted. It is advised to restart it manually\n         by running \\"/etc/webmin/restart-by-force-kill\\" when upgrade process is finished"
 		fi
 	fi
 fi

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -227,7 +227,7 @@ if [ "\$inetd" != "1" ]; then
 			echo "warning: Webmin server cannot be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
 		fi
 	else
-			echo "warning: Webmin server will not be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
+		echo "warning: Webmin server will not be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
 	fi
 fi
 

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -208,7 +208,7 @@ nostop=1
 if [ "\$tempdir" = "" ]; then
 	tempdir=/tmp/.webmin
 fi
-export config_dir var_dir perl autoos port login crypt host ssl nochown autothird noperlpath nouninstall nostart nostop allow atboot makeboot
+export config_dir var_dir perl autoos port login crypt host ssl nochown autothird noperlpath nouninstall nostart allow atboot makeboot nostop
 ./setup.sh >\$tempdir/webmin-setup.out 2>&1
 chmod 600 \$tempdir/webmin-setup.out
 rm -f /var/lock/subsys/webmin

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -170,19 +170,15 @@ fi
 
 %post
 inetd=`grep "^inetd=" /etc/webmin/miniserv.conf 2>/dev/null | sed -e 's/inetd=//g'`
-startafter=0
-
+supportupdprepost=0
 if [ "\$1" != 1 ]; then
 	# Upgrading the RPM, so stop the old Webmin properly
 	if [ "\$inetd" != "1" ]; then
-		kill -0 `cat /var/webmin/miniserv.pid 2>/dev/null` 2>/dev/null
-		if [ "\$?" = 0 ]; then
-		  startafter=1
+		if [ -e /etc/webmin/.pre-install ]; then
+			supportupdprepost=1
+			/etc/webmin/.pre-install >/dev/null 2>&1 </dev/null
 		fi
-		/etc/webmin/stop >/dev/null 2>&1 </dev/null
 	fi
-else
-  startafter=1
 fi
 cd /usr/libexec/webmin
 config_dir=/etc/webmin
@@ -210,19 +206,28 @@ autothird=1
 noperlpath=1
 nouninstall=1
 nostart=1
+nostop=1
 if [ "\$tempdir" = "" ]; then
 	tempdir=/tmp/.webmin
 fi
-export config_dir var_dir perl autoos port login crypt host ssl nochown autothird noperlpath nouninstall nostart allow atboot makeboot
+export config_dir var_dir perl autoos port login crypt host ssl nochown autothird noperlpath nouninstall nostart nostop allow atboot makeboot
 ./setup.sh >\$tempdir/webmin-setup.out 2>&1
 chmod 600 \$tempdir/webmin-setup.out
 rm -f /var/lock/subsys/webmin
 cd /usr/libexec/webmin
-if [ "\$inetd" != "1" -a "\$startafter" = "1" ]; then
-	/etc/webmin/stop >/dev/null 2>&1 </dev/null
-	/etc/webmin/start >/dev/null 2>&1 </dev/null
-	if [ "\$?" != "0" ]; then
-		echo "warning: Webmin server cannot be restarted. It is advised to restart it manually by\nrunning \\"/etc/webmin/restart-by-force-kill\\" when upgrade process is finished"
+if [ "\$inetd" != "1" ]; then
+  if [ "\$1" == 1 ]; then
+		/etc/webmin/start >/dev/null 2>&1 </dev/null
+		if [ "\$?" != "0" ]; then
+			echo "error: Webmin server cannot be started. It is advised to start it manually\n       by running \\"webmin force-restart\\" command"
+		fi
+	elif [ "\$supportupdprepost" = "1" ]; then
+		/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
+		if [ "\$?" != "0" ]; then
+			echo "warning: Webmin server cannot be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
+		fi
+	else
+			echo "warning: Webmin server will not be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
 	fi
 fi
 
@@ -267,9 +272,8 @@ if [ "\$1" = 0 ]; then
 	if [ "\$?" = 0 ]; then
 		# RPM is being removed, and no new version of webmin
 		# has taken it's place. Run uninstalls and stop the server
-		(cd /usr/libexec/webmin ; WEBMIN_CONFIG=/etc/webmin WEBMIN_VAR=/var/webmin LANG= /usr/libexec/webmin/run-uninstalls.pl) >/dev/null 2>&1 </dev/null
 		/etc/webmin/stop >/dev/null 2>&1 </dev/null
-		/etc/webmin/.stop-init --kill >/dev/null 2>&1 </dev/null
+		(cd /usr/libexec/webmin ; WEBMIN_CONFIG=/etc/webmin WEBMIN_VAR=/var/webmin LANG= /usr/libexec/webmin/run-uninstalls.pl) >/dev/null 2>&1 </dev/null
 	fi
 fi
 /bin/true
@@ -295,10 +299,8 @@ if [ ! -r /etc/webmin/miniserv.conf -a -d /etc/.webmin-backup -a "\$1" = 2 ]; th
 	rm -rf /etc/.webmin-broken
 	mv /etc/webmin /etc/.webmin-broken
 	mv /etc/.webmin-backup /etc/webmin
-	/etc/webmin/stop >/dev/null 2>&1 </dev/null
-	/etc/webmin/start >/dev/null 2>&1 </dev/null
-	if [ "\$?" != "0" ]; then
-		echo "warning: Webmin server cannot be restarted. It is advised to restart it manually by\nrunning \\"/etc/webmin/restart-by-force-kill\\" when upgrade process is finished"
+	if [ -r /etc/webmin/.post-install ]; then
+			/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
 	fi
 else
 	rm -rf /etc/.webmin-backup

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -170,12 +170,10 @@ fi
 
 %post
 inetd=`grep "^inetd=" /etc/webmin/miniserv.conf 2>/dev/null | sed -e 's/inetd=//g'`
-supportupdprepost=0
 if [ "\$1" != 1 ]; then
 	# Upgrading the RPM, so stop the old Webmin properly
 	if [ "\$inetd" != "1" ]; then
 		if [ -e /etc/webmin/.pre-install ]; then
-			supportupdprepost=1
 			/etc/webmin/.pre-install >/dev/null 2>&1 </dev/null
 		fi
 	fi
@@ -221,13 +219,11 @@ if [ "\$inetd" != "1" ]; then
 		if [ "\$?" != "0" ]; then
 			echo "error: Webmin server cannot be started. It is advised to start it manually\n       by running \\"webmin force-restart\\" command"
 		fi
-	elif [ "\$supportupdprepost" = "1" ]; then
+	else
 		/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
 		if [ "\$?" != "0" ]; then
 			echo "warning: Webmin server cannot be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
 		fi
-	else
-		echo "warning: Webmin server will not be restarted. It is advised to restart it manually\n         by running \\"webmin force-restart\\" when upgrade process is finished"
 	fi
 fi
 

--- a/setup.pl
+++ b/setup.pl
@@ -467,7 +467,7 @@ else {
 		$host = &get_system_hostname();
 		$cert = &tempname();
 		$key = &tempname();
-		open(SSL, "| openssl req -newkey rsa:512 -x509 -nodes -out $cert -keyout $key -days 1825 >/dev/null 2>&1");
+		open(SSL, "| openssl req -newkey rsa:2048 -x509 -nodes -out $cert -keyout $key -days 1825 -sha256 >/dev/null 2>&1");
 		print SSL ".\n";
 		print SSL ".\n";
 		print SSL ".\n";

--- a/setup.pl
+++ b/setup.pl
@@ -467,7 +467,7 @@ else {
 		$host = &get_system_hostname();
 		$cert = &tempname();
 		$key = &tempname();
-		open(SSL, "| openssl req -newkey rsa:2048 -x509 -nodes -out $cert -keyout $key -days 1825 -sha256 >/dev/null 2>&1");
+		open(SSL, "| openssl req -newkey rsa:512 -x509 -nodes -out $cert -keyout $key -days 1825 >/dev/null 2>&1");
 		print SSL ".\n";
 		print SSL ".\n";
 		print SSL ".\n";

--- a/setup.pl
+++ b/setup.pl
@@ -472,7 +472,7 @@ else {
 		$host = &get_system_hostname();
 		$cert = &tempname();
 		$key = &tempname();
-		open(SSL, "| openssl req -newkey rsa:512 -x509 -nodes -out $cert -keyout $key -days 1825 >/dev/null 2>&1");
+		open(SSL, "| openssl req -newkey rsa:2048 -x509 -nodes -out $cert -keyout $key -days 1825 -sha256 >/dev/null 2>&1");
 		print SSL ".\n";
 		print SSL ".\n";
 		print SSL ".\n";

--- a/setup.pl
+++ b/setup.pl
@@ -110,8 +110,6 @@ $ENV{'WEBMIN_CONFIG'} = $config_directory;
 $ENV{'WEBMIN_VAR'} = "/var/webmin";	# Only used for initial load of web-lib
 require "$srcdir/web-lib-funcs.pl";
 
-$supportprepost = 0;
-
 # Check if upgrading from an old version
 if ($upgrading) {
 	print "\n";
@@ -146,7 +144,6 @@ if ($upgrading) {
 			}
 		else {
 			if (-r "$config_directory/.pre-install") {
-				$supportprepost = 1;
 				system("$config_directory/.pre-install >/dev/null 2>&1");
 				}
 			}
@@ -178,8 +175,6 @@ if ($upgrading) {
 	unlink("$config_directory/module.infos.cache");
 	}
 else {
-	$supportprepost = 1;
-
 	# Config directory exists .. make sure it is not in use
 	@files = grep { !/rpmsave/ } &files_in_dir($config_directory);
 	if (@files && $config_directory ne "/etc/webmin") {
@@ -884,17 +879,12 @@ if (-r "$srcdir/setup-post.pl") {
 
 if (!$ENV{'nostart'}) {
 	if (!$miniserv{'inetd'}) {
-		if ($supportprepost) {
-			print "Attempting to start Webmin web server..\n";
-			$ex = system($start_cmd);
-			if ($ex) {
-				&errorexit("Failed to start web server!");
-				}
-			print "..done\n";
+		print "Attempting to start Webmin web server..\n";
+		$ex = system($start_cmd);
+		if ($ex) {
+			&errorexit("Failed to start web server!");
 			}
-		else {
-			print "Warning! Webmin server must be restarted manually. It is advised to be restarted by\nrunning \"webmin force-restart\" command\n";
-			}
+		print "..done\n";
 		print "\n";
 		}
 

--- a/setup.sh
+++ b/setup.sh
@@ -736,11 +736,9 @@ fi
 echo "..done"
 echo ""
 
-if [ "$nostop" = "" ]; then
-	if [ "$upgrading" = 1 -a "$inetd" != "1" ]; then
-		# Stop old version, with updated stop script
-		$config_dir/stop >/dev/null 2>&1
-	fi
+if [ "$upgrading" = 1 -a "$inetd" != "1" -a "$nostop" == "" ]; then
+	# Stop old version, with updated stop script
+	$config_dir/stop >/dev/null 2>&1
 fi
 
 if [ "$upgrading" = 1 ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -614,11 +614,10 @@ if [ "$noperlpath" = "" ]; then
 	echo ""
 fi
 
-# Re-generating main
-rm -f $config_dir/.stop-init $config_dir/.start-init $config_dir/.restart-init $config_dir/.restart-by-force-kill-init $config_dir/.reload-init
+# Re-generating main scripts
 echo "Creating start and stop init scripts.."
 # Start main
-echo "#!/bin/sh" >>$config_dir/.start-init
+echo "#!/bin/sh" >$config_dir/.start-init
 echo "echo Starting Webmin server in $wadir" >>$config_dir/.start-init
 echo "trap '' 1" >>$config_dir/.start-init
 echo "LANG=" >>$config_dir/.start-init
@@ -634,7 +633,7 @@ else
 	echo "exec '$wadir/miniserv.pl' \$* $config_dir/miniserv.conf" >>$config_dir/.start-init
 fi
 # Stop main
-echo "#!/bin/sh" >>$config_dir/.stop-init
+echo "#!/bin/sh" >$config_dir/.stop-init
 echo "if [ \"\$1\" = \"--kill\" ]; then" >>$config_dir/.stop-init
 echo "  echo Force stopping Webmin server in $wadir" >>$config_dir/.stop-init
 echo "else" >>$config_dir/.stop-init
@@ -656,20 +655,26 @@ echo "    (ps axf | grep \"webmin\/miniserv\.pl\" | awk '{print \"kill -9 -- -\"
 echo "  fi" >>$config_dir/.stop-init
 echo "fi" >>$config_dir/.stop-init
 # Restart main
-echo "#!/bin/sh" >>$config_dir/.restart-init
+echo "#!/bin/sh" >$config_dir/.restart-init
 echo "$config_dir/.stop-init" >>$config_dir/.restart-init
 echo "$config_dir/.start-init" >>$config_dir/.restart-init
 # Force reload main
-echo "#!/bin/sh" >>$config_dir/.restart-by-force-kill-init
+echo "#!/bin/sh" >$config_dir/.restart-by-force-kill-init
 echo "$config_dir/.stop-init --kill" >>$config_dir/.restart-by-force-kill-init
 echo "$config_dir/.start-init" >>$config_dir/.restart-by-force-kill-init
 # Reload main
-echo "#!/bin/sh" >>$config_dir/.reload-init
+echo "#!/bin/sh" >$config_dir/.reload-init
 echo "echo Reloading Webmin server in $wadir" >>$config_dir/.reload-init
 echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.reload-init
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
+# Pre install
+echo "#!/bin/sh" >$config_dir/.pre-install
+echo "$config_dir/.stop-init" >>$config_dir/.pre-install
+# Post install
+echo "#!/bin/sh" >$config_dir/.post-install
+echo "$config_dir/.start-init" >>$config_dir/.post-install
 
-chmod 755 $config_dir/.stop-init $config_dir/.start-init $config_dir/.restart-init $config_dir/.restart-by-force-kill-init $config_dir/.reload-init
+chmod 755 $config_dir/.stop-init $config_dir/.start-init $config_dir/.restart-init $config_dir/.restart-by-force-kill-init $config_dir/.reload-init $config_dir/.pre-install $config_dir/.post-install
 echo "..done"
 echo ""
 
@@ -696,27 +701,34 @@ if [ -x "$systemctlcmd" ]; then
 
 	echo "Creating start and stop scripts (systemd).."
 	# Start systemd
-	echo "#!/bin/sh" >>$config_dir/start
+	echo "#!/bin/sh" >$config_dir/start
 	echo "$systemctlcmd start webmin" >>$config_dir/start
 	# Stop systemd
-	echo "#!/bin/sh" >>$config_dir/stop
+	echo "#!/bin/sh" >$config_dir/stop
 	echo "$systemctlcmd stop webmin" >>$config_dir/stop
 	# Restart systemd
-	echo "#!/bin/sh" >>$config_dir/restart
+	echo "#!/bin/sh" >$config_dir/restart
 	echo "$systemctlcmd restart webmin" >>$config_dir/restart
 	# Force reload systemd
-	echo "#!/bin/sh" >>$config_dir/restart-by-force-kill
+	echo "#!/bin/sh" >$config_dir/restart-by-force-kill
 	echo "$systemctlcmd stop webmin" >>$config_dir/restart-by-force-kill
 	echo "$config_dir/.stop-init --kill >/dev/null 2>&1" >>$config_dir/restart-by-force-kill
 	echo "$systemctlcmd start webmin" >>$config_dir/restart-by-force-kill
 	# Reload systemd
-	echo "#!/bin/sh" >>$config_dir/reload
+	echo "#!/bin/sh" >$config_dir/reload
 	echo "$systemctlcmd reload webmin" >>$config_dir/reload
+	# Pre-install on systemd
+	echo "#!/bin/sh" >$config_dir/.pre-install
+	echo "$systemctlcmd kill --signal=SIGSTOP --kill-who=main webmin" >>$config_dir/.pre-install
+	# Post-install on systemd
+	echo "#!/bin/sh" >$config_dir/.post-install
+	echo "$systemctlcmd kill --signal=SIGCONT --kill-who=main webmin" >>$config_dir/.post-install
+	echo "$systemctlcmd kill --signal=SIGHUP --kill-who=main webmin" >>$config_dir/.post-install
 
 	# Fix existing systemd webmin.service file to update start and stop commands
 	(cd "$wadir/init" ; WEBMIN_CONFIG=$config_dir WEBMIN_VAR=$var_dir "$wadir/init/updateboot.pl" "webmin")
 	
-	chmod 755 $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
+	chmod 755 $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload $config_dir/.pre-install $config_dir/.post-install
 else
 	# Creating symlinks
 	echo "Creating start and stop init symlinks to scripts .."
@@ -724,9 +736,11 @@ fi
 echo "..done"
 echo ""
 
-if [ "$upgrading" = 1 -a "$inetd" != "1" ]; then
-	# Stop old version, with updated stop script
-	$config_dir/stop >/dev/null 2>&1
+if [ "$nostop" = "" ]; then
+	if [ "$upgrading" = 1 -a "$inetd" != "1" ]; then
+		# Stop old version, with updated stop script
+		$config_dir/stop >/dev/null 2>&1
+	fi
 fi
 
 if [ "$upgrading" = 1 ]; then
@@ -928,7 +942,7 @@ fi
 
 if [ "$nostart" = "" ]; then
 	if [ "$inetd" != "1" ]; then
-		echo "Attempting to start Webmin mini web server.."
+		echo "Attempting to start Webmin web server.."
 		$config_dir/start
 		if [ $? != "0" ]; then
 			echo "ERROR: Failed to start web server!"


### PR DESCRIPTION
This has been sorted!

 1. Webmin will be restarted from UI correctly (starting 1.996+)
 2. On `systemd` systems it will respect current status after upgrades (i.e. Webmin won't be restarted if it was stopped)
 3. Signals are only sent from scriptlets 
 4. Bonus: Fix `miniserv.pem` generation in `setup.pl`

It won't be reliably possible to send `SIGHUP` to the process running Webmin 1.994 as it will simply may die (and most likely will). Upgrades made from Webmin 1.994 to 1.996 will have to be restarted manually. There is nothing we can do, unfortunately (due to that `miniserv` bug that was recently fixed). After version 1.996 all upgrades (including from UI) will flow smoothly. Upgrading from 1.994 to 1.996 will show a nice message in package manager explaining what to do (how to restart it). This is the best safest we can do.

I am 1000% sure that it must be resolved now! Please have a look.
