### PR TITLE
Fix to save protocols to global config file

### DIFF
--- a/dovecot/dovecot-lib.pl
+++ b/dovecot/dovecot-lib.pl
@@ -33,18 +33,17 @@ return &get_config_file();
 # Returns a list of dovecot config entries
 sub get_config
 {
-my ($excl_tpl) = @_;
 if (!@get_config_cache) {
-	@get_config_cache = &read_config_file(&get_config_file(), undef, $excl_tpl);
+	@get_config_cache = &read_config_file(&get_config_file());
 	}
 return \@get_config_cache;
 }
 
-# read_config_file(filename, [&include-parent-rv], [exclude-templates])
+# read_config_file(filename, [&include-parent-rv])
 # Convert a file into a list od directives
 sub read_config_file
 {
-local ($file, $incrv, $excl_tpl) = @_;
+local ($file, $incrv) = @_;
 local $filedir = $file;
 $filedir =~ s/\/[^\/]+$//;
 local $lnum = 0;
@@ -139,7 +138,6 @@ foreach (@lines) {
 	elsif (/^\s*!(include|include_try)\s+(\S+)/) {
 		# Include file(s)
 		local $glob = $2;
-		$lnum++, next if ($glob =~ /^\/usr\/share/ && $excl_tpl);
 		if ($glob !~ /^\//) {
 			$glob = $filedir."/".$glob;
 			}
@@ -218,6 +216,8 @@ return wantarray ? @rv : $rv[0];
 sub save_directive
 {
 local ($conf, $name, $value, $sname, $svalue) = @_;
+$conf = [ grep { $_->{'file'} !~ /^\/usr\/share\/dovecot/ &&
+                 $_->{'file'} !~ /^\/opt/ } @$conf ];
 local $dir;
 if (ref($name)) {
 	# Old directive given

--- a/dovecot/dovecot-lib.pl
+++ b/dovecot/dovecot-lib.pl
@@ -33,17 +33,18 @@ return &get_config_file();
 # Returns a list of dovecot config entries
 sub get_config
 {
+my ($excl_tpl) = @_;
 if (!@get_config_cache) {
-	@get_config_cache = &read_config_file(&get_config_file());
+	@get_config_cache = &read_config_file(&get_config_file(), undef, $excl_tpl);
 	}
 return \@get_config_cache;
 }
 
-# read_config_file(filename, [&include-parent-rv])
+# read_config_file(filename, [&include-parent-rv], [exclude-templates])
 # Convert a file into a list od directives
 sub read_config_file
 {
-local ($file, $incrv) = @_;
+local ($file, $incrv, $excl_tpl) = @_;
 local $filedir = $file;
 $filedir =~ s/\/[^\/]+$//;
 local $lnum = 0;
@@ -138,6 +139,7 @@ foreach (@lines) {
 	elsif (/^\s*!(include|include_try)\s+(\S+)/) {
 		# Include file(s)
 		local $glob = $2;
+		next if ($glob =~ /^\/usr\/share/ && $excl_tpl);
 		if ($glob !~ /^\//) {
 			$glob = $filedir."/".$glob;
 			}
@@ -577,5 +579,4 @@ else {
 }
 
 1;
-r
 

--- a/dovecot/dovecot-lib.pl
+++ b/dovecot/dovecot-lib.pl
@@ -139,7 +139,7 @@ foreach (@lines) {
 	elsif (/^\s*!(include|include_try)\s+(\S+)/) {
 		# Include file(s)
 		local $glob = $2;
-		next if ($glob =~ /^\/usr\/share/ && $excl_tpl);
+		$lnum++, next if ($glob =~ /^\/usr\/share/ && $excl_tpl);
 		if ($glob !~ /^\//) {
 			$glob = $filedir."/".$glob;
 			}

--- a/dovecot/save_net.cgi
+++ b/dovecot/save_net.cgi
@@ -4,7 +4,7 @@
 require './dovecot-lib.pl';
 &ReadParse();
 &error_setup($text{'net_err'});
-$conf = &get_config(1);
+$conf = &get_config();
 &lock_dovecot_files($conf);
 
 &save_directive($conf, "protocols", join(" ", split(/\0/, $in{'protocols'})));

--- a/dovecot/save_net.cgi
+++ b/dovecot/save_net.cgi
@@ -4,7 +4,7 @@
 require './dovecot-lib.pl';
 &ReadParse();
 &error_setup($text{'net_err'});
-$conf = &get_config();
+$conf = &get_config(1);
 &lock_dovecot_files($conf);
 
 &save_directive($conf, "protocols", join(" ", split(/\0/, $in{'protocols'})));


### PR DESCRIPTION
Jamie, hey I made an attempts to use `/usr/share/dovecot` included files only in read-only mode.

This PR works, but only partially.

If we save Networking and Protocols page the first time (when there is no `protocols` directives in main config file yet) and with IMAP only, it adds `protocols = imap` directive. All is good at this point and if you re-visit the page, the correct IMAP protocol is selected. However, if you save it the second time, instead of overwriting `protocols = imap` directive, it adds a new line to the Dovecot global config, but what's worse, it removes the line above.

It really seems to me as a bug in `dovecot::save_directive` sub, in a block where we _add some directives_. Back in time (long time ago) some people reported that some last `}` in the block was deleted. If I keep saving and saving Networking and Protocols page with this PR, the code is just keep deleting each line above the first directive, instead of replacing it, e.g.:

<img width="739" alt="image" src="https://github.com/webmin/webmin/assets/4426533/719a0970-94c3-438a-8284-072d9a41654c">

I wouldn't expect this happening. What is wrong here, could you explain?

Ref.: https://github.com/virtualmin/virtualmin-gpl/issues/639#issuecomment-1720679637
