### PR TITLE
Simple nftables support via the use of update-alternatives

### DIFF
--- a/firewall/firewall-lib.pl
+++ b/firewall/firewall-lib.pl
@@ -407,13 +407,18 @@ local $out = &backquote_logged("cd / && $rcmd <$ipvx_save 2>&1");
 return $? ? "<pre>$out</pre>" : undef;
 }
 
+sub iptables_save_command
+{
+return &has_command("ip${ipvx}tables-legacy-save") ||
+       &has_command("ip${ipvx}tables-save");
+}
+
 # iptables_save()
 # Saves the active firewall rules, and returns any error
 sub iptables_save
 {
-local $scmd = &has_command("ip${ipvx}tables-legacy-save") ||
-	      "ip${ipvx}tables-save";
-local $out = &backquote_logged("$scmd >$ipvx_save 2>&1");
+local $scmd = &iptables_save_command();
+local $out = &backquote_logged("cd / && $scmd >$ipvx_save 2>&1");
 return $? ? "<pre>$out</pre>" : undef;
 }
 

--- a/firewall/firewall-lib.pl
+++ b/firewall/firewall-lib.pl
@@ -394,8 +394,8 @@ return undef;
 
 sub iptables_restore_command
 {
-return &has_command("ip${ipvx}tables-legacy-restore") ||
-       &has_command("ip${ipvx}tables-restore");
+return &has_command("ip${ipvx}tables-restore") ||
+       &has_command("ip${ipvx}tables-legacy-restore");
 }
 
 # iptables_restore()
@@ -409,8 +409,8 @@ return $? ? "<pre>$out</pre>" : undef;
 
 sub iptables_save_command
 {
-return &has_command("ip${ipvx}tables-legacy-save") ||
-       &has_command("ip${ipvx}tables-save");
+return &has_command("ip${ipvx}tables-save") ||
+       &has_command("ip${ipvx}tables-legacy-save");
 }
 
 # iptables_save()


### PR DESCRIPTION
Simply support for nftables (which is a drop-in replacement command line wise), simply by preferring to call `iptables-save|restore` rather over `iptables-legacy-save|restore`

Should be a simple resolve on #1097 for many people, and should work oob for any distros that set this alias up by default.

I'm unsure why the restore command was being run after a call to cd, is this a preventative measure for directing to the filepath? If so save should've had it also. If not, the `cd` should be removed from both, or a comment should be added to specify exactly why the move is required.

