### PR TITLE
Reprise: Fix Webmin restarts on upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,12 @@ Complete set of documentation for Webmin and all of its modules can be found at 
 
 * [Jamie Cameron](http://www.webmin.com/about.html) [![](https://github.com/webmin-devel/webmin/blob/master/media/linkedin-15x15.png?raw=true)](https://www.linkedin.com/in/jamiecameron2)
 
-### Developers
-* [Ilia Rostovtsev](https://github.com/iliajie)
-* [Joe Cooper](https://github.com/swelljoe)
-
 ### Contributors
+
+* [Joe Cooper](https://github.com/swelljoe)
+* [Ilia Rostovtsev](https://github.com/iliajie)
 * [Kay Marquardt](https://github.com/gnadelwartz)
-* [Nawawi Jamili](https://github.com/nawawi)
-* [unknown10777] https://github.com/unknown10777 + [90 more..](https://github.com/webmin/webmin/graphs/contributors)
+* [Nawawi Jamili](https://github.com/nawawi) + [57 more..](https://github.com/webmin/webmin/graphs/contributors)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ Complete set of documentation for Webmin and all of its modules can be found at 
 
 * [Jamie Cameron](http://www.webmin.com/about.html) [![](https://github.com/webmin-devel/webmin/blob/master/media/linkedin-15x15.png?raw=true)](https://www.linkedin.com/in/jamiecameron2)
 
-### Contributors
-
-* [Joe Cooper](https://github.com/swelljoe)
+### Developers
 * [Ilia Rostovtsev](https://github.com/iliajie)
+* [Joe Cooper](https://github.com/swelljoe)
+
+### Contributors
 * [Kay Marquardt](https://github.com/gnadelwartz)
-* [Nawawi Jamili](https://github.com/nawawi) + [57 more..](https://github.com/webmin/webmin/graphs/contributors)
+* [Nawawi Jamili](https://github.com/nawawi)
+* [unknown10777] https://github.com/unknown10777 + [90 more..](https://github.com/webmin/webmin/graphs/contributors)
 
 ## License
 

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -170,19 +170,13 @@ fi
 
 %post
 inetd=`grep "^inetd=" /etc/webmin/miniserv.conf 2>/dev/null | sed -e 's/inetd=//g'`
-startafter=0
-
 if [ "\$1" != 1 ]; then
 	# Upgrading the RPM, so stop the old Webmin properly
 	if [ "\$inetd" != "1" ]; then
-		kill -0 `cat /var/webmin/miniserv.pid 2>/dev/null` 2>/dev/null
-		if [ "\$?" = 0 ]; then
-		  startafter=1
+		if [ -e /etc/webmin/.pre-install ]; then
+			/etc/webmin/.pre-install >/dev/null 2>&1 </dev/null
 		fi
-		/etc/webmin/stop >/dev/null 2>&1 </dev/null
 	fi
-else
-  startafter=1
 fi
 cd /usr/libexec/webmin
 config_dir=/etc/webmin
@@ -219,11 +213,17 @@ export config_dir var_dir perl autoos port login crypt host ssl nochown autothir
 chmod 600 \$tempdir/webmin-setup.out
 rm -f /var/lock/subsys/webmin
 cd /usr/libexec/webmin
-if [ "\$inetd" != "1" -a "\$startafter" = "1" ]; then
-	/etc/webmin/stop >/dev/null 2>&1 </dev/null
-	/etc/webmin/start >/dev/null 2>&1 </dev/null
-	if [ "\$?" != "0" ]; then
-		echo "warning: Webmin server cannot be restarted. It is advised to restart it manually by\nrunning \\"/etc/webmin/restart-by-force-kill\\" when upgrade process is finished"
+if [ "\$inetd" != "1" ]; then
+	if [ "\$1" == 1 ]; then
+		/etc/webmin/start >/dev/null 2>&1 </dev/null
+		if [ "\$?" != "0" ]; then
+			echo "error: Webmin server cannot be started. It is advised to start it manually\n       by running \\"/etc/webmin/restart-by-force-kill\\" command"
+		fi
+	else
+		/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
+		if [ "\$?" != "0" ]; then
+			echo "warning: Webmin server cannot be restarted. It is advised to restart it manually\n         by running \\"/etc/webmin/restart-by-force-kill\\" when upgrade process is finished"
+		fi
 	fi
 fi
 
@@ -268,9 +268,8 @@ if [ "\$1" = 0 ]; then
 	if [ "\$?" = 0 ]; then
 		# RPM is being removed, and no new version of webmin
 		# has taken it's place. Run uninstalls and stop the server
-		(cd /usr/libexec/webmin ; WEBMIN_CONFIG=/etc/webmin WEBMIN_VAR=/var/webmin LANG= /usr/libexec/webmin/run-uninstalls.pl) >/dev/null 2>&1 </dev/null
 		/etc/webmin/stop >/dev/null 2>&1 </dev/null
-		/etc/webmin/.stop-init --kill >/dev/null 2>&1 </dev/null
+		(cd /usr/libexec/webmin ; WEBMIN_CONFIG=/etc/webmin WEBMIN_VAR=/var/webmin LANG= /usr/libexec/webmin/run-uninstalls.pl) >/dev/null 2>&1 </dev/null
 	fi
 fi
 /bin/true
@@ -296,10 +295,8 @@ if [ ! -r /etc/webmin/miniserv.conf -a -d /etc/.webmin-backup -a "\$1" = 2 ]; th
 	rm -rf /etc/.webmin-broken
 	mv /etc/webmin /etc/.webmin-broken
 	mv /etc/.webmin-backup /etc/webmin
-	/etc/webmin/stop >/dev/null 2>&1 </dev/null
-	/etc/webmin/start >/dev/null 2>&1 </dev/null
-	if [ "\$?" != "0" ]; then
-		echo "warning: Webmin server cannot be restarted. It is advised to restart it manually by\nrunning \\"/etc/webmin/restart-by-force-kill\\" when upgrade process is finished"
+	if [ -r /etc/webmin/.post-install ]; then
+		/etc/webmin/.post-install >/dev/null 2>&1 </dev/null
 	fi
 else
 	rm -rf /etc/.webmin-backup

--- a/setup.pl
+++ b/setup.pl
@@ -700,13 +700,13 @@ else {
 		# Pre install
 		open(PREINSTT, ">$config_directory/.pre-install");
 		print PREINSTT "#!/bin/sh\n";
-		print PREINSTT "$systemctlcmd kill --signal=SIGSTOP --kill-who=main webmin\n";
+		#print PREINSTT "$systemctlcmd kill --signal=SIGSTOP --kill-who=main webmin\n";
 		close(PREINSTT);
 
 		# Post install
 		open(POSTINSTT, ">$config_directory/.post-install");
 		print POSTINSTT "#!/bin/sh\n";
-		print POSTINSTT "$systemctlcmd kill --signal=SIGCONT --kill-who=main webmin\n";
+		#print POSTINSTT "$systemctlcmd kill --signal=SIGCONT --kill-who=main webmin\n";
 		print POSTINSTT "$systemctlcmd kill --signal=SIGHUP --kill-who=main webmin\n";
 		close(POSTINSTT);
 

--- a/setup.pl
+++ b/setup.pl
@@ -143,7 +143,9 @@ if ($upgrading) {
 			system("$config_directory/stop.bat >/dev/null 2>&1");
 			}
 		else {
-			system("$config_directory/stop >/dev/null 2>&1");
+			if (-r "$config_directory/.pre-install") {
+				system("$config_directory/.pre-install >/dev/null 2>&1");
+				}
 			}
 		}
 
@@ -540,7 +542,7 @@ if ($os_type eq "windows") {
 	}
 else {
 	
-	# Re-generating main	
+	# Re-generating main scripts
 	
 	# Start main
 	open(START, ">$config_directory/.start-init");
@@ -560,7 +562,14 @@ else {
 		print START "exec '$wadir/miniserv.pl' $config_directory/miniserv.conf\n";
 		}
 	close(START);
-	$start_cmd = "$config_directory/start";
+
+	# Define final start command
+	if ($upgrading) {
+		$start_cmd = "$config_directory/.post-install";
+		}
+	else {
+		$start_cmd = "$config_directory/start";
+		}
 
 	# Stop main
 	open(STOP, ">$config_directory/.stop-init");
@@ -609,11 +618,25 @@ else {
 	print RELOAD "kill -USR1 \`cat \$pidfile\`\n";
 	close(RELOAD);
 
+	# Pre install
+	open(PREINST, ">$config_directory/.pre-install");
+	print PREINST "#!/bin/sh\n";
+	print PREINST "$config_directory/.stop-init\n";
+	close(PREINST);
+
+	# # Post install
+	open(POSTINST, ">$config_directory/.post-install");
+	print POSTINST "#!/bin/sh\n";
+	print POSTINST "$config_directory/.start-init\n";
+	close(POSTINST);
+
 	chmod(0755, "$config_directory/.start-init");
 	chmod(0755, "$config_directory/.stop-init");
 	chmod(0755, "$config_directory/.restart-init");
 	chmod(0755, "$config_directory/.restart-by-force-kill-init");
 	chmod(0755, "$config_directory/.reload-init");
+	chmod(0755, "$config_directory/.pre-install");
+	chmod(0755, "$config_directory/.post-install");
 
 	# Re-generating supplementary
 
@@ -674,11 +697,26 @@ else {
 		print RELOADD "$systemctlcmd reload webmin\n";
 		close(RELOADD);
 
+		# Pre install
+		open(PREINSTT, ">$config_directory/.pre-install");
+		print PREINSTT "#!/bin/sh\n";
+		print PREINSTT "$systemctlcmd kill --signal=SIGSTOP --kill-who=main webmin\n";
+		close(PREINSTT);
+
+		# Post install
+		open(POSTINSTT, ">$config_directory/.post-install");
+		print POSTINSTT "#!/bin/sh\n";
+		print POSTINSTT "$systemctlcmd kill --signal=SIGCONT --kill-who=main webmin\n";
+		print POSTINSTT "$systemctlcmd kill --signal=SIGHUP --kill-who=main webmin\n";
+		close(POSTINSTT);
+
 		chmod(0755, "$config_directory/start");
 		chmod(0755, "$config_directory/stop");
 		chmod(0755, "$config_directory/restart");
 		chmod(0755, "$config_directory/restart-by-force-kill");
 		chmod(0755, "$config_directory/reload");
+		chmod(0755, "$config_directory/.pre-install");
+		chmod(0755, "$config_directory/.post-install");
 
 		# Fix existing systemd webmin.service file to update start and stop commands
 		my $perl = &get_perl_path();
@@ -841,7 +879,7 @@ if (-r "$srcdir/setup-post.pl") {
 
 if (!$ENV{'nostart'}) {
 	if (!$miniserv{'inetd'}) {
-		print "Attempting to start Webmin mini web server..\n";
+		print "Attempting to start Webmin web server..\n";
 		$ex = system($start_cmd);
 		if ($ex) {
 			&errorexit("Failed to start web server!");

--- a/setup.sh
+++ b/setup.sh
@@ -719,10 +719,10 @@ if [ -x "$systemctlcmd" ]; then
 	echo "$systemctlcmd reload webmin" >>$config_dir/reload
 	# Pre-install on systemd
 	echo "#!/bin/sh" >$config_dir/.pre-install
-	echo "$systemctlcmd kill --signal=SIGSTOP --kill-who=main webmin" >>$config_dir/.pre-install
+	# echo "$systemctlcmd kill --signal=SIGSTOP --kill-who=main webmin" >>$config_dir/.pre-install
 	# Post-install on systemd
 	echo "#!/bin/sh" >$config_dir/.post-install
-	echo "$systemctlcmd kill --signal=SIGCONT --kill-who=main webmin" >>$config_dir/.post-install
+	# echo "$systemctlcmd kill --signal=SIGCONT --kill-who=main webmin" >>$config_dir/.post-install
 	echo "$systemctlcmd kill --signal=SIGHUP --kill-who=main webmin" >>$config_dir/.post-install
 
 	# Fix existing systemd webmin.service file to update start and stop commands


### PR DESCRIPTION
As we added numerous small changes recently which intersect with yesterday's PR, I am closing that one, and adding all vital changes to this new PR, to have a clearer picture about what's happening.

**Summary:**

  1. Upgrading Webmin from 1.994 to 1.995 will run `systemctl stop webmin` command upon upgrade:
     * This *must not* kill Webmin, i.e. upgrade from UI will seem finished because Webmin 1.994 has _KillMode_ set to _none_;
     * However, upgrading further, i.e. 1.995 to 1.996 _will fail_ but only _if_ Webmin was restarted correctly when previously upgrading from 1.994 to 1.995! This is due to the fact that proper restart must change unit previous _KillMode_ that is was set to _none_ to _control-group_. If Webmin, when upgrading from 1.994 to 1.995, wasn't restarted correctly, you will see _false positive_ picture, where further upgrades from 1.995 to 1.996 happens "correctly" - don't be cheated by this.

  2. Proper restart of Webmin 1.994 will change the _KillMode_ to _control-group_, where further later _any_ Webmin upgrades will _kill_ Webmin upgrades from UI, because calling  `systemctl stop webmin` won't be forgiving with default _KillMode_ set to _control-group_;

  3. This PR address this issue delicately:
     * First of all, instead of completely killing the process, we will send _SIGSTOP_ signal _only_ on the main _PID_, which will suspend current Webmin process. Important to mention, that the signal _will not_ affect control group processes, meaning that package upgrade that is happening as a child process _will continue_. However, the main Webmin process will not be able to process any requests or spawn any new processes after the time when upgrade started;
     * After setup is finished we will send _SIGCONT_ on the main _PID_, un-pausing it and then _SIGHUP_ making Webmin to re-read configuration completely;
     * By pausing the main processes we _must_ make sure that Webmin update will not be interrupted in any way, for example while Webmin is upgrading, another user on the system must not be able to start a new child process, like creating a new domain in Virtualmin, which will try to restart Webmin afterwards, that most likely will cause issues;

-----

As the **proof of concept**, I have create development repos (_deb_/_rpm_) with both Webmin 1.995 that includes all current patches from _master_ and Webmin 1.996 with all patches from this _PR_.

The devel repo can be set up as easy as:

**Debian/Ubuntu**:
```
echo "deb [trusted=yes] https://builds.ilia.engineer ./" > /etc/apt/sources.list.d/webmin-devel.list
```

**RHEL/Fedora/CentOS/Alma/Rocky:**

```
echo -e "[webmin-devel-noarch]\nname=Webmin and modules development\nbaseurl=https://builds.ilia.engineer\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/webmin-devel.repo
```

I encourage advanced and capable Webmin users like @swelljoe @chris001 (and anyone reading this if willing) also participate and help testing to fix this bug as soon as possible.

I recommend anyone trying on a clean system starting with Webmin 1.994. Try different distros, let's say CentOS 7 and Ubuntu 22.04, as those have different `systemd` versions and the test will be more objective.

Install Webmin 1.994 and then try upgrading to 1.995 and then 1.996 using UI.

If you don't want to setup repo, you can download builds with these links:

**Debian/Ubuntu**:

```
https://builds.ilia.engineer/webmin_1.996_all.deb
https://builds.ilia.engineer/webmin_1.995_all.deb
https://builds.ilia.engineer/webmin_1.994_all.deb
```


**RHEL/Fedora/CentOS/Alma/Rocky:**

```
https://builds.ilia.engineer/webmin-1.996-1.noarch.rpm
https://builds.ilia.engineer/webmin-1.995-1.noarch.rpm
https://builds.ilia.engineer/webmin-1.994-1.noarch.rpm
```
