### PR TITLE
Perl scripts to enable XDMCP

### DIFF
--- a/vnc/enable_display_manager_xdmcp.pl
+++ b/vnc/enable_display_manager_xdmcp.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+BEGIN {
+	push(@INC, "..");
+	push(@INC, "../vendor_perl");
+	push(@INC, "/usr/libexec/webmin/vendor_perl");
+};
+use Config::IniFiles;
+my $cfg = Config::IniFiles->new( -file => '/etc/sysconfig/displaymanager', -fallback => 'GENERAL' );
+$cfg->setval('GENERAL', 'DISPLAYMANAGER_REMOTE_ACCESS', '"yes"');
+$cfg->newval('GENERAL', 'DISPLAYMANAGER_REMOTE_ACCESS', '"yes"');
+$cfg->RewriteConfig;

--- a/vnc/enable_gdm_xdmcp.pl
+++ b/vnc/enable_gdm_xdmcp.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+BEGIN {
+	push(@INC, "..");
+	push(@INC, "../vendor_perl");
+	push(@INC, "/usr/libexec/webmin/vendor_perl");
+};
+use Config::IniFiles;
+my $cfg = Config::IniFiles->new( -file => '/etc/gdm/custom.conf', -fallback => 'GENERAL' );
+$cfg->setval('xdmcp', 'Enable', 'true');
+$cfg->newval('xdmcp', 'Enable', 'true');
+$cfg->RewriteConfig;

--- a/vnc/module.info
+++ b/vnc/module.info
@@ -1,5 +1,5 @@
 desc=VNC Client
 name=VNCviewer
-version=2.0
+version=2.1
 webmin=1
 usermin=1


### PR DESCRIPTION
XDMCP is required by the VNC client. These scripts will try to enable it if it is disabled.