### PR TITLE
Add special flavors to a new Terminal module

### DIFF
--- a/xterm/config
+++ b/xterm/config
@@ -1,1 +1,2 @@
 base_port=555
+flavors=1

--- a/xterm/config
+++ b/xterm/config
@@ -1,2 +1,2 @@
 base_port=555
-flavors=1
+noflavors=0

--- a/xterm/config
+++ b/xterm/config
@@ -1,2 +1,2 @@
 base_port=555
-noflavors=0
+flavors=1

--- a/xterm/config
+++ b/xterm/config
@@ -1,1 +1,2 @@
 base_port=555
+flavors=0

--- a/xterm/config
+++ b/xterm/config
@@ -1,2 +1,1 @@
 base_port=555
-flavors=1

--- a/xterm/config.info
+++ b/xterm/config.info
@@ -1,3 +1,3 @@
 base_port=Base port number for WebSockets connections,0,5
 size=Terminal width and height in characters,3,Automatic,5,,,Static (80x24)
-flavors=Enable inbuilt command prompt color customization,1,1-Yes,0-No
+noflavors=Disable inbuilt command prompt color customization,1,1-Yes,0-No

--- a/xterm/config.info
+++ b/xterm/config.info
@@ -1,2 +1,3 @@
 base_port=Base port number for WebSockets connections,0,5
 size=Terminal width and height in characters,3,Automatic,5,,,Static (80x24)
+flavors=Enable inbuilt command prompt color customization,1,1-Yes,0-No

--- a/xterm/config.info
+++ b/xterm/config.info
@@ -1,3 +1,3 @@
 base_port=Base port number for WebSockets connections,0,5
 size=Terminal width and height in characters,3,Automatic,5,,,Static (80x24)
