### PR TITLE
Fix for 10+ versions of netbsd

### DIFF
--- a/mount/netbsd-lib.pl
+++ b/mount/netbsd-lib.pl
@@ -128,9 +128,9 @@ sub list_mounted
 {
 # get the list of mounted filesystems
 local(@rv, $_);
-local $cmd = $uname_release =~ /^[3456789]\.[0-9]/ ? "netbsd-mounts-3" :
+local $cmd = $uname_release =~ /^1\.[0-9]/ ? "netbsd-mounts" :
 	     $uname_release =~ /^2\.[0-9]/ ? "netbsd-mounts-2" :
-					     "netbsd-mounts";
+					     "netbsd-mounts-3";
 &compile_program($cmd);
 open(CMD, "$module_config_directory/$cmd |");
 while(<CMD>) {


### PR DESCRIPTION
Fix for this: https://forum.virtualmin.com/t/webmin-2-111-throws-error-on-netbsd-10-0/126039

Also reverses the logic so that it'll default to the new version for any unmatched version. Realistically, the old versions can probably just be dropped. I cannot imagine a world where someone is running a current Webmin version on a 30 year old NetBSD version.