### PR TITLE
[FIX] Add missing `title` parameter to `ui_print_header` method on the documentation

### DIFF
--- a/ui-lib.pl
+++ b/ui-lib.pl
@@ -1690,7 +1690,7 @@ if (!$tconfig{'nohr'} && !$tconfig{'nobottomhr'}) {
 return $rv;
 }
 
-=head2 ui_print_header(subtext, image, [help], [config], [nomodule], [nowebmin], [rightside], [head-stuff], [body-stuff], [below])
+=head2 ui_print_header(subtext, title, image, [help], [config], [nomodule], [nowebmin], [rightside], [head-stuff], [body-stuff], [below])
 
 Print HTML for a header with the post-header line. The args are the same
 as those passed to header(), defined in web-lib-funcs.pl, with the addition


### PR DESCRIPTION
While reading the `ui_print_header` method documentation, I realized that the `title` parameter was missing from the method definition while on parameter list description it was defined, which could lead to confusion and misuse of the method.
![image](https://github.com/user-attachments/assets/bfe721fc-ea97-478a-b7b1-73de079a908a)
