### PR TITLE
Add improvements to systemd section of Init module

### DIFF
--- a/gray-theme/unauthenticated/gray-theme.css
+++ b/gray-theme/unauthenticated/gray-theme.css
@@ -422,7 +422,7 @@ details.ui_hidden_table_start > summary::-webkit-details-marker {
     color: #a1acc0;
 }
 
-details.on-hover:not(:hover) summary::after {
+details:not([open]).on-hover:not(:hover) summary::after {
   visibility: hidden !important;
 }
 

--- a/gray-theme/unauthenticated/gray-theme.css
+++ b/gray-theme/unauthenticated/gray-theme.css
@@ -422,6 +422,10 @@ details.ui_hidden_table_start > summary::-webkit-details-marker {
     color: #a1acc0;
 }
 
+details.on-hover:not(:hover) summary::after {
+  visibility: hidden !important;
+}
+
 details.inline {
   cursor: pointer;
   padding: 0;

--- a/init/index.cgi
+++ b/init/index.cgi
@@ -359,7 +359,7 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 		my $title = ($u->{'boot'} == -1 ?
 			    &html_escape($sname) :
 			    &ui_link($l, &html_escape($sname)));
-		my $desc = &html_escape($u->{'desc'});
+		my $desc = $config{'desc'} ? &html_escape($u->{'desc'}) : '';
 		print &ui_columns_row([
 			&ui_checkbox("d", $u->{'name'}, undef),
 			!$desc ? $title : &ui_details({

--- a/init/index.cgi
+++ b/init/index.cgi
@@ -335,11 +335,13 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 		   &select_invert_link("d"),
 		   &ui_link("edit_systemd.cgi?new=1", $text{'index_sadd'}) );
 	print &ui_links_row(\@links);
-	print &ui_columns_start([ "", $text{'index_uname'},
-				  $text{'index_udesc'},
-				  $text{'index_ucstatus'},
-				  $text{'index_uboot'},
-				  $text{'index_ustatus'}, ]);
+	print &ui_columns_start([ "", $text{'systemd_name'},
+				  $text{'systemd_desc'},
+				  $text{'systemd_type'},
+				  $text{'systemd_status'},
+				  $text{'systemd_boot'},
+				  $text{'index_ustatus'} ]);
+	my $units_piped = join('|', map { quotemeta } &get_systemd_unit_types());
 	foreach $u (&list_systemd_services()) {
 		if ($u->{'legacy'}) {
 			$l = "edit_action.cgi?0+".&urlize($u->{'name'});
@@ -348,13 +350,20 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 			$l = "edit_systemd.cgi?name=".&urlize($u->{'name'});
 			}
 		my $sname = $u->{'name'};
-		$sname =~ s/\.service$//;
+		my ($type) = $sname =~ /\.([^.]+)$/;
+		if (defined($type) && $type =~ /^(?:$units_piped)$/) {
+			$sname =~ s/\.$type$//;
+			}
+		else {
+			$type = '';
+			}
 		print &ui_columns_row([
 			&ui_checkbox("d", $u->{'name'}, undef),
 			$u->{'boot'} == -1 ?
 			    &html_escape($sname) :
 			    &ui_link($l, &html_escape($sname)),
 			&html_escape($u->{'desc'}),
+			$type,
 			$u->{'fullstatus'} || "<i>$text{'index_unknown'}</i>",
 			$u->{'boot'} == 1 ?
 			    &ui_text_color("$text{'yes'}", 'success') :

--- a/init/index.cgi
+++ b/init/index.cgi
@@ -336,6 +336,7 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 		   &ui_link("edit_systemd.cgi?new=1", $text{'index_sadd'}) );
 	print &ui_links_row(\@links);
 	print &ui_columns_start([ "", $text{'systemd_name'},
+				  $config{'desc'} ? $text{'systemd_desc'} : (),
 				  $text{'systemd_type'},
 				  $text{'systemd_status'},
 				  $text{'systemd_boot'},
@@ -359,14 +360,11 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 		my $title = ($u->{'boot'} == -1 ?
 			    &html_escape($sname) :
 			    &ui_link($l, &html_escape($sname)));
-		my $desc = $config{'desc'} ? &html_escape($u->{'desc'}) : '';
+		my $desc = $config{'desc'} ? &html_escape($u->{'desc'}) : undef;
 		print &ui_columns_row([
 			&ui_checkbox("d", $u->{'name'}, undef),
-			!$desc ? $title : &ui_details({
-					class => 'inline on-hover',
-					html => 1,
-					title => $title,
-					content => $desc}),
+			$title,
+			$desc // (),
 			$type,
 			$u->{'fullstatus'} || "<i>$text{'index_unknown'}</i>",
 			$u->{'boot'} == 1 ?

--- a/init/index.cgi
+++ b/init/index.cgi
@@ -336,7 +336,6 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 		   &ui_link("edit_systemd.cgi?new=1", $text{'index_sadd'}) );
 	print &ui_links_row(\@links);
 	print &ui_columns_start([ "", $text{'systemd_name'},
-				  $text{'systemd_desc'},
 				  $text{'systemd_type'},
 				  $text{'systemd_status'},
 				  $text{'systemd_boot'},
@@ -357,12 +356,17 @@ elsif ($init_mode eq "systemd" && $access{'bootup'}) {
 		else {
 			$type = '';
 			}
+		my $title = ($u->{'boot'} == -1 ?
+			    &html_escape($sname) :
+			    &ui_link($l, &html_escape($sname)));
+		my $desc = &html_escape($u->{'desc'});
 		print &ui_columns_row([
 			&ui_checkbox("d", $u->{'name'}, undef),
-			$u->{'boot'} == -1 ?
-			    &html_escape($sname) :
-			    &ui_link($l, &html_escape($sname)),
-			&html_escape($u->{'desc'}),
+			!$desc ? $title : &ui_details({
+					class => 'inline on-hover',
+					html => 1,
+					title => $title,
+					content => $desc}),
 			$type,
 			$u->{'fullstatus'} || "<i>$text{'index_unknown'}</i>",
 			$u->{'boot'} == 1 ?

--- a/init/init-lib.pl
+++ b/init/init-lib.pl
@@ -2181,7 +2181,7 @@ while(@units) {
 	while(@args < 100 && @units) {
 		push(@args, shift(@units));
 		}
-	my $out = &backquote_command("systemctl show --property=Id,Description,UnitFileState,ActiveState,SubState,ExecStart,ExecStop,ExecReload,ExecMainPID,FragmentPath ".join(" ", @args)." 2>/dev/null");
+	my $out = &backquote_command("systemctl show --property=Id,Description,UnitFileState,ActiveState,SubState,ExecStart,ExecStop,ExecReload,ExecMainPID,FragmentPath,DropInPaths ".join(" ", @args)." 2>/dev/null");
 	my @lines = split(/\r?\n/, $out);
 	my $curr;
 	my @units;

--- a/init/init-lib.pl
+++ b/init/init-lib.pl
@@ -2901,4 +2901,12 @@ my ($name) = @_;
 return $name =~ /\./ ? $name : "com.webmin.".$name;
 }
 
+# config_pre_load(mod-info, [mod-order])
+# Check if some config options are conditional
+sub config_pre_load
+{
+my ($modconf_info, $modconf_order) = @_;
+$modconf_info->{'desc'} =~ s/2-[^,]+,// if ($init_mode eq "systemd");
+}
+
 1;

--- a/init/lang/en
+++ b/init/lang/en
@@ -227,6 +227,7 @@ systemd_egone=Unit no longer exists!
 systemd_elegacy=Not a systemd unit!
 systemd_header=Systemd unit details
 systemd_name=Unit name
+systemd_type=Unit type
 systemd_file=Configuration file
 systemd_desc=Unit description
 systemd_start=Commands to run on startup


### PR DESCRIPTION
Hey Jamie!

As [discussed here](https://github.com/webmin/webmin/commit/72621c292910449c9eeaeec85462db08334d9a0d#commitcomment-161486940), I am adding a separate column for unit types for _systemd_ systems.

Additionally, as part of other _systemd_ improvements, I removed the "Description" column and incorporated the description into a native HTML accordion.

<img width="994" alt="image" src="https://github.com/user-attachments/assets/7d4ebc6e-49e4-4d98-aa61-6dfc84b76c75" />


