### PR TITLE
Set websocket URL depending on the proxy unless defined in config

### DIFF
--- a/web-lib-funcs.pl
+++ b/web-lib-funcs.pl
@@ -13569,11 +13569,21 @@ my $ws_proto = lc($ENV{'HTTPS'}) eq 'on' ? 'wss' : 'ws';
 my %miniserv;
 &get_miniserv_config(\%miniserv);
 my $http_host_conf = &trim($miniserv{'websocket_host'} || $host);
+# Pass as defined
 if ($http_host_conf) {
 	if ($http_host_conf !~ /^wss?:\/\//) {
 		$http_host_conf = "$ws_proto://$http_host_conf";
 		}
 	$http_host_conf =~ s/[\/]+$//g;
+	}
+# Try to rely on the proxy
+if (!defined($http_host_conf)) {
+	my $forwarded_host = $ENV{'HTTP_X_FORWARDED_HOST'};
+	if ($forwarded_host) {
+		$http_host_conf = "$ws_proto://$forwarded_host".
+			&get_webprefix();
+		$http_host_conf =~ s/\/$//;
+		}
 	}
 my $http_host = $http_host_conf || "$ws_proto://$ENV{'HTTP_HOST'}";
 return "$http_host/$module/ws-$port";


### PR DESCRIPTION
Hi Jamie!

This PR will automatically set the WebSocket URL based on headers provided by the proxy.

We generally cannot trust these kinds of headers, but in this case, it's just an attempt to make it work automatically. In fact, it should work in most cases. If a WebSocket host is defined in the Webmin configuration page, it will override automatic configuration.