### PR TITLE
Prefer rpmbuild dir, even when building as root

### DIFF
--- a/makemodulerpm.pl
+++ b/makemodulerpm.pl
@@ -19,8 +19,11 @@ if (-d "$ENV{'HOME'}/redhat") {
 elsif (-d "$ENV{'HOME'}/rpmbuild") {
 	$basedir = "$ENV{'HOME'}/rpmbuild";
 	}
-else {
+elsif ( -d "/usr/src/redhat") {
 	$basedir = "/usr/src/redhat";
+	}
+else {
+	$basedir = "/usr/src/rpmbuild";
 	}
 my $target_dir = "$basedir" . "/RPMS/noarch";	# where to copy the RPM to
 


### PR DESCRIPTION
`redhat` stopped being the default path for RPM builds around RHEL 3 or 4. And, though most folks will only ever build as a normal user and not root, I'm building modules via github actions which does run as root (and on Ubuntu), and I prefer to use the modern conventional location.