### PR TITLE
Fix to allow disabling the enforcement of sudo-capable logins

### DIFF
--- a/xterm/acl_security.pl
+++ b/xterm/acl_security.pl
@@ -10,6 +10,14 @@ my ($o) = @_;
 print &ui_table_row($text{'acl_user'},
 	&ui_opt_textbox("user", $o->{'user'} eq '*' ? undef : $o->{'user'},
 			20, $text{'acl_sameuser'}));
+
+if ($o->{'user'} eq "root" && $remote_user ne $o->{'user'}) {
+	print &ui_table_row($text{'acl_sudoenforce'},
+		&ui_yesno_radio("sudoenforce", $o->{'sudoenforce'} == 1 ? 1 : 0));
+	}
+else {
+	print &ui_hidden("sudoenforce", $o->{'sudoenforce'});
+	}
 }
 
 sub acl_security_save
@@ -17,4 +25,5 @@ sub acl_security_save
 my ($o) = @_;
 
 $o->{'user'} = $in{'user_def'} ? '*' : $in{'user'};
+$o->{'sudoenforce'} = $in{'sudoenforce'} ? 1 : 0;
 }

--- a/xterm/acl_security.pl
+++ b/xterm/acl_security.pl
@@ -11,15 +11,9 @@ print &ui_table_row($text{'acl_user'},
 	&ui_opt_textbox("user", $o->{'user'} eq '*' ? undef : $o->{'user'},
 			20, $text{'acl_sameuser'}));
 
-if ($o->{'user'} eq "*" || 
-   ($o->{'user'} eq "root" && $remote_user ne $o->{'user'})) {
-	print &ui_table_row($text{'acl_sudoenforce'},
-		&ui_yesno_radio("sudoenforce",
-			$o->{'sudoenforce'} == 1 ? 1 : 0));
-	}
-else {
-	print &ui_hidden("sudoenforce", $o->{'sudoenforce'});
-	}
+print &ui_table_row($text{'acl_sudoenforce'},
+	&ui_yesno_radio("sudoenforce",
+		$o->{'sudoenforce'} == 1 ? 1 : 0));
 }
 
 sub acl_security_save

--- a/xterm/acl_security.pl
+++ b/xterm/acl_security.pl
@@ -11,9 +11,11 @@ print &ui_table_row($text{'acl_user'},
 	&ui_opt_textbox("user", $o->{'user'} eq '*' ? undef : $o->{'user'},
 			20, $text{'acl_sameuser'}));
 
-if ($o->{'user'} eq "root" && $remote_user ne $o->{'user'}) {
+if ($o->{'user'} eq "*" || 
+   ($o->{'user'} eq "root" && $remote_user ne $o->{'user'})) {
 	print &ui_table_row($text{'acl_sudoenforce'},
-		&ui_yesno_radio("sudoenforce", $o->{'sudoenforce'} == 1 ? 1 : 0));
+		&ui_yesno_radio("sudoenforce",
+			$o->{'sudoenforce'} == 1 ? 1 : 0));
 	}
 else {
 	print &ui_hidden("sudoenforce", $o->{'sudoenforce'});

--- a/xterm/defaultacl
+++ b/xterm/defaultacl
@@ -1,1 +1,2 @@
 user=root
+sudoenforce=1

--- a/xterm/index.cgi
+++ b/xterm/index.cgi
@@ -175,7 +175,8 @@ my $user = $access{'user'};
 if ($user eq "*") {
 	$user = $remote_user;
 	}
-elsif ($user eq "root" && $remote_user ne $user && !$in{'user'}) {
+elsif ($user eq "root" && $remote_user ne $user && !$in{'user'} &&
+       $access{'sudoenforce'} ne '0') {
 	# If possible, start with a sudo-capable user
 	my @uinfo = getpwnam($remote_user);
 	if (@uinfo && $uinfo[7]) {

--- a/xterm/lang/en
+++ b/xterm/lang/en
@@ -9,3 +9,4 @@ index_eproxy=The Terminal module cannot be used when accessing Webmin via anothe
 
 acl_user=Run shell as Unix user
 acl_sameuser=Same as Webmin login
+acl_sudoenforce=Enforce <em>sudo</em>-only privileges


### PR DESCRIPTION
Hello Jamie!

This PR addresses a problem where sudo-capable users might not always want to use sudo or su to gain root access in Terminal.
