### PR TITLE
fix displaying perviously selected users

### DIFF
--- a/user_chooser.cgi
+++ b/user_chooser.cgi
@@ -19,7 +19,7 @@ if ($in{'multi'}) {
 		# base frame
 		&PrintHeader();
 		print "<script type='text/javascript'>\n";
-		@ul = &split_quoted_string(/\s+/, &filter_javascript($in{'user'}));
+		@ul = &split_quoted_string(&filter_javascript($in{'user'}));
 		$len = @ul;
 		print "sel = new Array($len);\n";
 		print "selr = new Array($len);\n";


### PR DESCRIPTION
Looks like a typo, but it was preventing displaying previously selected users if you try to edit valid users list from Samba module
Groups selector doesn't have that typo