### PR TITLE
Fixes webmin/webmin#1894

### DIFF
--- a/samba/samba-lib.pl
+++ b/samba/samba-lib.pl
@@ -646,7 +646,7 @@ if ($has_pdbedit) {
 	local $out = &backquote_logged(
 		"cd / && $config{'pdbedit'} -a -s $config{'smb_conf'} -t -u ".
 		quotemeta($user->{'name'}).
-		($config{'sync_gid'} ? " -G $config{'sync_gid'}" : "").
+		($config{'sync_gid'} ? " -g $config{'sync_gid'}" : "").
 		" -c '[".join("", @opts)."]' $ws <$temp 2>&1");
 	$? && &error("$config{'pdbedit'} failed : <pre>$out</pre>");
 	}


### PR DESCRIPTION
Invalid option for pdbedit in samba-lib.pl that broke due to a recent update of samba-common