### PR TITLE
Fix to properly transition from `non-systemd` to `systemd` instance

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -618,6 +618,9 @@ if [ ! -f "$config_dir/.pre-install" ]; then
 	killmodenonesh=1
 fi
 
+# Test if we have systemd system
+systemctlcmd=`which systemctl 2>/dev/null`
+
 # Re-generating main scripts
 echo "Creating start and stop init scripts .."
 # Start main
@@ -671,6 +674,14 @@ echo "#!/bin/sh" >$config_dir/.reload-init
 echo "echo Reloading Webmin server in $wadir" >>$config_dir/.reload-init
 echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.reload-init
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
+if [ -x "$systemctlcmd" ]; then
+	current_version=`cat "$config_dir/version" 2>/dev/null`
+	ancient_version=`echo $current_version 1.993 | awk '{if ($1 < $2) print 1; else print 0}'`
+	if [ "$ancient_version" = "1" ];then
+		echo "$config_dir/.stop-init" >>$config_dir/.reload-init
+		echo "$config_dir/start" >>$config_dir/.reload-init
+	fi
+fi
 # Pre install
 echo "#!/bin/sh" >$config_dir/.pre-install
 echo "$config_dir/.stop-init" >>$config_dir/.pre-install
@@ -699,7 +710,6 @@ ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill 
 ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
 
 # For systemd create different start/stop scripts
-systemctlcmd=`which systemctl 2>/dev/null`
 if [ -x "$systemctlcmd" ]; then
 	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 

--- a/setup.sh
+++ b/setup.sh
@@ -680,11 +680,6 @@ if [ "$killmodenonesh" = "1" ] && [ -x "$systemctlcmd" ]; then
 	if [ "$ancient_version" = "1" ]; then
 		echo "$config_dir/.stop-init" >>$config_dir/.reload-init
 		echo "$config_dir/start" >>$config_dir/.reload-init
-		# Reset this file after the call in setup.sh
-		echo "echo \"#!/bin/sh\" >$config_dir/.reload-init" >>$config_dir/.reload-init
-		echo "echo \"echo Reloading Webmin server in $wadir\" >>$config_dir/.reload-init" >>$config_dir/.reload-init
-		echo "echo \"pidfile=\\\`grep \\\"^pidfile=\\\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\\\`\" >>$config_dir/.reload-init" >>$config_dir/.reload-init
-		echo "echo \"kill -USR1 \\\`cat \\\$pidfile\\\`\" >>$config_dir/.reload-init" >>$config_dir/.reload-init
 	fi
 fi
 # Pre install

--- a/setup.sh
+++ b/setup.sh
@@ -676,10 +676,23 @@ echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
 if [ -x "$systemctlcmd" ]; then
 	current_version=`cat "$config_dir/version" 2>/dev/null`
-	ancient_version=`echo $current_version 1.993 | awk '{if ($1 < $2) print 1; else print 0}'`
-	if [ "$ancient_version" = "1" ];then
-		echo "$config_dir/.stop-init" >>$config_dir/.reload-init
-		echo "$config_dir/start" >>$config_dir/.reload-init
+	if [ "$current_version" != "" ]; then
+		ancient_version=`echo $current_version 1.994 | awk '{if ($1 < $2) print 1; else print 0}'`
+		# If upgrading from ancient version
+		if [ "$ancient_version" = "1" ]; then
+			echo "$config_dir/.stop-init" >>$config_dir/.reload-init
+			echo "$config_dir/start" >>$config_dir/.reload-init
+		fi
+		# If Webmin 1.994 is started outside of systemd, and
+		# has no pid file (possible if upgraded from < 1.990)
+		if [ "$current_version" = "1.994" ] && [ ! -f "$var_dir/miniserv.pid" ]; then
+			echo "if [ ! -f \"\$pidfile\" ]; then" >>$config_dir/.reload-init
+				# If started with systemd (with KillMode=none)
+				echo "  $config_dir/stop" >>$config_dir/.reload-init
+				# Start service
+				echo "  $config_dir/start" >>$config_dir/.reload-init
+			echo "fi" >>$config_dir/.reload-init
+		fi
 	fi
 fi
 # Pre install

