### PR TITLE
Fix issues in new PHP package manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 ## Changelog
 
-#### 2.400 (May 24, 2025)
-* Added built-in support for forgotten password recovery
-* Fixed bugs with IPv6 interface creation on systems using Network Manager
-* Improved security of single-use login links
-* Added support for SSL certificates and DNS over TLS in the BIND module
+#### 2.400 (May 25, 2025)
+* Add built-in support for forgotten password recovery
+* Add support for SSL certificates and DNS over TLS in the BIND module
+* Add support to configure listen for any type of address in Dovecot module
+* Add display of the PHP binary and its version in the PHP Configuration module
+* Add TOML as editable format in the File Manager module
+* Add support for template variables in help pages
+* Improve security of single-use login links
+* Fix Linux systems to show human-readable timestamps in the System Logs module
+* Fix to prefer JSON::XS over JSON::PP if available for better performance
+* Fix bugs with IPv6 interface creation on systems using Network Manager
+* Fix to address the security issue in the System Documentation module
+
 
 #### 2.303 (March 14, 2025)
 * Fix permissions error when attempting to open a temp file for writing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,10 @@
 ## Changelog
 
-#### 2.400 (May 25, 2025)
-* Add built-in support for forgotten password recovery
-* Add support for SSL certificates and DNS over TLS in the BIND module
-* Add support to configure listen for any type of address in Dovecot module
-* Add display of the PHP binary and its version in the PHP Configuration module
-* Add TOML as editable format in the File Manager module
-* Add support for template variables in help pages
-* Improve security of single-use login links
-* Fix Linux systems to show human-readable timestamps in the System Logs module
-* Fix to prefer JSON::XS over JSON::PP if available for better performance
-* Fix bugs with IPv6 interface creation on systems using Network Manager
-* Fix to address the security issue in the System Documentation module
-
+#### 2.400 (May 24, 2025)
+* Added built-in support for forgotten password recovery
+* Fixed bugs with IPv6 interface creation on systems using Network Manager
+* Improved security of single-use login links
+* Added support for SSL certificates and DNS over TLS in the BIND module
 
 #### 2.303 (March 14, 2025)
 * Fix permissions error when attempting to open a temp file for writing

--- a/phpini/delete_pkgs.cgi
+++ b/phpini/delete_pkgs.cgi
@@ -12,7 +12,7 @@ my @d = split(/\0/, $in{'d'});
 my $vmap = &get_virtualmin_php_map();
 
 # Find all packages and check that they can be safely removed
