### PR TITLE
Add ability to show reverse dependencies

### DIFF
--- a/phpini/edit_mods.cgi
+++ b/phpini/edit_mods.cgi
@@ -39,8 +39,16 @@ print &ui_columns_start([ $text{'mods_enabled'},
 foreach my $m (@mods) {
 	my $pkg;
 	if ($n && $ver) {
-		($pkg) = grep { $_ } map { $pkgmap{$_} }
-			      &php_module_packages($m->{'mod'}, $ver, $filever);
+		my @poss = &php_module_packages($m->{'mod'}, $ver, $filever);
+		($pkg) = grep { $_ } map { $pkgmap{$_} } @poss;
+		if (!$pkg) {
+			# Package is referenced by another name
+			foreach (@poss) {
+				my @pinfo = &software::virtual_package_info($_);
+				$pkg = { 'name' => $pinfo[0],
+					 'version' => $pinfo[4] } if @pinfo;
+				}
+			}
 		}
 	print &ui_columns_row([
 		&ui_checkbox("mod", $m->{'mod'}, "", $m->{'enabled'}),

--- a/phpini/install_mod.cgi
+++ b/phpini/install_mod.cgi
@@ -23,6 +23,7 @@ if ($got) {
 	my $already;
 	foreach my $pkg (@poss) {
 		my @pinfo = &software::package_info($pkg);
+		@pinfo = &software::virtual_package_info($pkg) if (!@pinfo);
 		$already++ if (@pinfo);
 		}
 	$already && &error(&text('imod_alreadygot',
@@ -39,10 +40,12 @@ print &text('imod_alldoing', "<tt>".&html_escape($in{'mod'})."</tt>",
 my $ok = 0;
 foreach my $pkg (@poss) {
 	my @pinfo = &software::package_info($pkg);
+	@pinfo = &software::virtual_package_info($pkg) if (!@pinfo);
 	next if (@pinfo);
 	my ($out, $rs) = &capture_function_output(
 		\&software::update_system_install, $pkg);
-	my @pinfo = &software::package_info($pkg);
+	@pinfo = &software::package_info($pkg);
+	@pinfo = &software::virtual_package_info($pkg) if (!@pinfo);
 	if (@pinfo && @$rs) {
 		($got) = grep { $_->{'mod'} eq $in{'mod'} }
 			      &list_php_ini_modules($inidir);

--- a/software/aix-lib.pl
+++ b/software/aix-lib.pl
@@ -67,6 +67,14 @@ sub package_info
      	}
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Tests if some file is a valid package file
 sub is_package

--- a/software/cygwin-lib.pl
+++ b/software/cygwin-lib.pl
@@ -80,6 +80,14 @@ close(RPM);
 return ($tmp[0], $tmp[1], $d, $tmp[2], $tmp[3], $tmp[4], &make_date($tmp[5]));
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Check if some file is a package file
 sub is_package

--- a/software/emerge-lib.pl
+++ b/software/emerge-lib.pl
@@ -98,6 +98,14 @@ return ( $packages{0,'name'}, $packages{0,'class'}, $packages{0,'desc'},
 	 $system_arch, $packages{0,'version'}, "Gentoo", &make_date($st[9]) );
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Check if some file is a package file
 sub is_package

--- a/software/freebsd-lib.pl
+++ b/software/freebsd-lib.pl
@@ -73,6 +73,14 @@ push(@rv, @st ? ctime($st[9]) : $text{'bsd_unknown'});
 return @rv;
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # check_files(package, version)
 # Fills in the %files array with information about the files belonging
 # to some package. Values in %files are  path type user group mode size error

--- a/software/hpux-lib.pl
+++ b/software/hpux-lib.pl
@@ -92,6 +92,14 @@ close(SW);
 return ($name, $class, $desc, $arch, $version, $vendor, $date);
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Check if some file is a package file
 sub is_package

--- a/software/ipkg-lib.pl
+++ b/software/ipkg-lib.pl
@@ -113,6 +113,14 @@ push(@rv, $packages{$pos, 'install'} ? "" : false);
 return @rv;
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # check_files(package)
 # Fills in the %files array with information about the files belonging
 # to some package. Values in %files are  path type user group mode size error

--- a/software/msi-lib.pl
+++ b/software/msi-lib.pl
@@ -175,6 +175,14 @@ else {
 	}
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Check if some file is a package file
 sub is_package

--- a/software/openbsd-lib.pl
+++ b/software/openbsd-lib.pl
@@ -49,6 +49,14 @@ push(@rv, @st ? ctime($st[9]) : $text{'bsd_unknown'});
 return @rv;
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # check_files(package)
 # Fills in the %files array with information about the files belonging
 # to some package. Values in %files are  path type user group mode size error

--- a/software/pkgadd-lib.pl
+++ b/software/pkgadd-lib.pl
@@ -71,6 +71,14 @@ push(@rv, $out =~ /INSTDATE:\s+(.*)\n/ ? $1 : $text{'pkgadd_unknown'});
 return @rv;
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Tests if some file is a valid package file
 sub is_package

--- a/software/pkgsrc-lib.pl
+++ b/software/pkgsrc-lib.pl
@@ -78,6 +78,14 @@ return ($packages{0,'name'}, $packages{0,'class'}, $packages{0,'desc'},
 	$packages{0,'arch'}, $packages{0,'version'}, undef, undef);
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # is_package(file)
 # Always returns 0, because pkgsrc doesn't support installing from files
 sub is_package

--- a/software/slackware-lib.pl
+++ b/software/slackware-lib.pl
@@ -94,6 +94,14 @@ close(PKG);
 return @rv;
 }
 
+# virtual_package_info(package)
+# Returns an array of package information for a virtual package, usually called
+# if "package_info" returns nothing.
+sub virtual_package_info
+{
+return ( );
+}
+
 # check_files(package)
 # Fills in the %files array with information about the files belonging
 # to some package. Values in %files are  path type user group mode size error


### PR DESCRIPTION
Hey Jamie!

As discussed in the chat, this PR adds the ability to return a reverse dependency. For example, if `php-calendar` is given as the package name, the returned package will be `php-common`.