### PR TITLE
Dev/redirect no message

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1452,8 +1452,14 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 				"This web server is running in SSL mode. ".
 				"Try the URL <a href='$url'>$url</a> instead.</noscript>".
 				"<script>".
+				"var noscript = document.querySelector('noscript');".
+				"var redirect = '<tt>This web server is running in SSL mode.<br>".
+				"Redirecting to the URL ".
+				"<a style=\"color: #f12b2b\" href=\"https://".
+				"'+location.host+'\">https://'+location.host+'</a> instead ...</tt>';".
+				"noscript.insertAdjacentHTML('afterend', redirect);".
 				"if (location.protocol != 'https:') {".
-				"  location.protocol = 'https:';".
+				"  setTimeout(function(){location.protocol = 'https:'},4000);".
 				"}".
 				"</script>",
 				0, 1, 1);

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1399,12 +1399,19 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 			}
 		local $url = $wantport == 443 ? "https://$urlhost/"
 					      : "https://$urlhost:$wantport/";
+		local $jsurl = $config{'musthost'} ?
+				                   $url :
+				                   "https://'+location.host+'";
+		local $jsredir = $config{'musthost'} ?
+				                   "location.href='$url'" :
+				                   "location.protocol='https:'";
 		&http_error(200, "Document follows",
 			"This web server is running in SSL mode. ".
-			"Try the URL <a href='$url'>$url</a> instead.".
+			"Trying to redirect to <a href='$url'>$url</a> instead URL ...".
 			"<script>".
 			"if (location.protocol != 'https:') {".
-			"  location.protocol = 'https:';".
+			"  document.querySelector('a').href='".$jsurl."';document.querySelector('a').innerText='".$jsurl."';".
+			"".$jsredir."".
 			"}".
 			"</script>",
 			0, 1);

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1447,14 +1447,16 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 		} elsif ($config{'hide_admin_url'} != 1) {
 			# Tell user the correct URL
 			&http_error(200, "Document follows",
+				"<noscript>".
+				"<h2 class=\"err-head\">Error — Document follows</h2>".
 				"This web server is running in SSL mode. ".
-				"Try the URL <a href='$url'>$url</a> instead.".
+				"Try the URL <a href='$url'>$url</a> instead.</noscript>".
 				"<script>".
 				"if (location.protocol != 'https:') {".
 				"  location.protocol = 'https:';".
 				"}".
 				"</script>",
-				0, 1);
+				0, 1, 1);
 		} else {
 			# Throw an error
 			&http_error(404, "Page not found",
@@ -2846,7 +2848,7 @@ return $rv;
 # Output an error message to the browser, and log it to the error log
 sub http_error
 {
-my ($code, $msg, $body, $noexit, $noerr) = @_;
+my ($code, $msg, $body, $noexit, $noerr, $nohead) = @_;
 local $eh = $error_handler_recurse ? undef :
 	    $config{"error_handler_".$code} ? $config{"error_handler_".$code} :
 	    $config{'error_handler'} ? $config{'error_handler'} : undef;
@@ -2872,7 +2874,9 @@ else {
 	&reset_byte_count();
 	&write_data("<html>\n");
 	&write_data("<head>".&embed_error_styles($roots[0])."<title>$code &mdash; $msg</title></head>\n");
-	&write_data("<body class=\"err-body\"><h2 class=\"err-head\">Error &mdash; $msg</h2>\n");
+	my $errhead = "<h2 class=\"err-head\">Error &mdash; $msg</h2>";
+	$errhead = undef if ($nohead);
+	&write_data("<body class=\"err-body\">$errhead\n");
 	if ($body) {
 		&write_data("<p class=\"err-content\">$body</p>\n");
 		}

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1452,14 +1452,15 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 				"Try the URL <a style=\"color: #f12b2b\" ".
 				"href='$url'>$url</a> instead.</tt></noscript>".
 				"<script>".
-				"var noscript = document.querySelector('noscript');".
+				"var timeout = 4000;".
+				"try {var noscript = document.querySelector('noscript');".
 				"var redirect = '<tt>This web server is running in SSL mode.<br>".
 				"Redirecting to the URL ".
 				"<a style=\"color: #f12b2b\" href=\"https://".
 				"'+location.host+'\">https://'+location.host+'</a> ...</tt>';".
-				"noscript.insertAdjacentHTML('afterend', redirect);".
+				"noscript.insertAdjacentHTML('afterend', redirect);}catch(e){timeout = 0;}".
 				"if (location.protocol != 'https:') {".
-				"  setTimeout(function(){location.protocol = 'https:'},4000);".
+				"  setTimeout(function(){location.protocol = 'https:'},timeout);".
 				"}".
 				"</script>",
 				0, 1, 1);

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1448,15 +1448,15 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 			# Tell user the correct URL
 			&http_error(200, "Document follows",
 				"<noscript>".
-				"<h2 class=\"err-head\">Error — Document follows</h2>".
-				"This web server is running in SSL mode. ".
-				"Try the URL <a href='$url'>$url</a> instead.</noscript>".
+				"<tt>This web server is running in SSL mode.<br>".
+				"Try the URL <a style=\"color: #f12b2b\" ".
+				"href='$url'>$url</a> instead.</tt></noscript>".
 				"<script>".
 				"var noscript = document.querySelector('noscript');".
 				"var redirect = '<tt>This web server is running in SSL mode.<br>".
 				"Redirecting to the URL ".
 				"<a style=\"color: #f12b2b\" href=\"https://".
-				"'+location.host+'\">https://'+location.host+'</a> instead ...</tt>';".
+				"'+location.host+'\">https://'+location.host+'</a> ...</tt>';".
 				"noscript.insertAdjacentHTML('afterend', redirect);".
 				"if (location.protocol != 'https:') {".
 				"  setTimeout(function(){location.protocol = 'https:'},4000);".


### PR DESCRIPTION
This fix to redirect without showing a message if JavaScript is enabled, or show a message if there is no JavaScript on the browser support.