### PR TITLE
update openrc based outdated script in sync with current gentoo and alpine

### DIFF
--- a/webmin-gentoo-init
+++ b/webmin-gentoo-init
@@ -1,19 +1,52 @@
-#!/sbin/runscript
-# Copyright 1999-2002 Gentoo Technologies, Inc.
+#!/sbin/openrc-run
+
+# Copyright 2024 webmin & mckaygerhard
 # Distributed under the terms of the GNU General Public License, v2 or later
 
+
+name="webmin"
+# config file must be in sync with setup script, so i will not touch cos process will be the same as webmin-systemd
+# like calling updateboot.pl with a new procedure method defined as openrc and not just assumed sysvinit if not systemd is present
+# and also atboot.pl with new procedure for openrc the alpine linux init system at the moment
+#conf_file="WEBMIN_CONFIG/miniserv.conf"
+conf_file="/etc/webmin/miniserv.conf"
+
+
 depend() { 
-	need net logger 
+    need logger localmount
+    use net
+    after bootmisc
 }
 
 start() {
-	ebegin "Starting webmin"
-	/etc/webmin/start
-	eend $?
+# same problem here.. we need to use WEBMIN_CONFIG variable to find the start script
+#   WEBMIN_CONFIG/start
+    /etc/webmin/start
+    eend $?
 }
 
 stop() {
-	ebegin "Stopping webmin"
-	/etc/webmin/stop
-	eend $?
+# same problem here.. we need to use WEBMIN_CONFIG variable to find the stop script
+#   WEBMIN_CONFIG/stop
+    /etc/webmin/stop
+    eend $?
+}
+
+status() {
+    pidfile=`grep "^pidfile=" "${conf_file}" | sed -e 's/pidfile=//g'`
+    if [ -s $pidfile ]; then
+	pid=`cat $pidfile`
+	kill -0 $pid >/dev/null 2>&1
+	if [ "$?" = "0" ]; then
+	    einfo "webmin (pid $pid) is running"
+	    return 0
+	else
+	    einfo "webmin is stopped"
+	    return 0
+	fi
+    else
+	einfo "webmin is stopped"
+	return 0
+    fi
+
 }


### PR DESCRIPTION
* This script its from ancient webmin era.. we need up to date to be able to use for alpine and modern gentoo linux distributions, gentoo still uses Openrc for many things no matter if you choose other init systems, also as or issue #835 we can noted there are much more options to setup on geento that seems are not well supported, webmin 
seems do not use the scripts from the OS init system, it seems if you use the web UI it will use directly the scripts from the config `WEBMIN_CONFIG` directory
* Fix status command not available to, by the detection of the pid, this is using the config pid variable from webmin config miniserv is need for future support on issue #2353 and related to #835 that just assume init sysv systems or the other s*** only. Still is pending future support for openrc init system but with this path next changes are more easy to do
* The pull request is open to maintainers editing, because we can just merge or improve the  `updateboot.pl` 
script with a new procedure method defined for `openrc` and not just assumed `sysvinit` as the only other present
and also `atboot.pl` with new procedure for openrc the alpine linux init system at the moment! This cos we need to setup and use `WEBMIN_CONFIG` variable to setup the init system in future improvements