### PR TITLE
Fix to optimize getting table index structure for large databases

### DIFF
--- a/mysql/edit_dbase.cgi
+++ b/mysql/edit_dbase.cgi
@@ -117,9 +117,11 @@ elsif (@titles || @indexes) {
 			local @str = &table_structure($in{'db'}, $t);
 			push(@fields, scalar(@str));
 			}
+		my $table_index_stats = &get_table_index_stats($in{'db'});
 		foreach $t (@indexes) {
 			push(@types, $text{'dbase_typeindex'});
-			$str = &index_structure($in{'db'}, $t);
+			$str = &parse_index_structure($table_index_stats,
+						      $in{'db'}, $t);
 			push(@rows, "<i>$text{'dbase_index'}</i>");
 			push(@fields, scalar(@{$str->{'cols'}}));
 			}

--- a/mysql/mysql-lib.pl
+++ b/mysql/mysql-lib.pl
@@ -1309,7 +1309,7 @@ return &ui_textbox($name, $value, 8)."\n".
 sub get_table_index_stats
 {
 my ($db) = @_;
-my $table_list = join(", ", map { "'$_'" } &list_tables($db));
+my @tables = &list_tables($db);
 my $sql_query = "
     SELECT 
         TABLE_SCHEMA,
@@ -1329,9 +1329,11 @@ my $sql_query = "
     FROM 
         INFORMATION_SCHEMA.STATISTICS
     WHERE 
-        TABLE_SCHEMA = '$db' AND TABLE_NAME IN ($table_list);
+        TABLE_SCHEMA = ?
+	AND
+	TABLE_NAME IN (" . join(", ", ("?") x @tables) . ")
 ";
-my $rs = &execute_sql_safe($db, $sql_query);
+my $rs = &execute_sql_safe($db, $sql_query, $db, @tables);
 return $rs;
 }
 


### PR DESCRIPTION
Hey Jamie!

This PR will optimize getting table index structure on the huge databases.

It was tested with TikiWiki database which over 400 tables and indexes.

The performace boost is around 500%.