### PR TITLE
Capitalize SMTP auth command for broader compatibility.

### DIFF
--- a/mailboxes/boxes-lib.pl
+++ b/mailboxes/boxes-lib.pl
@@ -965,7 +965,7 @@ elsif ($sm) {
 						'pass' => $pass } );
 		&error("Failed to create Authen::SASL object") if (!$sasl);
 		local $conn = $sasl->client_new("smtp", &get_system_hostname());
-		local $arv = &smtp_command($h, uc "auth $auth\r\n", 1);
+		local $arv = &smtp_command($h, "AUTH ".uc($auth)."\r\n", 1);
 		if ($arv =~ /^(334)(\-\S+)?\s+(.*)/) {
 			# Server says to go ahead
 			$extra = $3;

--- a/mailboxes/boxes-lib.pl
+++ b/mailboxes/boxes-lib.pl
@@ -965,7 +965,7 @@ elsif ($sm) {
 						'pass' => $pass } );
 		&error("Failed to create Authen::SASL object") if (!$sasl);
 		local $conn = $sasl->client_new("smtp", &get_system_hostname());
-		local $arv = &smtp_command($h, "auth $auth\r\n", 1);
+		local $arv = &smtp_command($h, uc "auth $auth\r\n", 1);
 		if ($arv =~ /^(334)(\-\S+)?\s+(.*)/) {
 			# Server says to go ahead
 			$extra = $3;


### PR DESCRIPTION
Some SMTP servers only accept a capitalized auth command. This patch capitalized the command before it is sent.