### PR TITLE
Update save_profile.cgi

### DIFF
--- a/burner/save_profile.cgi
+++ b/burner/save_profile.cgi
@@ -130,6 +130,7 @@ if ($in{'burn'} || $in{'test'}) {
 		$iso = $config{'temp'} ? "$config{'temp'}/burner.iso"
 				       : &tempname("burner.iso");
 		local $cmd = "$config{'mkisofs'} -graft-points -o $iso";
+		$cmd .= " -iso-level 3";
 		$cmd .= " -J" if ($profile->{'joliet'});
 		$cmd .= " --netatalk" if ($profile->{'netatalk'});
 		$cmd .= " --cap" if ($profile->{'cap'});


### PR DESCRIPTION
allows to create and burn (backup) files > 4GB and long filenames
--
todo: maybe allow users to choose level in iso-setup