### PR TITLE
Fix latest SSLeay support for redirects to SSL work

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -937,7 +937,7 @@ while(1) {
 						$ssl_con || exit;
 						}
 					else {
-						$plain_http = 1;
+						$use_ssl = 0;
 						}
 					}
 
@@ -3257,15 +3257,7 @@ while(($idx = index($main::read_buffer, "\n")) < 0) {
 	# need to read more..
 	&wait_for_data_error() if (!$nowait);
 	if ($use_ssl) {
-		if (!$plain_http) {
-			$more = Net::SSLeay::read($ssl_con);
-			}
-		else {
-			# Expected output from Net::SSLeay::read is empty string
-			# in non-SSL mode before version 1.93, which now just
-			# hangs indefinitely
-			$more = '';
-			}
+		$more = Net::SSLeay::read($ssl_con);
 		}
 	else {
 		my $bufsize = $config{'bufsize'} || 32768;

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -3262,7 +3262,8 @@ while(($idx = index($main::read_buffer, "\n")) < 0) {
 			}
 		else {
 			# Expected output from Net::SSLeay::read is empty string
-			# before version 1.93, which now hangs indefinitely
+			# in non-SSL mode before version 1.93, which now just
+			# hangs indefinitely
 			$more = '';
 			}
 		}


### PR DESCRIPTION
Hey Jamie!

This PR addresses the issue with newer versions of Net::SSLeay (1.93+) where accessing in non-SSL mode causes it to hang indefinitely, as described in [this issue](https://github.com/webmin/webmin/issues/2504).

The minimal fix is to peek at the socket to get the connection type, set a flag, and avoid calling `Net::SSLeay::read($ssl_con)` when not in SSL mode at all.

I’ve tested it, and it seems to work jsut fine. A different fix is possible, but it would be much more complex.