### PR TITLE
Fix for file chooser not displayed correctly in bacula module

### DIFF
--- a/bacula-backup/list.cgi
+++ b/bacula-backup/list.cgi
@@ -2,7 +2,7 @@
 # Returns a list of files and directories under some directory
 
 $trust_unknown_referers = 1;
-require './bacula-backup-lib.pl';
+BEGIN { require './bacula-backup-lib.pl'; }
 &ReadParse();
 
 # Input sanitization


### PR DESCRIPTION
This PR fixes the file chooser not displaying correctly in the bacula module when restoring.

List.cgi needs JSON::PP which is now included via bacula-backup-lib.pl. Without a BEGIN block around the require, JSON::PP was not visible (soon enough?).

Closes: #1833 