### PR TITLE
Fix to use correct URL name ; consider `musthost` option

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1407,7 +1407,7 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 				                   "location.protocol='https:'";
 		&http_error(200, "Document follows",
 			"This web server is running in SSL mode. ".
-			"Trying to redirect to <a href='$url'>$url</a> instead URL ...".
+			"Trying to redirect to <a href='$url'>$url</a> instead ...".
 			"<script>".
 			"if (location.protocol != 'https:') {".
 			"  document.querySelector('a').href='".$jsurl."';document.querySelector('a').innerText='".$jsurl."';".

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1399,12 +1399,19 @@ elsif ($reqline !~ /^(\S+)\s+(.*)\s+HTTP\/1\..$/) {
 			}
 		local $url = $wantport == 443 ? "https://$urlhost/"
 					      : "https://$urlhost:$wantport/";
+		local $jsurl = $config{'musthost'} ?
+				                   $url :
+				                   "https://'+location.host+'";
+		local $jsredir = $config{'musthost'} ?
+				                   "location.href='$url'" :
+				                   "location.protocol='https:'";
 		&http_error(200, "Document follows",
 			"This web server is running in SSL mode. ".
-			"Try the URL <a href='$url'>$url</a> instead.".
+			"Trying to redirect to <a href='$url'>$url</a> instead URL ...".
 			"<script>".
 			"if (location.protocol != 'https:') {".
-			"  location.protocol = 'https:';".
+			"  document.querySelector('a').href='".$jsurl."';document.querySelector('a').innerText='".$jsurl."';".
+			"".$jsredir."".
 			"}".
 			"</script>",
 			0, 1);


### PR DESCRIPTION
This PR replaces previous PR. It is more simple and works in all browsers.

This PR:

   * Considers `musthost` option
   * Prints correct _hostname_ in UI to make it look consistent, otherwise it may say redirecting to `smtp.hostname.local` and eventually redirect to `window.location.host` (which may be completely different host)