-noflavors=Disable inbuilt command prompt color customization,1,1-Yes,0-No
+flavors=Enable inbuilt command prompt color customization,1,1-Yes,0-No

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -201,7 +201,7 @@ if ($user eq "root" && $in{'user'}) {
 
 # Terminal flavors
 my (@cmds, $term_flavors);
-if (!$config{'noflavors'}) {
+if ($config{'flavors'}) {
 	my ($cmd_lsalias, $cmd_ps1) = ("alias ls='ls --color=auto'");
 
 	# Optionally add colors to the prompt depending on the user type

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -270,11 +270,13 @@ print "<script>\n";
 if ($xmlhr) {
 	print "var xterm_argv = ".
 	      &convert_to_json(
-			{ 'files' => $termlinks,
-			  'cols' => $env_cols,
-			  'rows' => $env_rows,
-			  'port' => $port,
-			  'socket_url' => $url });
+			{ 'conf'  => \%config,
+              'files' => $termlinks,
+              'socket_url' => $url,
+              'port'  => $port,
+              'cols'  => $env_cols,
+              'rows'  => $env_rows,
+              'ps1'   => $ps1 });
 	}
 else {
 	print $term_script;

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -113,6 +113,19 @@ body[style='height:100%'] {
 #terminal + script ~ * {
 	display: none
 }
+#terminal > .terminal {
+	visibility: hidden;
+	animation: .15s fadeIn;
+	animation-fill-mode: forwards;
+}
+\@keyframes fadeIn {
+  99% {
+    visibility: hidden;
+  }
+  100% {
+    visibility: visible;
+  }
+}
 
 EOF
 

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -201,7 +201,7 @@ if ($user eq "root" && $in{'user'}) {
 
 # Terminal flavors
 my (@cmds, $term_flavors);
-if ($config{'flavors'}) {
+if (!$config{'noflavors'}) {
 	my ($cmd_lsalias, $cmd_ps1) = ("alias ls='ls --color=auto'");
 
 	# Optionally add colors to the prompt depending on the user type

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -215,8 +215,8 @@ if ($config{'flavors'}) {
                "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
                "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
 		}
-	$term_flavors = "socket.send(\"alias ls='ls --color=auto'\\r\"); ".
-                    "socket.send(\"$ps1\\r\");";
+	$term_flavors = "socket.send(\" alias ls='ls --color=auto'\\r\"); ".
+                    "socket.send(\" $ps1\\r\");";
 	}
 
 # Check for directory to start the shell in
@@ -251,7 +251,7 @@ my $term_script = <<EOF;
 		term.open(termcont);
 		term.focus();
 		$term_flavors
-		socket.send('clear\\r');
+		socket.send(' clear\\r');
 	};
 	socket.onerror = function() {
 		termcont.innerHTML = '<tt style="color: \#ff0000">Error: ' +

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -202,9 +202,6 @@ if ($user eq "root" && $in{'user'}) {
 # Terminal flavors
 my (@cmds, $term_flavors);
 if ($config{'flavors'}) {
-
-	$ENV{'HISTCONTROL'} = 'ignoredups:ignorespace';
-
 	my ($cmd_lsalias, $cmd_ps1) = ("alias ls='ls --color=auto'");
 
 	# Optionally add colors to the prompt depending on the user type
@@ -236,6 +233,7 @@ if (!-r $shellserver_cmd) {
 	}
 defined(getpwnam($user)) || &error(&text('index_euser', &html_escape($user)));
 my $tmpdir = &tempname_dir();
+$ENV{'HISTCONTROL'} = 'ignoredups:ignorespace';
 $ENV{'SESSION_ID'} = $main::session_id;
 &system_logged($shellserver_cmd." ".quotemeta($port)." ".quotemeta($user).
 	       ($dir ? " ".quotemeta($dir) : "").

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -200,25 +200,29 @@ if ($user eq "root" && $in{'user'}) {
 	}
 
 # Terminal flavors
-my ($ps1, $term_flavors);
+my (@cmds, $term_flavors);
 if ($config{'flavors'}) {
 
 	$ENV{'HISTCONTROL'} = 'ignoredups:ignorespace';
+
+	my ($cmd_lsalias, $cmd_ps1) = ("alias ls='ls --color=auto'");
+
 	# Optionally add colors to the prompt depending on the user type
 	if ($user eq "root") {
 		# magenta@blue ~# (for root)
-		$ps1 = "PS1='\\\\[\\\\033[1;35m\\\\]\\\\u\\\\[\\\\033[1;37m\\\\]".
-               "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
-               "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
+		$cmd_ps1 = "PS1='\\\\[\\\\033[1;35m\\\\]\\\\u\\\\[\\\\033[1;37m\\\\]".
+                   "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
+                   "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
 		}
 	else {
 		# green@blue ~$ (for regular users)
-		$ps1 = "PS1='\\\\[\\\\033[1;32m\\\\]\\\\u\\\\[\\\\033[1;37m\\\\]".
-               "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
-               "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
+		$cmd_ps1 = "PS1='\\\\[\\\\033[1;32m\\\\]\\\\u\\\\[\\\\033[1;37m\\\\]".
+                   "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
+                   "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
 		}
-	$term_flavors = "socket.send(\" alias ls='ls --color=auto'\\r\"); ".
-                    "socket.send(\" $ps1\\r\");";
+	$term_flavors = "socket.send(\" $cmd_lsalias\\r\"); ".
+                    "socket.send(\" $cmd_ps1\\r\");";
+    push(@cmds, $cmd_ps1, $cmd_lsalias);
 	}
 
 # Check for directory to start the shell in
@@ -271,14 +275,14 @@ EOF
 print "<script>\n";
 if ($xmlhr) {
 	print "var xterm_argv = ".
-	      &convert_to_json(
-			{ 'conf'  => \%config,
+          &convert_to_json(
+            { 'conf'  => \%config,
               'files' => $termlinks,
               'socket_url' => $url,
               'port'  => $port,
               'cols'  => $env_cols,
               'rows'  => $env_rows,
-              'ps1'   => $ps1 });
+              'cmds'  => \@cmds });
 	}
 else {
 	print $term_script;

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -186,6 +186,26 @@ if ($user eq "root" && $in{'user'}) {
 	$user = $in{'user'};
 	}
 
+# Terminal flavors
+my ($ps1, $term_flavors);
+if ($config{'flavors'}) {
+	# Optionally add colors to the prompt depending on the user type
+	if ($user eq "root") {
+		# magenta@blue ~# (for root)
+		$ps1 = "PS1='\\\\[\\\\033[1;35m\\\\]\\\\u\\\\[\\\\033[1;37m\\\\]".
+               "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
+               "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
+		}
+	else {
+		# green@blue ~$ (for regular users)
+		$ps1 = "PS1='\\\\[\\\\033[1;32m\\\\]\\\\u\\\\[\\\\033[1;37m\\\\]".
+               "@\\\\[\\\\033[1;34m\\\\]\\\\h:\\\\[\\\\033[1;37m\\\\]".
+               "\\\\w\\\\[\\\\033[1;37m\\\\]\\\\\$\\\\[\\\\033[0m\\\\] '";
+		}
+	$term_flavors = "socket.send(\"alias ls='ls --color=auto'\\r\"); ".
+                    "socket.send(\"$ps1\\r\");";
+	}
+
 # Check for directory to start the shell in
 my $dir = $in{'dir'};
 
@@ -217,6 +237,7 @@ my $term_script = <<EOF;
 		term.loadAddon(attachAddon);
 		term.open(termcont);
 		term.focus();
+		$term_flavors
 		socket.send('clear\\r');
 	};
 	socket.onerror = function() {

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -202,6 +202,8 @@ if ($user eq "root" && $in{'user'}) {
 # Terminal flavors
 my ($ps1, $term_flavors);
 if ($config{'flavors'}) {
+
+	$ENV{'HISTCONTROL'} = 'ignoredups:ignorespace';
 	# Optionally add colors to the prompt depending on the user type
 	if ($user eq "root") {
 		# magenta@blue ~# (for root)


### PR DESCRIPTION
This PR fixes/improves:

  1. Fixes sent init commands (such as `clear` and other) via socket won't be stored in `bash` history
  2. Fixes initial command line prompt shown with 150 ms delay to make sure initial commands won't be reflected in UI
  3. Adds (optional) colors to `ls` command
  3. Adds (optional) colors to `bash` prompt depending on the user

For _root_ capable users (magenta user name and blue host):

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/4426533/199052624-aa6d7972-a9ce-4911-a664-9f395dbed171.png">

For regular users (green user and blue host):

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/4426533/199052883-7c07babe-312e-4aa0-986c-4b6636362ee0.png">


This will make our Terminal look distinctive and improves UX.