### PR TITLE
Fix to always show password recovery link if enabled

### DIFF
--- a/pam_login.cgi
+++ b/pam_login.cgi
@@ -102,7 +102,7 @@ if (!$in{'initial'}) {
 	}
 print &ui_form_end();
 
-if ($in{'failed'} && $gconfig{'forgot_pass'}) {
+if ($gconfig{'forgot_pass'}) {
 	# Show forgotten password link
 	print &ui_form_start("forgot_form.cgi", "post");
 	print &ui_hidden("failed", $in{'failed'});

--- a/session_login.cgi
+++ b/session_login.cgi
@@ -125,7 +125,7 @@ print &ui_submit($text{'session_login'});
 print &ui_reset($text{'session_clear'});
 print &ui_form_end();
 
-if ($in{'failed'} && $gconfig{'forgot_pass'}) {
+if ($gconfig{'forgot_pass'}) {
 	# Show forgotten password link
 	print &ui_form_start("forgot_form.cgi", "post");
 	print &ui_hidden("failed", $in{'failed'});


### PR DESCRIPTION
Hello Jamie!

This PR always shows the recovery button-link when it’s enabled in Webmin, since no other service hides it until after a failed login.

And now that we support mailbox users, making them fail a Webmin login just to see the password reset button doesn’t make sense.