### PR TITLE
Fix to allow no port with custom redirect host

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1573,6 +1573,8 @@ if (defined($header{'host'})) {
 $ssl = $config{'redirect_ssl'} ne '' ? $config{'redirect_ssl'} :
 	$use_ssl || $config{'inetd_ssl'};
 $redirport = $config{'redirect_port'} || $port;
+$redirport = $config{'redirect_port'}
+	if ($config{'redirect_host'});
 $portstr = $redirport == 80 && !$ssl ? "" :
 	   $redirport == 443 && $ssl ? "" : ":".$redirport;
 $redirhost = $config{'redirect_host'} || $host;


### PR DESCRIPTION
This change will make sure that it will be possible to use correctly redirect after login.

For example, if you configure Webmin behind proxy which proxies to `127.0.0.1:10000` then after login it will redirect to `127.0.0.1:10000` .. this is why we created _Internal redirect URL overrides_ option:

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/4426533/185789595-cdfa7e89-301b-43f1-b8a8-1e446a497166.png">

However, the problem pops up when a user sets _Redirect host_ but leaves _Redirect port_ option _empty_. Then redirect would happen to in my example `alma9-pro.ilia.engineer:10000` which is undesirable.

Currently there is no way to work around this at all, and it's practically broken. This change will make sure that a user would need to be forced to set the port explicitly (if needed in super rare cases) if custom hostname is defined.