### PR TITLE
Add support for listing `deb822-style` repos

### DIFF
--- a/package-updates/index.cgi
+++ b/package-updates/index.cgi
@@ -244,7 +244,7 @@ if ($has_repos) {
 				    "<font color=green>$text{'yes'}</font>" :
 				    "<font color=red>$text{'no'}</font>",
 				$r->{'url'},
-				], "", "d", $r->{'id'});
+				], "", "d", $r->{'id'}, undef, $r->{'cannot'});
 			}
 		print &ui_columns_end();
 		print &ui_form_end([

--- a/software/apt-lib.pl
+++ b/software/apt-lib.pl
@@ -457,7 +457,34 @@ my @rv;
 foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 	my $lref = &read_file_lines($f, 1);
 	my $lnum = 0;
+	my (%repo, @types);
+	my $repo = sub {
+		foreach my $type (@types) {
+			my @suites = @{$repo{'suites'}};
+			foreach my $suite (@suites) {
+				my @comps = @{$repo{'comps'}};
+				foreach my $comp (@comps) {
+					my $repo =
+					  {
+					    'cannot' => 1,
+					    'file' => $f,
+					    # 'line' => $lnum,
+					    'url' => $repo{'url'},
+					    'enabled' => !$repo{'disabled'},
+					    'words' => [$comp, $suite],
+					    'name' => join("/", $comp, $suite).
+					      ($type =~ /src/ ? " ($type)" : ""),
+					    'signed_by' => $repo{'signed_by'},
+					  };
+					$repo->{'id'} =
+						$repo->{'url'}.$repo->{'name'};
+					push(@rv, $repo);
+					}
+				}
+			}
+		};
 	foreach my $l (@$lref) {
+		# Debian classic format (using .list files)
 		if ($l =~ /^(#*)\s*deb.*?((http|https)\S+)\s+(\S.*)/) {
 			my $repo = { 'file' => $f,
 				     'line' => $lnum,
@@ -470,6 +497,40 @@ foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 			$repo->{'name'} = join("/", @w).$type;
 			$repo->{'id'} = $repo->{'url'}.$repo->{'name'};
 			push(@rv, $repo);
+			}
+		# New Ubuntu-style repos (using .sources files)
+		elsif ($f =~ /\.sources$/) {
+			if ($l =~ /^([\w\-]+):\s*(.+)$/) {
+				my ($key, $value) = ($1, $2);
+				if ($key eq 'Types') {
+					@types = split(/\s+/, $value);
+					}
+				elsif ($key eq 'URIs') {
+					$repo{'url'} = $value;
+					}
+				elsif ($key eq 'Suites') {
+					$repo{'suites'} = [split(/\s+/, $value)];
+					}
+				elsif ($key eq 'Components') {
+					$repo{'comps'} = [split(/\s+/, $value)];
+					}
+				elsif ($key eq 'Signed-By') {
+					$repo{'signed_by'} = $value;
+					}
+				elsif ($key eq 'Enabled') {
+					$repo{'disabled'} =
+						(lc($value) eq 'no') ? 1 : 0;
+					}
+				}
+			elsif ($l =~ /^\s*$/ || $lnum == $#{$lref}) {
+				# Process and push the current repo if we
+				# got an empty line or it's the last line
+				if (%repo) {
+					$repo->();
+					%repo = ();
+					@types = ();
+					}
+				}
 			}
 		$lnum++;
 		}

--- a/software/apt-lib.pl
+++ b/software/apt-lib.pl
@@ -458,7 +458,7 @@ foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 	my $lref = &read_file_lines($f, 1);
 	my $lnum = 0;
 	my (%repo, @types);
-	my $repo = sub {
+	my $repo_proc = sub {
 		foreach my $type (@types) {
 			my @suites = @{$repo{'suites'}};
 			foreach my $suite (@suites) {
@@ -525,7 +525,7 @@ foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 				# Process and push the current repo if we
 				# got an empty line or it's the last line
 				if (%repo) {
-					$repo->();
+					$repo_proc->();
 					%repo = ();
 					@types = ();
 					}

--- a/software/apt-lib.pl
+++ b/software/apt-lib.pl
@@ -521,14 +521,12 @@ foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 						(lc($value) eq 'no') ? 1 : 0;
 					}
 				}
-			if ($l =~ /^\s*$/ || $lnum == $#{$lref}) {
+			if (($l =~ /^\s*$/ || $lnum == $#{$lref}) && %repo) {
 				# Process and push the current repo if we
 				# got an empty line or it's the last line
-				if (%repo) {
-					$repo_proc->();
-					%repo = ();
-					@types = ();
-					}
+				$repo_proc->();
+				%repo = ();
+				@types = ();
 				}
 			}
 		$lnum++;

--- a/software/apt-lib.pl
+++ b/software/apt-lib.pl
@@ -468,7 +468,6 @@ foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 					  {
 					    'cannot' => 1,
 					    'file' => $f,
-					    # 'line' => $lnum,
 					    'url' => $repo{'url'},
 					    'enabled' => !$repo{'disabled'},
 					    'words' => [$comp, $suite],

--- a/software/apt-lib.pl
+++ b/software/apt-lib.pl
@@ -521,7 +521,7 @@ foreach my $f ($sources_list_file, glob("$sources_list_dir/*")) {
 						(lc($value) eq 'no') ? 1 : 0;
 					}
 				}
-			elsif ($l =~ /^\s*$/ || $lnum == $#{$lref}) {
+			if ($l =~ /^\s*$/ || $lnum == $#{$lref}) {
 				# Process and push the current repo if we
 				# got an empty line or it's the last line
 				if (%repo) {


### PR DESCRIPTION
Hello Jamie!

As we [discussed earlier](https://forum.virtualmin.com/t/package-repositories-empty-ubuntu-24-04/129152/11?u=ilia), here’s the PR to add support for the `.sources` repos format.

Unfortunately, `deb822-style` isn’t very compatible with how we currently delete, enable, and disable repos, as everything revolves around a single line, rather than a block of connected lines. Unless we completely change the logic in `software::list_package_repos`, I've kept it simple for now and just added support for repos listing.

Please have a look.