### PR TITLE
Add support to parse calendar events files #2160

### DIFF
--- a/mailboxes/mailboxes-lib.pl
+++ b/mailboxes/mailboxes-lib.pl
@@ -1286,5 +1286,81 @@ if (!glob("\Q$rv\E.*")) {
 return $rv;
 }
 
+# parse_calendar_file(calendar-file)
+# Parses an iCalendar file and returns a list of events
+sub parse_calendar_file
+{
+my (@events, %event);
+eval "use DateTime; use DateTime::TimeZone;";
+return \@events if ($@);
+my ($calendar_file) = @_;
+my $adjust_time_with_timezone = sub {
+	my ($time, $tzid) = @_;
+	my $dt = DateTime->new(
+		year      => substr($time, 0, 4),
+		month     => substr($time, 4, 2),
+		day       => substr($time, 6, 2),
+		hour      => substr($time, 9, 2),
+		minute    => substr($time, 11, 2),
+		second    => substr($time, 13, 2),
+		time_zone => $tzid);
+	my $local_dt = $dt->clone->set_time_zone('local');
+	return {
+		formatted => $local_dt->strftime('%Y-%m-%d %H:%M:%S'),
+		timestamp => $local_dt->epoch
+	};
+};
+my $ics_file_lines = &read_file_lines($calendar_file, 1);
+foreach (@$ics_file_lines) {
+	if (/^BEGIN:VEVENT/) {
+		# Start a new event
+		%event = ();
+		}
+	elsif (/^END:VEVENT/) {
+		# Convert times using the timezone
+		if ($event{'dtstart'} && $event{'tzid'}) {
+			my $adjusted_start = $adjust_time_with_timezone->($event{'dtstart'}, $event{'tzid'});
+			$event{'dtstart_local_timestamp'} = $adjusted_start->{'timestamp'};
+			$event{'dtstart_local_date'} = &make_date($event{'dtstart_local_timestamp'});
+			}
+		if ($event{'dtend'} && $event{'tzid'}) {
+			my $adjusted_end = $adjust_time_with_timezone->($event{'dtend'}, $event{'tzid'});
+			$event{'dtend_local_timestamp'} = $adjusted_end->{'timestamp'};
+			$event{'dtend_local_date'} = &make_date($event{'dtend_local_timestamp'});
+			}
+		# Local timezone
+		$event{'tzid_local'} = DateTime::TimeZone->new(name => 'local')->name;
+		# Add the event to the list
+		push(@events, { %event });
+		}
+	# Parse fields
+	elsif (/^SUMMARY:(.*)$/) {
+		$event{'summary'} = $1;
+		}
+	elsif (/^DTSTART;TZID=(.*?):(.*)$/) {
+		$event{'tzid'} = $1;
+		$event{'dtstart'} = $2;
+		}
+	elsif (/^DTEND;TZID=(.*?):(.*)$/) {
+		$event{'tzid'} = $1;
+		$event{'dtend'} = $2;
+		}
+	elsif (/^DESCRIPTION:(.*)$/) {
+		$event{'description'} = $1;
+		}
+	elsif (/^LOCATION:(.*)$/) {
+		$event{'location'} = $1;
+		}
+	elsif (/^ATTENDEE.*:(.*)$/) {
+		push @{$event{'attendees'}}, $1;
+		}
+	elsif (/^ORGANIZER;CN=(.*?):mailto:(.*)$/) {
+		$event{'organizer_name'} = $1;
+		$event{'organizer_email'} = $2;
+		}
+	}
+return \@events;
+}
+
 1;
 

--- a/mailboxes/mailboxes-lib.pl
+++ b/mailboxes/mailboxes-lib.pl
@@ -1290,10 +1290,10 @@ return $rv;
 # Parses an iCalendar file and returns a list of events
 sub parse_calendar_file
 {
+my ($calendar_file) = @_;
 my (@events, %event);
 eval "use DateTime; use DateTime::TimeZone;";
 return \@events if ($@);
-my ($calendar_file) = @_;
 my $adjust_time_with_timezone = sub {
 	my ($time, $tzid) = @_;
 	my $dt = DateTime->new(


### PR DESCRIPTION
Hey Jamie!

People [want to have](https://github.com/webmin/webmin/issues/2160) calendar events and invitations displayed nicely in the email body.

Right now, the file is displayed as an attachment with a `.ics` file.

I made this custom parser, which will accept the file containing the calendar event and return a data structure like this:

```
[
  {
    'dtend' => '20240604T161500',
    'dtend_local_date' => '06/04/2024 05:15 PM',
    'dtend_local_timestamp' => 1717510500,
    'dtstart' => '20240604T153000',
    'dtstart_local_date' => '06/04/2024 04:30 PM',
    'dtstart_local_timestamp' => 1717507800,
    'location' => 'https://example.com/video-room-1',
    'organizer_email' => 'organizer@example.com',
    'organizer_name' => 'John Doe',
    'summary' => 'Meeting with Elliot',
    'tzid' => 'Europe/Paris',
    'tzid_local' => 'Asia/Nicosia'
  }
]

```

Later, you'll be able to use it to add a virtually inserted table to the email body, containing event details.
