### PR TITLE
Fix not to truncate usernames

### DIFF
--- a/useradmin/linux-lib.pl
+++ b/useradmin/linux-lib.pl
@@ -22,7 +22,7 @@ sub open_last_command
 {
 local ($fh, $user) = @_;
 local $quser = quotemeta($user);
-open($fh, "(last -F $quser || last $quser) |");
+open($fh, "(last -F -w $quser || last -w $quser) |");
 }
 
 # read_last_line(handle)


### PR DESCRIPTION
Hello Jamie!

This PR fixes the issue with truncating usernames longer than 8 characters.