-my @pkgs = &list_any_php_base_packages();
+my @pkgs = &list_php_base_packages();
 my @delpkgs;
 foreach my $name (@d) {
 	($pkg) = grep { $_->{'name'} eq $name } @pkgs;

--- a/phpini/delete_pkgs.cgi
+++ b/phpini/delete_pkgs.cgi
@@ -12,7 +12,7 @@ my @d = split(/\0/, $in{'d'});
 my $vmap = &get_virtualmin_php_map();
 
 # Find all packages and check that they can be safely removed
-my @pkgs = &list_php_base_packages();
+my @pkgs = &list_any_php_base_packages();
 my @delpkgs;
 foreach my $name (@d) {
 	($pkg) = grep { $_->{'name'} eq $name } @pkgs;

--- a/phpini/delete_pkgs.cgi
+++ b/phpini/delete_pkgs.cgi
@@ -50,7 +50,7 @@ else {
 	foreach my $pkg (@delpkgs) {
 		print &text('dpkgs_doing', "<tt>$pkg->{'name'}</tt>",
 					   $pkg->{'phpver'}),"<br>\n";
-		$err = &delete_php_base_package($pkg);
+		$err = &delete_php_base_package($pkg, \@pkgs);
 		if ($err) {
 			print &text('dpkgs_failed', $err),"<p>\n";
 			}

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -50,8 +50,7 @@ if (@pkgs) {
 else {
 	print "<b>$text{'pkgs_none'}</b> <p>\n";
 	}
-
-my @newpkgs = grep { !$got{$_->{'name'}} } &list_any_available_php_packages();
+my @newpkgs = grep { !$got{$_->{'name'}} } &list_best_available_php_packages();
 if (@newpkgs && &foreign_installed("package-updates")) {
 	# Show form to install a new version
 	print &ui_hr();

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -49,24 +49,27 @@ if (@pkgs) {
 else {
 	print "<b>$text{'pkgs_none'}</b> <p>\n";
 	}
-my @newpkgs = grep { !$got{$_->{'phpver'}} } &list_best_available_php_packages();
-if (@newpkgs && &foreign_installed("package-updates")) {
+if (&foreign_installed("package-updates")) {
+	my @newpkgs = grep { !$got{$_->{'phpver'}} }
+		&list_best_available_php_packages();
 	# Show form to install a new version
-	print &ui_hr();
-	print &ui_form_start(
-		&get_webprefix()."/package-updates/update.cgi", "post");
-	print "$text{'pkgs_newver'}&nbsp;\n";
-	&extend_installable_php_packages(\@newpkgs);
-	# Largest version on top
-	@newpkgs = sort { $b->{'phpver'} cmp $a->{'phpver'} } @newpkgs;
-	print &ui_select("u", undef,
-		[ map { [ $_->{'name'},
-			  "PHP $_->{'shortver'}" ] } @newpkgs ]);
-	print &ui_hidden(
-		"redir", &get_webprefix()."/$module_name/list_pkgs.cgi");
-	print &ui_hidden("redirdesc", $text{'pkgs_title'});
-	print &ui_hidden("mode", "new");
-	print &ui_form_end([ [ undef, $text{'pkgs_install'} ] ]);
+	if (@newpkgs) {
+		print &ui_hr();
+		print &ui_form_start(
+			&get_webprefix()."/package-updates/update.cgi", "post");
+		print "$text{'pkgs_newver'}&nbsp;\n";
+		&extend_installable_php_packages(\@newpkgs);
+		# Largest version on top
+		@newpkgs = sort { $b->{'phpver'} cmp $a->{'phpver'} } @newpkgs;
+		print &ui_select("u", undef,
+			[ map { [ $_->{'name'},
+				"PHP $_->{'shortver'}" ] } @newpkgs ]);
+		print &ui_hidden(
+			"redir", &get_webprefix()."/$module_name/list_pkgs.cgi");
+		print &ui_hidden("redirdesc", $text{'pkgs_title'});
+		print &ui_hidden("mode", "new");
+		print &ui_form_end([ [ undef, $text{'pkgs_install'} ] ]);
+		}
 	}
 
 &ui_print_footer("", $text{'index_return'});

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -58,12 +58,11 @@ if (&foreign_installed("package-updates")) {
 		print &ui_form_start(
 			&get_webprefix()."/package-updates/update.cgi", "post");
 		print "$text{'pkgs_newver'}&nbsp;\n";
-		&extend_installable_php_packages(\@newpkgs);
-		# Largest version on top
-		@newpkgs = sort { $b->{'phpver'} cmp $a->{'phpver'} } @newpkgs;
+		my @allpkgs = &extend_installable_php_packages(\@newpkgs);
+		@allpkgs = sort { $b->{'ver'} cmp $a->{'ver'} } @allpkgs;
 		print &ui_select("u", undef,
 			[ map { [ $_->{'name'},
-				"PHP $_->{'shortver'}" ] } @newpkgs ]);
+				"PHP $_->{'ver'}" ] } @allpkgs ]);
 		print &ui_hidden(
 			"redir", &get_webprefix()."/$module_name/list_pkgs.cgi");
 		print &ui_hidden("redirdesc", $text{'pkgs_title'});

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -42,7 +42,7 @@ if (@pkgs) {
 			$pkg->{'binary'},
 			$vmap ? ( $pkg->{'shortver'}, $users ) : ( ),
 			], \@tds, "d", $pkg->{'name'});
-		$got{$pkg->{'name'}}++;
+		$got{$pkg->{'phpver'}}++;
 		}
 	print &ui_columns_end();
 	print &ui_form_end([ [ undef, $text{'pkgs_delete'} ] ]);
@@ -50,7 +50,7 @@ if (@pkgs) {
 else {
 	print "<b>$text{'pkgs_none'}</b> <p>\n";
 	}
-my @newpkgs = grep { !$got{$_->{'name'}} } &list_best_available_php_packages();
+my @newpkgs = grep { !$got{$_->{'phpver'}} } &list_best_available_php_packages();
 if (@newpkgs && &foreign_installed("package-updates")) {
 	# Show form to install a new version
 	print &ui_hr();

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -57,6 +57,8 @@ if (@newpkgs && &foreign_installed("package-updates")) {
 		&get_webprefix()."/package-updates/update.cgi", "post");
 	print "$text{'pkgs_newver'}&nbsp;\n";
 	&extend_installable_php_packages(\@newpkgs);
+	# Largest version on top
+	@newpkgs = sort { $b->{'phpver'} cmp $a->{'phpver'} } @newpkgs;
 	print &ui_select("u", undef,
 		[ map { [ $_->{'name'},
 			  "PHP $_->{'shortver'}" ] } @newpkgs ]);

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -56,14 +56,7 @@ if (@newpkgs && &foreign_installed("package-updates")) {
 	print &ui_form_start(
 		&get_webprefix()."/package-updates/update.cgi", "post");
 	print "$text{'pkgs_newver'}&nbsp;\n";
-	# Always install -cli package, along with the common package
-	foreach my $pkg (@newpkgs) {
-		if ($pkg->{'name'} =~ /-common$/) {
-			my $pkg_cli = $pkg->{'name'};
-			$pkg_cli =~ s/-common$/-cli/;
-			$pkg->{'name'} .= " $pkg_cli";
-			}
-		}
+	&extend_installable_php_packages(\@newpkgs);
 	print &ui_select("u", undef,
 		[ map { [ $_->{'name'},
 			  "PHP $_->{'shortver'}" ] } @newpkgs ]);

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -18,7 +18,6 @@ if (@pkgs) {
 				      $text{'pkgs_phpver'},
 				      $text{'pkgs_bin'},
 				      $vmap ? (
-					$text{'pkgs_shortver'},
 					$text{'pkgs_users'} ) : ( ),
 			        ], \@tds);
 	foreach my $pkg (@pkgs) {
@@ -40,7 +39,7 @@ if (@pkgs) {
 			$pkg->{'ver'},
 			$pkg->{'phpver'},
 			$pkg->{'binary'},
-			$vmap ? ( $pkg->{'shortver'}, $users ) : ( ),
+			$vmap ? ( $users ) : ( ),
 			], \@tds, "d", $pkg->{'name'});
 		$got{$pkg->{'phpver'}}++;
 		}

--- a/phpini/list_pkgs.cgi
+++ b/phpini/list_pkgs.cgi
@@ -7,7 +7,7 @@ $access{'global'} || &error($text{'pkgs_ecannot'});
 
 &ui_print_header(undef, $text{'pkgs_title'}, "");
 
-my @pkgs = &list_any_php_base_packages();
+my @pkgs = &list_php_base_packages();
 my %got;
 if (@pkgs) {
 	my $vmap = &get_virtualmin_php_map();

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1049,7 +1049,7 @@ foreach my $p (@targets) {
 	next if (!@info);
 	my $err = &software::delete_package($p,
 		{ nodeps => 1,
-		  ( !$deb_want_deps ? ( depstoo => 1 ) : () ) });
+		  ( !$deb_want_deps ? ( depstoo => 1, purge => 1 ) : () ) });
 	return &html_strip($err) if ($err);
 	}
 return undef;

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -881,8 +881,8 @@ my @rv;
 my %done;
 for(my $i=0; $i<$n; $i++) {
 	my $name = $software::packages{$i,'name'};
-	next unless ($name =~ /^((?:rh-)?php(?:\d[\d.]*)?(?:-php)?-common|php\d*[\d.]*)$/);
-	$name = $1;
+	next unless ($name =~ /^((?:rh-)?(php(?:\d[\d.]*)??)(?:-php)?-common|php\d*[\d.]*)$/);
+	$name = $2 || $1;
 	my $phpver = $software::packages{$i,'version'};
 	$phpver =~ s/\-.*$//;
 	my $bin;

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -918,7 +918,7 @@ for(my $i=0; $i<$n; $i++) {
 		    'phpver' => $phpver,
 		    'binary' => $bin, });
 	}
-@rv = sort { $a->{'name'} cmp $b->{'name'} } @rv;
+@rv = sort { $b->{'name'} cmp $a->{'name'} } @rv;
 @rv = grep { !$done{$_->{'shortver'}}++ } @rv;
 return sort { &compare_version_numbers($a->{'ver'}, $b->{'ver'}) } @rv;
 }

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1012,10 +1012,11 @@ my ($pkg) = @_;
 my @rv = map { $_->{'name'} }
 	     &list_all_php_module_packages($pkg->{'name'});
 my $base = $pkg->{'name'};
+$base =~ s/-php-common$//;
 $base =~ s/-common$//;
 my @poss = ( $base."-runtime", $base );
 foreach my $p (@poss) {
-	my @info = &software::package_info($p, $pkg->{'ver'});
+	my @info = &software::package_info($p);
 	next if (!@info);
 	push(@rv, $p);
 	}

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1022,6 +1022,21 @@ foreach my $p (@poss) {
 return @rv;
 }
 
+# extend_installable_php_packages(&packages)
+# Given a list of PHP packages to install, extends them to include packages
+# that are also has to be installed, such as -cli or -fpm
+sub extend_installable_php_packages
+{
+my ($pkgs) = @_;
+my @extra = ('cli', 'fpm');
+foreach my $pkg (@$pkgs) {
+	if ($pkg->{'name'} =~ /-common$/) {
+		$pkg->{'name'} .= ' ' . join(' ',
+		    map {(my $n = $pkg->{'name'}) =~ s/-common$/-$_/r } @extra);
+		}
+	}
+}
+
 # delete_php_base_package(&package)
 # Delete a PHP package, and return undef on success or an error on failure
 sub delete_php_base_package

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -866,7 +866,7 @@ else {
 return @poss;
 }
 
-# list_php_base_packages([common])
+# list_php_base_packages()
 # Returns a list of hash refs, one per PHP version installed, with the
 # following keys :
 # name - Package name
@@ -875,19 +875,13 @@ return @poss;
 # phpver - PHP version
 sub list_php_base_packages
 {
-my ($common) = @_;
 &foreign_require("software");
 my $n = &software::list_packages();
 my @rv;
 my %done;
 for(my $i=0; $i<$n; $i++) {
 	my $name = $software::packages{$i,'name'};
-	if ($common) {
-		next if ($name !~ /^(php(?:\d+(?:\.\d+)?)?(?:-php)?-common)$/);
-		}
-	else {
-		next if ($name !~ /^php(\d*)$/);
-		}
+	next unless ($name =~ /^((?:rh-)?php(?:\d[\d.]*)?(?:-php)?-common|php\d*[\d.]*)$/);
 	$name = $1;
 	my $phpver = $software::packages{$i,'version'};
 	$phpver =~ s/\-.*$//;
@@ -917,20 +911,6 @@ for(my $i=0; $i<$n; $i++) {
 	}
 @rv = sort { $a->{'name'} cmp $b->{'name'} } @rv;
 @rv = grep { !$done{$_->{'shortver'}}++ } @rv;
-return sort { &compare_version_numbers($a->{'ver'}, $b->{'ver'}) } @rv;
-}
-
-# list_any_php_base_packages()
-# Returns a list of all PHP base packages, either common or full,
-# sorted by version number. If no common packages are available, the
-# full PHP packages are used instead, mainly for non-Linux systems
-sub list_any_php_base_packages
-{
-my @rv = &list_php_base_packages(1);
-if (!@rv) {
-	# If no common packages, then use the full PHP packages
-	@rv = &list_php_base_packages();
-	}
 return sort { &compare_version_numbers($a->{'ver'}, $b->{'ver'}) } @rv;
 }
 

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1035,7 +1035,10 @@ my @extra = ('cli', 'fpm');
 foreach my $pkg (@$pkgs) {
 	if ($pkg->{'name'} =~ /-common$/) {
 		$pkg->{'name'} .= ' ' . join(' ',
-		    map {(my $n = $pkg->{'name'}) =~ s/-common$/-$_/r } @extra);
+		    map {
+			my $n = $pkg->{'name'};
+			$n =~ s/-common$/-$_/;
+			$n } @extra);
 		}
 	}
 }

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1045,13 +1045,8 @@ my @extra = ('cli', 'fpm');
 foreach my $pkg (@{$pkgs}) {
 	my $p = { 'name' => $pkg->{'name'},
 		  'ver'  => $pkg->{'shortver'} };
-	if ($p->{'name'} =~ /-common$/) {
-		$p->{'name'} .= ' ' . join(' ',
-		    map {
-		    	my $n = $p->{'name'};
-		    	$n =~ s/-common$/-$_/;
-		    	$n } @extra);
-		}
+	$p->{'name'} .= ' '.join(' ', map { "$1-$_" } @extra)
+		if ($p->{'name'} =~ /^(.*)-common$/);
 	push(@pkgs, $p);
 	}
 return @pkgs;

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1049,7 +1049,8 @@ foreach my $p (@targets) {
 	next if (!@info);
 	my $err = &software::delete_package($p,
 		{ nodeps => 1,
-		  ( !$deb_want_deps ? ( depstoo => 1, purge => 1 ) : () ) });
+		  purge => 1,
+		  ( !$deb_want_deps ? ( depstoo => 1 ) : () ) });
 	return &html_strip($err) if ($err);
 	}
 return undef;

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1034,21 +1034,27 @@ return @rv;
 }
 
 # extend_installable_php_packages(&packages)
