### PR TITLE
Fix connecting to external IPv6 LDAP server

### DIFF
--- a/ldap-server/ldap-server-lib.pl
+++ b/ldap-server/ldap-server-lib.pl
@@ -39,8 +39,8 @@ local ($server, $port, $user, $pass, $ssl);
 if ($config{'server'}) {
 	# Remote box .. everything must be set
 	$server = $config{'server'};
-	&to_ipaddress($server) || return &text('connect_eserver',
-					       "<tt>$server</tt>");
+	&to_ipaddress($server) || &to_ip6address($server) ||
+		return &text('connect_eserver', "<tt>$server</tt>");
 	$port = $config{'port'};
 	$user = $config{'user'};
 	$user || return $text{'connect_euser'};


### PR DESCRIPTION
If the provided hostname couldn't be translated to IPv4 address or wasn't IPv4 address, Webmin threw error:
"The LDAP server $1 does not exist".