### PR TITLE
Fix wrong condition when asking first

### DIFF
--- a/setup-repos.sh
+++ b/setup-repos.sh
@@ -87,7 +87,7 @@ fi
 # Ask first
 printf "Setup Webmin official repository? (y/N) "
 read -r sslyn
-if [ "$sslyn" != "y" ] || [ "$sslyn" = "Y" ]; then
+if [ "$sslyn" != "y" ] && [ "$sslyn" != "Y" ]; then
   exit
 fi
 


### PR DESCRIPTION
The second test was wrong, it exits if the user asks with a capital Y. Fix by exiting only if the answer from the user is different from a lowercase y AND a capital Y