-# Given a list of PHP packages to install, extends them to include packages
-# that are also has to be installed, such as -cli or -fpm
+# Given a list of PHP packages to install, create a new list with the version
+# and name to include packages that also need to be installed, such as -cli or
+# -fpm.
 sub extend_installable_php_packages
 {
 my ($pkgs) = @_;
+my @pkgs;
 my @extra = ('cli', 'fpm');
-foreach my $pkg (@$pkgs) {
-	if ($pkg->{'name'} =~ /-common$/) {
-		$pkg->{'name'} .= ' ' . join(' ',
+foreach my $pkg (@{$pkgs}) {
+	my $p = { 'name' => $pkg->{'name'},
+		  'ver'  => $pkg->{'shortver'} };
+	if ($p->{'name'} =~ /-common$/) {
+		$p->{'name'} .= ' ' . join(' ',
 		    map {
-			my $n = $pkg->{'name'};
-			$n =~ s/-common$/-$_/;
-			$n } @extra);
+		    	my $n = $p->{'name'};
+		    	$n =~ s/-common$/-$_/;
+		    	$n } @extra);
 		}
+	push(@pkgs, $p);
 	}
+return @pkgs;
 }
 
 # delete_php_base_package(&package, &installed)

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -1037,19 +1037,20 @@ foreach my $pkg (@$pkgs) {
 	}
 }
 
