### PR TITLE
webmin-setup-repo.sh: Set mode of repo key to 644 for deb distros

### DIFF
--- a/webmin-setup-repo.sh
+++ b/webmin-setup-repo.sh
@@ -474,7 +474,8 @@ EOF
       gpg --dearmor < "$repo_key" \
         > "/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg"
       post_status $?
-      chmod 644 "/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg" 1>/dev/null 2>&1
+      # Set correct permissions on the repo key in case the system uses a restrictive umask
+      chmod 644 "/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg"
       sources_list=$(grep -v "$repo_host" /etc/apt/sources.list)
       echo "$sources_list" > /etc/apt/sources.list
       # Configure packages priority if provided

--- a/webmin-setup-repo.sh
+++ b/webmin-setup-repo.sh
@@ -473,10 +473,8 @@ EOF
       gpg --import "$repo_key" 1>/dev/null 2>&1
       gpg --dearmor < "$repo_key" \
         > "/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg"
-      chmod 644 \
-"/usr/share/keyrings/debian-$repo_key_suffix.gpg" \
-"/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg" 1>/dev/null 2>&1
       post_status $?
+      chmod 644 "/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg" 1>/dev/null 2>&1
       sources_list=$(grep -v "$repo_host" /etc/apt/sources.list)
       echo "$sources_list" > /etc/apt/sources.list
       # Configure packages priority if provided

--- a/webmin-setup-repo.sh
+++ b/webmin-setup-repo.sh
@@ -473,6 +473,9 @@ EOF
       gpg --import "$repo_key" 1>/dev/null 2>&1
       gpg --dearmor < "$repo_key" \
         > "/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg"
+      chmod 644 \
+"/usr/share/keyrings/debian-$repo_key_suffix.gpg" \
+"/usr/share/keyrings/$repoid_debian_like-$repo_key_suffix.gpg" 1>/dev/null 2>&1
       post_status $?
       sources_list=$(grep -v "$repo_host" /etc/apt/sources.list)
       echo "$sources_list" > /etc/apt/sources.list


### PR DESCRIPTION
This change fixed the issue below for me on Debian 13.

>   Downloading Webmin developers key ..  
  .. done  
  Installing Webmin developers key ..  
  .. done  
  Setting up Webmin releases repository ..  
  .. done  
  Cleaning repository metadata ..  
  .. done  
  Downloading repository metadata ..  
  .. failed : Hit:1 http://deb.debian.org/debian trixie InRelease  
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.1 kB]  
Get:3 http://security.debian.org/debian-security trixie-security InRelease [43.4 kB]  
Get:4 http://security.debian.org/debian-security trixie-security/main Sources [38.4 kB]  
Get:5 https://download.webmin.com/download/newkey/repository stable InRelease [19.2 kB]  
Get:6 http://security.debian.org/debian-security trixie-security/main amd64 Packages [33.1 kB]  
Get:7 http://security.debian.org/debian-security trixie-security/main Translation-en [22.0 kB]  
Err:5 https://download.webmin.com/download/newkey/repository stable InRelease  
  Sub-process /usr/bin/sqv returned an error code (1)  
error message is: Error: Failed to parse keyring "/usr/share/keyrings/debian-webmin-developers.gpg"  Caused by:     0: Reading "/usr/share/keyrings/debian-webmin-developers.gpg": Permission denied (os error 13)     1: Permission denied (os error 13)  
Reading package lists...  
W: OpenPGP signature verification failed: https://download.webmin.com/download/newkey/repository stable InRelease: Sub-process /usr/bin/sqv returned an error code (1)  
error message is: Error: Failed to parse keyring "/usr/share/keyrings/debian-webmin-developers.gpg"  Caused by:     0: Reading "/usr/share/keyrings/debian-webmin-developers.gpg": Permission denied (os error 13)     1: Permission denied (os error 13)  
E: The repository 'https://download.webmin.com/download/newkey/repository stable InRelease' is not signed.  

Related to https://github.com/webmin/webmin/issues/1966
