### PR TITLE
Add apply patch CLI API

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -8,7 +8,6 @@ use 5.010;
 
 use Getopt::Long qw(:config permute pass_through);
 use Pod::Usage;
-use Term::ANSIColor qw(:constants);
 use File::Basename;
 use Cwd qw(cwd);
 
@@ -38,13 +37,13 @@ init_config();
 
 # Check if curl is installed
 if (!has_command('curl')) {
-	print RED, "curl is not installed\n", RESET;
+	print "curl is not installed\n";
 	exit 1;
 	}
 
 # Check if git is installed
 if (!has_command('git')) {
-	print RED, "git is not installed\n", RESET;
+	print "git is not installed\n";
 	exit 1;
 	}
 
@@ -60,7 +59,7 @@ if (!$patch) {
 # Patch check
 if ($patch !~ /^https?:\/\//) {
 	if (!-r $patch) {
-		print RED, "Patch file $patch doesn't exist\n", RESET;
+		print "Patch file $patch doesn't exist\n";
 		exit 1;
 		}
 	}
@@ -83,7 +82,7 @@ if ($patch =~ m{https://(github|gitlab)\.com/[^/]+/([^/]+)/commit/[^/]+}) {
 
 # Check if module exists
 if (!-d "$path/$module") {
-    print RED, "Module $module doesn't exist\n", RESET;
+    print "Module $module doesn't exist\n";
     exit 1;
 }
 
@@ -100,7 +99,7 @@ else {
 # Apply patch using Git
 my $output = `$cmd 2>&1 | git apply --reject --verbose --whitespace=fix 2>&1`;
 if ($output !~ /applied patch.*?cleanly/i) {
-	print YELLOW, "Patch failed: $output\n", RESET;
+	print "Patch failed: $output\n";
 	exit 1;
 	}
 print "Patch applied successfully to:\n";

--- a/bin/patch
+++ b/bin/patch
@@ -106,7 +106,7 @@ Apply a patch to Webmin core or its modules from GitHub or a local file.
 
 =head1 SYNOPSIS
 
-patch module-name patch-url/file
+webmin patch module-name patch-url/file
 
 =head1 OPTIONS
 

--- a/bin/patch
+++ b/bin/patch
@@ -26,27 +26,24 @@ if (!-r "$path/$lib") {
 		}
 }
 
-# Get module and patch
-my $module = $ARGV[2];
-my $patch = $ARGV[3];
+# Check if curl is installed
+if (!`which curl`) {
+	print RED, "curl is not installed\n", RESET;
+	exit 1;
+	}
+
+# Check if git is installed
+if (!`which git`) {
+	print RED, "git is not installed\n", RESET;
+	exit 1;
+	}
+
+# Get patch URL or file
+my $patch = $ARGV[2];
 
 # Params check
-if (!$module || !$patch) {
+if (!$patch) {
     pod2usage(0);
-    exit 1;
-}
-
-# Special modules handling
-if ($module =~ /^virtualmin-(gpl|pro)$/) {
-	if ($module =~ /^virtualmin-pro/) {
-		$module = 'virtual-server/pro';
-		}
-	else {
-		$module = 'virtual-server';
-		}
-	}
-if (!-d "$path/$module") {
-    print RED, "Module $module doesn't exist\n", RESET;
     exit 1;
 }
 
@@ -62,29 +59,35 @@ elsif ($patch =~ /^https?:\/\/(github|gitlab)\.com/ &&
 	$patch .= '.patch';
 	}
 
-# Check if curl is installed
-if (!`which curl`) {
-	print RED, "curl is not installed\n", RESET;
-	exit 1;
+# Parse module name from URL
+my $module = "";
+if ($patch =~ m{https://(github|gitlab)\.com/[^/]+/([^/]+)/commit/[^/]+}) {
+	$module = $2;
+	$module = "" if ($2 eq 'webmin');
+	# Special handling for some modules
+	$module = $module =~ /^virtualmin-pro$/ ?
+		'virtual-server/pro' :
+			'virtual-server'
+				if $module =~ /^virtualmin-(gpl|pro)$/;
 	}
 
-# Check if git is installed
-if (!`which git`) {
-	print RED, "git is not installed\n", RESET;
-	exit 1;
-	}
+# Check if module exists
+if (!-d "$path/$module") {
+    print RED, "Module $module doesn't exist\n", RESET;
+    exit 1;
+}
 
 # Download command or cat patch file
 my $cmd;
 if ($patch =~ /^https?:\/\//) {
 	$cmd = "curl -s $patch";
+	chdir "$path/$module";
 	}
 else {
 	$cmd = "cat $patch";
 	}
 
 # Apply patch using Git
-chdir "$path/$module";
 my $output = `$cmd 2>&1 | git apply --reject --verbose --whitespace=fix 2>&1`;
 if ($output !~ /applied patch.*?cleanly/i) {
 	print YELLOW, "Patch failed: $output\n", RESET;
@@ -106,7 +109,7 @@ Apply a patch to Webmin core or its modules from GitHub or a local file.
 
 =head1 SYNOPSIS
 
-webmin patch module-name patch-url/file
+webmin patch patch-url/file
 
 =head1 OPTIONS
 
@@ -118,23 +121,16 @@ Give this help list.
 
 Examples of usage:
 
-  Apply a patch to the Package Updates module from GitHub using the commit ID.
-		
-    - webmin patch package-updates https://github.com/webmin/webmin/commit/fbee8
-	
-  Apply a patch to Webmin root files (e.g., `web-lib-funcs.pl`) from 
-  GitHub using the commit ID.
-  
-    - webmin patch . https://github.com/webmin/webmin/commit/e6a2bb15b0.patch
+  Apply a patch from a URL.
 
-  Apply a patch to Virtualmin GPL module from GitHub using commit ID.
+    - webmin patch https://github.com/webmin/webmin/commit/e6a2bb15b0.patch
+
+    - webmin patch https://github.com/virtualmin/virtualmin-gpl/commit/f4433153d
   
-    - webmin patch virtualmin-gpl \
-        https://github.com/virtualmin/virtualmin-gpl/commit/f4433153dbbb017932b9
+  Apply a patch from local file.
   
-  Apply a patch to Virtualmin Pro module from local file.
-  
-    - webmin patch virtualmin-pro /root/virtualmin-pro/patches/patch-1.patch
+    - cd /usr/libexec/webmin/virtual-server/pro &&
+      webmin patch /root/virtualmin-pro/patches/patch-1.patch
 
 =back
 

--- a/bin/patch
+++ b/bin/patch
@@ -13,7 +13,10 @@ use File::Basename;
 use Cwd qw(cwd);
 
 my %opt;
-GetOptions('help|h' => \$opt{'help'});
+GetOptions(
+	'help|h' => \$opt{'help'},
+	'config|c=s' => \$opt{'config'},
+	);
 pod2usage(0) if ($opt{'help'});
 
 # Get Webmin path
@@ -24,35 +27,41 @@ if (!-r "$path/$lib") {
 	if (!-r "$path/$lib") {
 		$path = $path = Cwd::realpath('..');
 		}
-}
+	}
+
+# Init core
+$ENV{'WEBMIN_CONFIG'} = $opt{'config'} || "/etc/webmin";
+push(@INC, $path);
+eval 'use WebminCore';
+init_config();
 
 # Check if curl is installed
-if (!`which curl`) {
+if (!has_command('curl')) {
 	print RED, "curl is not installed\n", RESET;
 	exit 1;
 	}
 
 # Check if git is installed
-if (!`which git`) {
+if (!has_command('git')) {
 	print RED, "git is not installed\n", RESET;
 	exit 1;
 	}
 
 # Get patch URL or file
-my $patch = $ARGV[2];
+my $patch = $ARGV[0];
 
 # Params check
 if (!$patch) {
-    pod2usage(0);
-    exit 1;
-}
+	pod2usage(0);
+	exit 1;
+	}
 
 # Patch check
 if ($patch !~ /^https?:\/\//) {
 	if (!-r $patch) {
 		print RED, "Patch file $patch doesn't exist\n", RESET;
 		exit 1;
-    		}
+		}
 	}
 elsif ($patch =~ /^https?:\/\/(github|gitlab)\.com/ &&
        $patch !~ /\.patch$/ && $patch !~ /\.diff$/) {
@@ -118,6 +127,11 @@ webmin patch patch-url/file
 =item --help, -h
 
 Give this help list.
+
+=item --config, -c
+
+Specify the full path to the Webmin configuration directory. Defaults to
+C</etc/webmin>
 
 Examples of usage:
 

--- a/bin/patch
+++ b/bin/patch
@@ -89,11 +89,11 @@ if (!-d "$path/$module") {
 # Download command or cat patch file
 my $cmd;
 if ($patch =~ /^https?:\/\//) {
-	$cmd = "curl -s $patch";
+	$cmd = "curl -s @{[quotemeta($patch)]}";
 	chdir "$path/$module";
 	}
 else {
-	$cmd = "cat $patch";
+	$cmd = "cat @{[quotemeta($patch)]}";
 	}
 
 # Apply patch using Git

--- a/bin/patch
+++ b/bin/patch
@@ -92,6 +92,7 @@ if ($output !~ /applied patch.*?cleanly/i) {
 	}
 print "Patch applied successfully to:\n";
 print "  $1\n" while $output =~ /^Applied patch\s+(\S+)/mg;
+system('/etc/webmin/restart');
 
 =pod
 

--- a/bin/patch
+++ b/bin/patch
@@ -1,0 +1,142 @@
+#!/usr/bin/env perl
+# patch - Apply a patch to Webmin core or its modules from GitHub or a local file
+
+use strict;
+use warnings;
+
+use 5.010;
+
+use Getopt::Long qw(:config permute pass_through);
+use Pod::Usage;
+use Term::ANSIColor qw(:constants);
+use File::Basename;
+use Cwd qw(cwd);
+
+my %opt;
+GetOptions('help|h' => \$opt{'help'});
+pod2usage(0) if ($opt{'help'});
+
+# Get Webmin path
+my $path = cwd;
+my $lib = "web-lib-funcs.pl";
+if (!-r "$path/$lib") {
+	$path = dirname(dirname($0));
+	if (!-r "$path/$lib") {
+		$path = $path = Cwd::realpath('..');
+		}
+}
+
+# Get module and patch
+my $module = $ARGV[2];
+my $patch = $ARGV[3];
+
+# Params check
+if (!$module || !$patch) {
+    pod2usage(0);
+    exit 1;
+}
+
+# Special modules handling
+if ($module =~ /^virtualmin-(gpl|pro)$/) {
+	if ($module =~ /^virtualmin-pro/) {
+		$module = 'virtual-server/pro';
+		}
+	else {
+		$module = 'virtual-server';
+		}
+	}
+if (!-d "$path/$module") {
+    print RED, "Module $module doesn't exist\n", RESET;
+    exit 1;
+}
+
+# Patch check
+if ($patch !~ /^https?:\/\//) {
+	if (!-r $patch) {
+		print RED, "Patch file $patch doesn't exist\n", RESET;
+		exit 1;
+    		}
+	}
+elsif ($patch =~ /^https?:\/\/(github|gitlab)\.com/ &&
+       $patch !~ /\.patch$/ && $patch !~ /\.diff$/) {
+	$patch .= '.patch';
+	}
+
+# Check if curl is installed
+if (!`which curl`) {
+	print RED, "curl is not installed\n", RESET;
+	exit 1;
+	}
+
+# Check if git is installed
+if (!`which git`) {
+	print RED, "git is not installed\n", RESET;
+	exit 1;
+	}
+
+# Download command or cat patch file
+my $cmd;
+if ($patch =~ /^https?:\/\//) {
+	$cmd = "curl -s $patch";
+	}
+else {
+	$cmd = "cat $patch";
+	}
+
+# Apply patch using Git
+chdir "$path/$module";
+my $output = `$cmd 2>&1 | git apply --reject --verbose --whitespace=fix 2>&1`;
+if ($output !~ /applied patch.*?cleanly/i) {
+	print YELLOW, "Patch failed: $output\n", RESET;
+	exit 1;
+	}
+print "Patch applied successfully to:\n";
+print "  $1\n" while $output =~ /^Applied patch\s+(\S+)/mg;
+
+=pod
+
+=head1 NAME
+
+patch
+
+=head1 DESCRIPTION
+
+Apply a patch to Webmin core or its modules from GitHub or a local file.
+
+=head1 SYNOPSIS
+
+patch module-name patch-url/file
+
+=head1 OPTIONS
+
+=over
+
+=item --help, -h
+
+Give this help list.
+
+Examples of usage:
+
+  Apply a patch to the Package Updates module from GitHub using the commit ID.
+		
+    - webmin patch package-updates https://github.com/webmin/webmin/commit/fbee8
+	
+  Apply a patch to Webmin root files (e.g., `web-lib-funcs.pl`) from 
+  GitHub using the commit ID.
+  
+    - webmin patch . https://github.com/webmin/webmin/commit/e6a2bb15b0.patch
+
+  Apply a patch to Virtualmin GPL module from GitHub using commit ID.
+  
+    - webmin patch virtualmin-gpl \
+        https://github.com/virtualmin/virtualmin-gpl/commit/f4433153dbbb017932b9
+  
+  Apply a patch to Virtualmin Pro module from local file.
+  
+    - webmin patch virtualmin-pro /root/virtualmin-pro/patches/patch-1.patch
+
+=back
+
+=head1 LICENSE AND COPYRIGHT
+
+ Copyright 2024 Ilia Ross <ilia@virtualmin.com>

--- a/bin/patch
+++ b/bin/patch
@@ -30,7 +30,8 @@ if (!-r "$path/$lib") {
 	}
 
 # Init core
-$ENV{'WEBMIN_CONFIG'} = $opt{'config'} || "/etc/webmin";
+my $config_dir = $opt{'config'} || '/etc/webmin';
+$ENV{'WEBMIN_CONFIG'} = $config_dir;
 push(@INC, $path);
 eval 'use WebminCore';
 init_config();
@@ -104,7 +105,7 @@ if ($output !~ /applied patch.*?cleanly/i) {
 	}
 print "Patch applied successfully to:\n";
 print "  $1\n" while $output =~ /^Applied patch\s+(\S+)/mg;
-system('/etc/webmin/restart');
+system("$config_dir/restart");
 
 =pod
 


### PR DESCRIPTION
G'day Jamie!

Time after time, users want to apply the fix immediately, so I added this API to simplify the process for the users.

```perl
=pod

=head1 NAME

patch

=head1 DESCRIPTION

Apply a patch to Webmin core or its modules from GitHub or a local file.

=head1 SYNOPSIS

patch module-name patch-url/file

=head1 OPTIONS

=over

=item --help, -h

Give this help list.

Examples of usage:

  Apply a patch to the Package Updates module from GitHub using the commit ID.
		
    - webmin patch package-updates https://github.com/webmin/webmin/commit/fbee8
	
  Apply a patch to Webmin root files (e.g., `web-lib-funcs.pl`) from 
  GitHub using the commit ID.
  
    - webmin patch . https://github.com/webmin/webmin/commit/e6a2bb15b0.patch

  Apply a patch to Virtualmin GPL module from GitHub using commit ID.
  
    - webmin patch virtualmin-gpl \
        https://github.com/virtualmin/virtualmin-gpl/commit/f4433153dbbb017932b9
  
  Apply a patch to Virtualmin Pro module from local file.
  
    - webmin patch virtualmin-pro /root/virtualmin-pro/patches/patch-1.patch

=back

=head1 LICENSE AND COPYRIGHT

 Copyright 2024 Ilia Ross
```
