### PR TITLE
Fix LetsEncrypt dynamic dns zones

### DIFF
--- a/webmin/letsencrypt-cleanup.pl
+++ b/webmin/letsencrypt-cleanup.pl
@@ -67,4 +67,11 @@ else {
 	&virtual_server::reload_bind_records($d);
 	}
 
+# Clean up any dynamic record
+use Net::DNS;
+my $update = Net::DNS::Update->new( $dname );
+$update->push( update => rr_del('_acme-challenge.'.$dname.' TXT') );       my $resolver = Net::DNS::Resolver->new();
+$resolver->nameservers('127.0.0.1');
+my $reply = $resolver->send($update);
+
 &webmin_log("letsencryptcleanup", undef, $dname);

--- a/webmin/letsencrypt-dns.pl
+++ b/webmin/letsencrypt-dns.pl
@@ -67,6 +67,14 @@ else {
 			      $r->{'type'}, $r->{'values'}->[0]);
 	}
 
+# Create via dynamic update for dynamic zones
+use Net::DNS;
+my $update = Net::DNS::Update->new( $dname );
+$update->push( update => rr_add('_acme-challenge.'.$dname.' 5 TXT "'.$val.'"') );
+my $resolver = Net::DNS::Resolver->new();
+$resolver->nameservers('127.0.0.1');
+my $reply = $resolver->send($update);
+
 my $err;
 if (!$wapi) {
 	# Apply using BIND API calls


### PR DESCRIPTION
This PR patches the LetsEncrypt auth-hook and cleanup-hook perl scripts to add in RFC2136 based dynamic zone updates to add and delete the required TXT record for dynamic DNS zones.

Tested with both dynamic and static BIND DNS zones successfully.

Closes: #1752 