### PR TITLE
Add ability to make authentication in two steps

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -4276,8 +4276,10 @@ if ($ok && (!$expired ||
 	# Log in creds were OK but two-factor auth is still pending
 	if ($twof_probe) {
 		# Two-factor auth is required
-		$validated=$already_session_id=$authuser=$baseauthuser = undef;
-		$querystring=$method=$page=$request_uri=$logged_code = undef;
+		$validated = $already_session_id = undef;
+		$authuser = $baseauthuser = undef;
+		$querystring = $method = $page = $request_uri = undef;
+		$logged_code = undef;
 		$queryargs = "";
 		# Write response
 		&http_error(401, "Two-factor authentication is required");

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -2101,12 +2101,8 @@ if (!$validated) {
 			$method = "GET";
 			$querystring .= "&failed=".&urlize($failed_user)
 				if ($failed_user);
-			if ($twofactor_msg) {
-				$querystring .= "&failed_save=".&urlize($failed_save);
-				$querystring .= "&failed_pass=".&urlize($failed_pass);
-				$querystring .= "&failed_twofactor_attempt=".&urlize($failed_twofactor_attempt);
-				$querystring .= "&twofactor_msg=".&urlize($twofactor_msg);
-				}
+			$querystring .= "&twofactor_msg=".&urlize($twofactor_msg)
+				if ($twofactor_msg);
 			$querystring .= "&timed_out=$timed_out"
 				if ($timed_out);
 			$queryargs = "";
@@ -4352,10 +4348,7 @@ else {
 				$expired ? 'expiredpass' : 'wrongpass',
 			   $loghost, $localip);
 	$failed_user = $vu;
-	$failed_pass = $pass;
 	$failed_save = $in{'save'};
-	$failed_twofactor_attempt = $in{'failed_twofactor_attempt'} || 0;
-	$failed_twofactor_attempt++;
 	$request_uri = $in{'page'};
 	$already_session_id = undef;
 	$method = "GET";


### PR DESCRIPTION
Hey Jamie!

As we talked about in [this thread](https://github.com/webmin/webmin/issues/2459#issuecomment-2832845920), we need to show the 2FA input field only for users who have 2FA turned on.

To make it work right, we have to do it in two steps, so we don’t trigger any false positive error messages printed to logs.

This patch is needed for SPA themes to show the 2FA field only after the user enters the right login info. The theme will handle it based on the server’s response.

At first, I got it working without any changes on the Webmin side, but it meant sending the username and password in the headers. Eventually, I gave up on that idea because some proxies could log headers and eventually leak passwords—and, it's just not right.

So, I made this quite well tested change. Please take a look; I'm still here for now.
