### PR TITLE
Fix `miniserv` message sent on reloads

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -327,7 +327,9 @@ if ($use_syslog) {
 		$use_syslog = 0;
 		}
 	else {
-		local $msg = ucfirst($config{'pam'})." starting";
+		local $msg = ucfirst($config{'pam'});
+		$msg .= $ENV{'STARTED'}++ ?
+		    " reloaded configuration" : " starting";
 		eval { syslog("info", "%s", $msg); };
 		if ($@) {
 			eval {


### PR DESCRIPTION
Otherwise, `systemd` logs will receive `Webmin starting` upon sending `HUP` signal, and now it looks as expected:

<img width="846" alt="image" src="https://user-images.githubusercontent.com/4426533/182354823-1988b751-b72c-46bb-b5ba-649c182405db.png">
