### PR TITLE
Add support to set TERM variable and shell character encoding

### DIFF
--- a/xterm/config
+++ b/xterm/config
@@ -1,2 +1,3 @@
 base_port=555
 rcfile=0
+xterm=xterm-256color

--- a/xterm/config
+++ b/xterm/config
@@ -1,3 +1,4 @@
+xterm=xterm-256color
 base_port=555
 rcfile=0
-xterm=xterm-256color
+locale=0

--- a/xterm/config.info
+++ b/xterm/config.info
@@ -1,4 +1,5 @@
 xterm=Set <tt>TERM</tt> environmental variable to,4,0-xterm&#45;256color,1-xterm&#45;16color,2-xterm,3-vt102,3-vt100,4-vt52,5-rxvt,6-nsterm,7-dtterm,8-ansi
 base_port=Base port number for WebSockets connections,0,5
 size=Terminal width and height in characters,3,Automatic,5,,,Static (80x24)
+locale=Set shell character encoding,10,0-Shell default,1-<tt>en_US.UTF&#45;8</tt>,Custom
 rcfile=Execute initialization commands from file,10,0-Shell default,1-Module default,Custom

--- a/xterm/config.info
+++ b/xterm/config.info
@@ -1,4 +1,4 @@
-xterm=Set <tt>TERM</tt> environmental variable to,4,0-xterm&#45;256color,1-xterm&#45;16color,2-xterm,3-vt102,3-vt100,4-vt52,5-rxvt,6-nsterm,7-dtterm,8-ansi
+xterm=Set <tt>TERM</tt> environmental variable to,4,xterm+256color-xterm&#45;256color,xterm+16color-xterm&#45;16color,xterm-xterm,vt102-vt102,vt100-vt100,vt52-vt52,rxvt-rxvt,nsterm-nsterm,dtterm-dtterm,ansi-ansi
 base_port=Base port number for WebSockets connections,0,5
 size=Terminal width and height in characters,3,Automatic,5,,,Static (80x24)
 locale=Set shell character encoding,10,0-Shell default,1-<tt>en_US.UTF&#45;8</tt>,Custom

--- a/xterm/config.info
+++ b/xterm/config.info
@@ -1,3 +1,4 @@
+xterm=Set <tt>TERM</tt> environmental variable to,4,0-xterm&#45;256color,1-xterm&#45;16color,2-xterm,3-vt102,3-vt100,4-vt52,5-rxvt,6-nsterm,7-dtterm,8-ansi
 base_port=Base port number for WebSockets connections,0,5
 size=Terminal width and height in characters,3,Automatic,5,,,Static (80x24)
 rcfile=Execute initialization commands from file,10,0-Shell default,1-Module default,Custom

--- a/xterm/shellserver.pl
+++ b/xterm/shellserver.pl
@@ -29,7 +29,8 @@ else {
 &clean_environment();
 
 # Set terminal
-$ENV{'TERM'} = 'xterm-256color';
+my @terms = ('xterm-256color', 'xterm-16color', 'xterm', 'vt102', 'vt100', 'vt52', 'rxvt', 'nsterm', 'dtterm', 'ansi');
+$ENV{'TERM'} = defined($config{'xterm'}) ? $terms[$config{'xterm'}] : 'xterm-256color';
 $ENV{'HOME'} = $uinfo[7];
 chdir($dir || $uinfo[7] || "/");
 my $shellcmd = $uinfo[8];

--- a/xterm/shellserver.pl
+++ b/xterm/shellserver.pl
@@ -39,8 +39,11 @@ if ($lang) {
 	}
 
 # Set terminal
-my @terms = ('xterm-256color', 'xterm-16color', 'xterm', 'vt102', 'vt100', 'vt52', 'rxvt', 'nsterm', 'dtterm', 'ansi');
-$ENV{'TERM'} = defined($config{'xterm'}) ? $terms[$config{'xterm'}] : 'xterm-256color';
+my $config_xterm = $config{'xterm'};
+$config_xterm = 'xterm-256color'
+	if (!$config_xterm);
+$config_xterm =~ s/\+/-/;
+$ENV{'TERM'} = $config_xterm;
 $ENV{'HOME'} = $uinfo[7];
 chdir($dir || $uinfo[7] || "/");
 my $shellcmd = $uinfo[8];

--- a/xterm/shellserver.pl
+++ b/xterm/shellserver.pl
@@ -28,6 +28,16 @@ else {
 &foreign_require("proc");
 &clean_environment();
 
+# Set locale
+my $lang = $config{'locale'};
+if ($lang) {
+	my @opts = ('LC_ALL', 'LANG', 'LANGUAGE');
+	$lang = 'en_US.UTF-8' if ($lang == 1);
+	foreach my $opt (@opts) {
+		$ENV{$opt} = &trim($lang);
+		}
+	}
+
 # Set terminal
 my @terms = ('xterm-256color', 'xterm-16color', 'xterm', 'vt102', 'vt100', 'vt52', 'rxvt', 'nsterm', 'dtterm', 'ansi');
 $ENV{'TERM'} = defined($config{'xterm'}) ? $terms[$config{'xterm'}] : 'xterm-256color';


### PR DESCRIPTION
This PR adds ability to set `TERM` variable and shell character encoding from module config:

<img width="608" alt="image" src="https://user-images.githubusercontent.com/4426533/205525037-f1c6bb4f-3657-4d56-b822-52d59df0dbd7.png">