--- a/setup.sh
+++ b/setup.sh
@@ -676,23 +676,10 @@ echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
 if [ -x "$systemctlcmd" ]; then
 	current_version=`cat "$config_dir/version" 2>/dev/null`
-	if [ "$current_version" != "" ]; then
-		ancient_version=`echo $current_version 1.994 | awk '{if ($1 < $2) print 1; else print 0}'`
-		# If upgrading from ancient version
-		if [ "$ancient_version" = "1" ]; then
-			echo "$config_dir/.stop-init" >>$config_dir/.reload-init
-			echo "$config_dir/start" >>$config_dir/.reload-init
-		fi
-		# If Webmin 1.994 is started outside of systemd, and
-		# has no pid file (possible if upgraded from < 1.990)
-		if [ "$current_version" = "1.994" ] && [ ! -f "$var_dir/miniserv.pid" ]; then
-			echo "if [ ! -f \"\$pidfile\" ]; then" >>$config_dir/.reload-init
-				# If started with systemd (with KillMode=none)
-				echo "  $config_dir/stop" >>$config_dir/.reload-init
-				# Start service
-				echo "  $config_dir/start" >>$config_dir/.reload-init
-			echo "fi" >>$config_dir/.reload-init
-		fi
+	ancient_version=`echo $current_version 1.993 | awk '{if ($1 < $2) print 1; else print 0}'`
+	if [ "$ancient_version" = "1" ];then
+		echo "$config_dir/.stop-init" >>$config_dir/.reload-init
+		echo "$config_dir/start" >>$config_dir/.reload-init
 	fi
 fi
 # Pre install

--- a/setup.sh
+++ b/setup.sh
@@ -676,7 +676,7 @@ echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
 if [ -x "$systemctlcmd" ]; then
 	current_version=`cat "$config_dir/version" 2>/dev/null`
-	ancient_version=`echo $current_version 1.993 | awk '{if ($1 < $2) print 1; else print 0}'`
+	ancient_version=`echo $current_version 1.994 | awk '{if ($1 < $2) print 1; else print 0}'`
 	if [ "$ancient_version" = "1" ];then
 		echo "$config_dir/.stop-init" >>$config_dir/.reload-init
 		echo "$config_dir/start" >>$config_dir/.reload-init

--- a/setup.sh
+++ b/setup.sh
@@ -674,12 +674,17 @@ echo "#!/bin/sh" >$config_dir/.reload-init
 echo "echo Reloading Webmin server in $wadir" >>$config_dir/.reload-init
 echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.reload-init
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
-if [ -x "$systemctlcmd" ]; then
+if [ "$killmodenonesh" = "1" ] && [ -x "$systemctlcmd" ]; then
 	current_version=`cat "$config_dir/version" 2>/dev/null`
 	ancient_version=`echo $current_version 1.994 | awk '{if ($1 < $2) print 1; else print 0}'`
-	if [ "$ancient_version" = "1" ];then
+	if [ "$ancient_version" = "1" ]; then
 		echo "$config_dir/.stop-init" >>$config_dir/.reload-init
 		echo "$config_dir/start" >>$config_dir/.reload-init
+		# Reset this file after the call in setup.sh
+		echo "echo \"#!/bin/sh\" >$config_dir/.reload-init" >>$config_dir/.reload-init
+		echo "echo \"echo Reloading Webmin server in $wadir\" >>$config_dir/.reload-init" >>$config_dir/.reload-init
+		echo "echo \"pidfile=\\\`grep \\\"^pidfile=\\\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\\\`\" >>$config_dir/.reload-init" >>$config_dir/.reload-init
+		echo "echo \"kill -USR1 \\\`cat \\\$pidfile\\\`\" >>$config_dir/.reload-init" >>$config_dir/.reload-init
 	fi
 fi
 # Pre install


### PR DESCRIPTION
I have come to understanding that it's actually possible to transition/restart old Webmin installs (before Webmin 1.993), even those were started outside of `systemd` (with an old version of `/etc/webmin/start` script) to using a new `webmin-systemd` unit file seamlessly.