### PR TITLE
Add support for loading given modules info in background only on initial Dashboard load

### DIFF
--- a/package-updates/package-updates-lib.pl
+++ b/package-updates/package-updates-lib.pl
@@ -46,7 +46,7 @@ if (!$get_software_packages_cache) {
 return $get_software_packages_cache;
 }
 
-# list_current(nocache)
+# list_current([nocache])
 # Returns a list of packages and versions for installed software. Keys are :
 #  name - The my package name (ie. CSWapache2)
 #  update - Name used to refer to it by the updates system (ie. apache2)
@@ -418,15 +418,16 @@ if (defined(&software::update_system_operations)) {
 return ( );
 }
 
-# list_possible_updates([nocache])
+# list_possible_updates([nocache], [nocache-no-data])
 # Returns a list of updates that are available. Each element in the array
 # is a hash ref containing a name, version, description and severity flag.
 # Intended for calling from themes. Nocache 0=cache everything, 1=flush all
-# caches, 2=flush only current
+# caches, 2=flush only current. Nocache-no-data prohibits collecting data
 sub list_possible_updates
 {
-my ($nocache) = @_;
+my ($nocache, $nocache_no_data) = @_;
 my @rv;
+return @rv if ($nocache_no_data);
 my @current = &list_current($nocache);
 if (&supports_updates_available()) {
 	# Software module supplies a function that can list just packages

--- a/package-updates/package-updates-lib.pl
+++ b/package-updates/package-updates-lib.pl
@@ -677,10 +677,13 @@ return $mode eq 'updates' || $mode eq 'security' ?
 	&list_possible_updates($nocache) : &list_available($nocache);
 }
 
-# check_reboot_required(after-flag)
+# check_reboot_required([no-collect])
 # Returns 1 if the package system thinks a reboot is needed
+# If the no-collect flag is set, then check won't happen
 sub check_reboot_required
 {
+my ($no_collect) = @_;
+return 0 if ($no_collect);
 if ($gconfig{'os_type'} eq 'debian-linux') {
         return -e "/var/run/reboot-required" ? 1 : 0;
         }

--- a/package-updates/update.cgi
+++ b/package-updates/update.cgi
@@ -108,7 +108,7 @@ else {
 		}
 	else {
 		# Check if a reboot was required before
-		$reboot_before = &check_reboot_required(0);
+		$reboot_before = &check_reboot_required();
 
 		# Do it
 		$msg = $in{'mode'} eq 'new' ? 'update_pkg2' : 'update_pkg';
@@ -165,7 +165,7 @@ else {
 			}
 
 		# Check if a reboot is required now
-		if (!$reboot_before && &check_reboot_required(1) &&
+		if (!$reboot_before && &check_reboot_required() &&
 		    &foreign_check("init")) {
 			print &ui_form_start(
 				"@{[&get_webprefix()]}/init/reboot.cgi");

--- a/system-status/system-status-lib.pl
+++ b/system-status/system-status-lib.pl
@@ -69,7 +69,7 @@ if (&foreign_installed("package-updates") && $config{'collect_pkgs'}) {
 	my $poss_current = !$poss_collect_blocked ? 2 : undef;
 	my @poss = &package_updates::list_possible_updates(undef, $poss_collect_blocked);
 	$info->{'poss'} = \@poss;
-	$info->{'reboot'} = &package_updates::check_reboot_required();
+	$info->{'reboot'} = &package_updates::check_reboot_required($poss_collect_blocked);
 	}
 
 # CPU and drive temps

--- a/system-status/system-status-lib.pl
+++ b/system-status/system-status-lib.pl
@@ -65,7 +65,7 @@ if (&foreign_check("mount")) {
 # Available package updates
 if (&foreign_installed("package-updates") && $config{'collect_pkgs'}) {
 	&foreign_require("package-updates");
-	my $poss_collect_blocked = grep(/^\Qpackage-updates\E$/, @{$modskip});
+	my $poss_collect_blocked = (&indexof('package-updates', @{$modskip}) > -1);
 	my $poss_current = !$poss_collect_blocked ? 2 : undef;
 	my @poss = &package_updates::list_possible_updates(undef, $poss_collect_blocked);
 	$info->{'poss'} = \@poss;

--- a/system-status/system-status-lib.pl
+++ b/system-status/system-status-lib.pl
@@ -24,7 +24,8 @@ our $get_collected_info_cache;
 # Returns a hash reference containing system information
 sub collect_system_info
 {
-my ($manual) = @_;
+my ($manual, $modskip) = @_;
+$modskip ||= [];
 my $info = { };
 
 if (&foreign_check("proc")) {
@@ -64,7 +65,9 @@ if (&foreign_check("mount")) {
 # Available package updates
 if (&foreign_installed("package-updates") && $config{'collect_pkgs'}) {
 	&foreign_require("package-updates");
-	my @poss = &package_updates::list_possible_updates(2, 1);
+	my $poss_collect_blocked = grep(/^\Qpackage-updates\E$/, @{$modskip});
+	my $poss_current = !$poss_collect_blocked ? 2 : undef;
+	my @poss = &package_updates::list_possible_updates(undef, $poss_collect_blocked);
 	$info->{'poss'} = \@poss;
 	$info->{'reboot'} = &package_updates::check_reboot_required();
 	}
@@ -105,7 +108,7 @@ return $info;
 # Returns the most recently collected system information, or the current info
 sub get_collected_info
 {
-my ($manual) = @_;
+my ($manual, $modskip) = @_;
 if (!defined($manual) ||
      defined($manual) && $manual ne 'manual') {
 	if ($get_collected_info_cache) {
@@ -124,7 +127,7 @@ if (!defined($manual) ||
 			}
 		}
 	}
-$get_collected_info_cache ||= &collect_system_info($manual);
+$get_collected_info_cache ||= &collect_system_info($manual, $modskip);
 return $get_collected_info_cache;
 }
 

--- a/system-status/system_info.pl
+++ b/system-status/system_info.pl
@@ -10,7 +10,8 @@ our (%text, %gconfig, $module_name, %config);
 # Returns general information about the system, such as available disk space
 sub list_system_info
 {
-my $info = &get_collected_info();
+my ($data, $in, $modskip) = @_;
+my $info = &get_collected_info(undef, $modskip);
 my @rv;
 my @table;
 my @raw = $info;

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -12103,7 +12103,7 @@ return { 'type' => 'item',
          'link' => '/'.$minfo->{'dir'}.'/' };
 }
 
-=head2 list_combined_system_info(&data, &in)
+=head2 list_combined_system_info(&data, &in, [&modskip])
 
 Returns an array of objects, each representing a block of system information
 to display. Each is a hash ref with the following keys :
@@ -12179,15 +12179,17 @@ use where a system info block has a form that submits to itself.
 =cut
 sub list_combined_system_info
 {
-my ($data, $in) = @_;
+my ($data, $in, $modskip) = @_;
 &load_theme_library();
+$modskip ||= [];
 foreach my $m (&get_all_module_infos()) {
+	next if (grep(/^\Q$m->{'dir'}\E$/, @{$modskip}));
 	my $dir = &module_root_directory($m->{'dir'});
 	my $mfile = "$dir/system_info.pl";
 	next if (!-r $mfile);
 	&foreign_require($m->{'dir'}, "system_info.pl");
 	foreach my $i (&foreign_call($m->{'dir'}, "list_system_info",
-				     $data, $in)) {
+				     $data, $in, $modskip)) {
 		$i->{'module'} = $m->{'dir'};
 		push(@rv, $i);
 		}

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -12183,7 +12183,7 @@ my ($data, $in, $modskip) = @_;
 &load_theme_library();
 $modskip ||= [];
 foreach my $m (&get_all_module_infos()) {
-	next if (grep(/^\Q$m->{'dir'}\E$/, @{$modskip}));
+	next if (&indexof($m->{'dir'}, @{$modskip}) > -1);
 	my $dir = &module_root_directory($m->{'dir'});
 	my $mfile = "$dir/system_info.pl";
 	next if (!-r $mfile);
@@ -12194,7 +12194,7 @@ foreach my $m (&get_all_module_infos()) {
 		push(@rv, $i);
 		}
 	}
-if (!grep(/^webmin$/, @{$modskip}) && &foreign_available("webmin")) {
+if ((&indexof('webmin', @{$modskip}) == -1) && &foreign_available("webmin")) {
 	# Merge in old-style notification API
 	&foreign_require("webmin");
 	foreach my $n (&webmin::get_webmin_notifications()) {

--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -12194,7 +12194,7 @@ foreach my $m (&get_all_module_infos()) {
 		push(@rv, $i);
 		}
 	}
-if (&foreign_available("webmin")) {
+if (!grep(/^webmin$/, @{$modskip}) && &foreign_available("webmin")) {
 	# Merge in old-style notification API
 	&foreign_require("webmin");
 	foreach my $n (&webmin::get_webmin_notifications()) {

--- a/webmin/webmin-lib.pl
+++ b/webmin/webmin-lib.pl
@@ -1298,7 +1298,7 @@ if (&foreign_check("package-updates") && &foreign_available("init")) {
 				}
 			}
 		}
-	if (&package_updates::check_reboot_required() && $allow_reboot_required) {
+	if ($allow_reboot_required && &package_updates::check_reboot_required()) {
 		push(@notifs,
 			&ui_form_start("@{[&get_webprefix()]}/init/reboot.cgi").
 			$text{'notif_reboot'}."<p>\n".


### PR DESCRIPTION
This patch will allow Authentic theme not to process any possible available packages updates on the Dashboard load making it much faster. It will only use currently collected data from `system-status` module on initial Dashboard load. It will especially be noticeable if `package-updates` cache is not present.

Also, I believe there is some other bug as well, probably in `system-status` module. So, after background collection was run, the Dashboard load jumps 2x of time.

That is unrelated to this PR, I think but could you also double check why after background collection was run the Dashboard load doubles in time? And by the way -- restarting Webmin fixes it!