-# delete_php_base_package(&package)
+# delete_php_base_package(&package, &installed)
 # Delete a PHP package, and return undef on success or an error on failure
 sub delete_php_base_package
 {
-my ($pkg) = @_;
-foreach my $p (&list_all_php_version_packages($pkg)) {
+my ($pkg, $installed) = @_;
+my @targets = &list_all_php_version_packages($pkg);
+my $deb_want_deps = (grep { $_ eq 'php-common' } @targets) && @{$installed} > 1;
+foreach my $p (@targets) {
 	my @info = &software::package_info($p);
 	next if (!@info);
 	my $err = &software::delete_package($p,
-		{ 'nodeps' => 1, 'depstoo' => 1 });
-	if ($err) {
-		return &html_strip($err);
-		}
+		{ nodeps => 1,
+		  ( !$deb_want_deps ? ( depstoo => 1 ) : () ) });
+	return &html_strip($err) if ($err);
 	}
 return undef;
 }

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -918,6 +918,14 @@ for(my $i=0; $i<$n; $i++) {
 		    'phpver' => $phpver,
 		    'binary' => $bin, });
 	}
+# Fill in missing binary path for the default version that is later discarded
+# from the view
+my %bin;
+foreach my $pkg (@rv) {
+	$pkg->{'binary'} ||= $bin{$pkg->{'shortver'}};
+	$bin{$pkg->{'shortver'}} ||= $pkg->{'binary'};
+	}
+# Sort and remove duplicates
 @rv = sort { $b->{'name'} cmp $a->{'name'} } @rv;
 @rv = grep { !$done{$_->{'shortver'}}++ } @rv;
 return sort { &compare_version_numbers($a->{'ver'}, $b->{'ver'}) } @rv;

--- a/phpini/phpini-lib.pl
+++ b/phpini/phpini-lib.pl
@@ -958,6 +958,8 @@ foreach my $pkg (&package_updates::list_available()) {
 	my $name = $pkg->{'name'};
 	next unless ($name =~ /^((?:rh-)?(php(?:\d[\d.]*)??)(?:-php)?-common|php\d*[\d.]*)$/);
 	$name = $2 || $1;
+	# Skip meta packages on Debian and Ubuntu
+	next if ($pkg->{'version'} =~ /^([\d]+)/ && $1 > 40);
 	my ($phpver, $shortver, $bin) = &get_php_info($name, $pkg->{'version'});
 	push(@rv, { 'name' => $pkg->{'name'},
 		    'ver' => $pkg->{'version'},


### PR DESCRIPTION
Hey Jamie!

This PR fixes issues with installing and listing PHP packages across different systems—EL, Debian, and FreeBSD. On Linux, everything revolves around the `-common` package. Debian doesn’t have a `-runtime` package at all, so things are currently broken there. FreeBSD doesn’t have a `php-common` package and expects just `php`, while on Linux, installing `php` pulls in `mod_php`.

This PR gets everything working correctly across those systems, though the implementation could likely be improved.