### PR TITLE
Fix to respect option to copy new key and certificate to Webmin

### DIFF
--- a/webmin/config
+++ b/webmin/config
@@ -8,3 +8,4 @@ warn_days=7
 letsencrypt_dns_wait=10
 letsencrypt_algo=rsa
 letsencrypt_reuse=1
+letsencrypt_nouse=0

--- a/webmin/edit_ssl.cgi
+++ b/webmin/edit_ssl.cgi
@@ -326,7 +326,7 @@ else {
 
 	# Install in Webmin now?
 	print &ui_table_row($text{'ssl_usewebmin'},
-		&ui_yesno_radio("use", !!($config{'letsencrypt_use'} // 1)));
+		&ui_yesno_radio("use", !$config{'letsencrypt_nouse'}));
 
 	# SSL key size
 	print &ui_table_row($text{'ssl_size'},

--- a/webmin/edit_ssl.cgi
+++ b/webmin/edit_ssl.cgi
@@ -326,7 +326,7 @@ else {
 
 	# Install in Webmin now?
 	print &ui_table_row($text{'ssl_usewebmin'},
-		&ui_yesno_radio("use", 1));
+		&ui_yesno_radio("use", !!($config{'letsencrypt_use'} // 1)));
 
 	# SSL key size
 	print &ui_table_row($text{'ssl_size'},

--- a/webmin/letsencrypt.cgi
+++ b/webmin/letsencrypt.cgi
@@ -172,7 +172,7 @@ $config{'letsencrypt_webroot'} = $webroot;
 $config{'letsencrypt_mode'} = $mode;
 $config{'letsencrypt_size'} = $size;
 $config{'letsencrypt_subset'} = $subset;
-$config{'letsencrypt_use'} = $usewebmin;
+$config{'letsencrypt_nouse'} = !$usewebmin ? 1 : 0;
 &save_module_config();
 if (&foreign_check("webmincron")) {
 	my $job = &find_letsencrypt_cron_job();

--- a/webmin/letsencrypt.cgi
+++ b/webmin/letsencrypt.cgi
@@ -172,7 +172,7 @@ $config{'letsencrypt_webroot'} = $webroot;
 $config{'letsencrypt_mode'} = $mode;
 $config{'letsencrypt_size'} = $size;
 $config{'letsencrypt_subset'} = $subset;
-$config{'letsencrypt_nouse'} = !$usewebmin ? 1 : 0;
+$config{'letsencrypt_nouse'} = $usewebmin ? 0 : 1;
 &save_module_config();
 if (&foreign_check("webmincron")) {
 	my $job = &find_letsencrypt_cron_job();

--- a/webmin/webmin-lib.pl
+++ b/webmin/webmin-lib.pl
@@ -2697,7 +2697,7 @@ my @doms = split(/\s+/, $config{'letsencrypt_doms'});
 my $webroot = $config{'letsencrypt_webroot'};
 my $mode = $config{'letsencrypt_mode'} || "web";
 my $size = $config{'letsencrypt_size'};
-my $usewebmin = !!($config{'letsencrypt_use'} // 1);
+my $usewebmin = !$config{'letsencrypt_nouse'};
 if (!@doms) {
 	print "No domains saved to renew cert for!\n";
 	return;

--- a/webmin/webmin-lib.pl
+++ b/webmin/webmin-lib.pl
@@ -2697,6 +2697,7 @@ my @doms = split(/\s+/, $config{'letsencrypt_doms'});
 my $webroot = $config{'letsencrypt_webroot'};
 my $mode = $config{'letsencrypt_mode'} || "web";
 my $size = $config{'letsencrypt_size'};
+my $usewebmin = !!($config{'letsencrypt_use'} // 1);
 if (!@doms) {
 	print "No domains saved to renew cert for!\n";
 	return;
@@ -2715,6 +2716,9 @@ if (!$ok) {
 	print "Failed to renew certificate : $cert\n";
 	return;
 	}
+
+# If we don't want to update the Webmin SSL certificate, then just return
+return if (!$usewebmin);
 
 # Copy into place
 my %miniserv;


### PR DESCRIPTION
G'day Jamie!

There was a [bug report](https://forum.virtualmin.com/t/letsencrypt-automatic-certificate-advice/132891) on the Virtualmin Forums—I checked it out and confirmed the issue.

This fix addresses the problem where the "Copy new key and certificate to Webmin" option isn’t being respected.