### PR TITLE
Fix bind8 undefined warnings and sort/splice with non-numeric value

### DIFF
--- a/bind8/bind8-lib.pl
+++ b/bind8/bind8-lib.pl
@@ -700,7 +700,7 @@ if ($v && $v->{'members'}) {
 		push(@av, join(" ", $av->{'name'}, @{$av->{'values'}}));
 		}
 	}
-if ($_[3] == 0) {
+if (!$_[3]) {
 	# text area
 	return &ui_table_row($_[0],
 		&ui_textarea($_[1], join("\n", @av), 3, 50));
@@ -805,14 +805,14 @@ my $v = &find($_[1], $_[2]);
 my $n;
 ($n = $_[1]) =~ s/[^A-Za-z0-9_]/_/g;
 return &ui_table_row($_[0],
-	&ui_opt_textbox($n, $v ? $v->{'value'} : "", $_[4], $_[3])." ".$_[5],
+	&ui_opt_textbox($n, $v ? $v->{'value'} : "", $_[4], $_[3])." ".($_[5] // ""),
 	$_[4] > 30 ? 3 : 1);
 }
 
 sub save_opt
 {
 my ($dir, $n, $err);
-($n = $_[0]) =~ s/[^A-Za-z0-9_]/_/g;
+($n = ($_[0] // "")) =~ s/[^A-Za-z0-9_]/_/g;
 if ($in{"${n}_def"}) { &save_directive($_[2], $_[0], [ ], $_[3]); }
 elsif ($err = &{$_[1]}($in{$n})) {
 	&error($err);
@@ -906,7 +906,7 @@ my ($fwdconf, $fwdfile, $fwdrec, $ipv6);
 # find forward domain
 my $host = $_[0]; $host =~ s/\.$//;
 my @zl = grep { $_->{'type'} ne 'view' } &list_zone_names();
-if ($_[1] ne '' && $_[1] ne 'any') {
+if ($_[1] && $_[1] ne 'any') {
 	@zl = grep { $_->{'view'} && $_->{'viewindex'} == $_[1] } @zl;
 	}
 else {
@@ -968,6 +968,7 @@ else {
 # Returns 1 if some zone can be edited
 sub can_edit_zone
 {
+$access{'zones'} //= '*';
 my %zcan;
 my ($zn, $vn, $file);
 if ($_[0]->{'members'}) {
@@ -2405,7 +2406,7 @@ return undef;
 sub is_bind_running
 {
 my $pidfile = &get_pid_file();
-my $rv = &check_pid_file(&make_chroot($pidfile, 1));
+my $rv = &check_pid_file(&make_chroot($pidfile, 1)) || 0;
 if (!$rv && $gconfig{'os_type'} eq 'windows') {
 	# Fall back to checking for process
 	$rv = &find_byname("named");
@@ -2536,6 +2537,7 @@ if ($changed || !$znc{'version'} ||
 			next if (!$type);
 			$type = lc($type);
 			my $file = &find_value("file", $z->{'members'});
+			$file //= "";
 			my $up = &find("update-policy", $z->{'members'});
 			my $au = &find("allow-update", $z->{'members'});
 			my $dynamic = $up || $au || $gau ? 1 : 0;
@@ -3198,6 +3200,7 @@ else {
 	$zonename = $zone->{'name'};
 	$zonefile = $zone->{'file'};
 	}
+return () if (!$zonename || !$zonefile);
 my $out = &backquote_command(
 	$config{'checkzone'}." ".quotemeta($zonename)." ".
 	quotemeta(&make_chroot(&absolute_path($zonefile)))." 2>&1 </dev/null");
@@ -3221,6 +3224,7 @@ else {
 	$zonename = $zone->{'name'};
 	$zonefile = $zone->{'file'};
 	}
+return () if (!$zonename || !$zonefile);
 my $absfile = &make_chroot(&absolute_path($zonefile));
 my $out = &backquote_command(
 	$config{'checkzone'}." ".quotemeta($zonename)." ".
@@ -3934,7 +3938,7 @@ if (&find_byname("nscd")) {
 sub transfer_slave_records
 {
 my ($dom, $masters, $file, $source, $sourceport) = @_;
-my $sourcearg;
+my $sourcearg = "";
 if ($source && $source ne "*") {
 	$sourcearg = "-t ".$source;
 	if ($sourceport) {

--- a/bind8/bind8-lib.pl
+++ b/bind8/bind8-lib.pl
@@ -3367,7 +3367,7 @@ if (!$access{'ro'} && $access{'apply'}) {
 		if ($zone && ($access{'apply'} == 1 || $access{'apply'} == 2)) {
 			# Apply this zone
 		        my $link = "restart_zone.cgi?return=$r&".
-				   "view=$zone->{'viewindex'}&".
+				   "view=".($zone->{'viewindex'} // "")."&".
 				   "zone=$zone->{'name'}";
 			push(@rv, &ui_link($link, $text{'links_apply'}) );
 			}

--- a/bind8/conf_servers.cgi
+++ b/bind8/conf_servers.cgi
@@ -28,12 +28,12 @@ for(my $i=0; $i<@servers; $i++) {
 	my @cols = ( );
 	push(@cols, &ui_textbox("ip_$i", $s->{'value'}, 30));
 
-	my $bogus = &find_value("bogus", $s->{'members'});
+	my $bogus = &find_value("bogus", $s->{'members'}) // "";
 	push(@cols, &ui_radio("bogus_$i", lc($bogus) eq 'yes' ? 1 : 0,
 			      [ [ 1, $text{'yes'} ],
 				[ 0, $text{'no'} ] ]));
 
-	my $format = &find_value("transfer-format", $s->{'members'});
+	my $format = &find_value("transfer-format", $s->{'members'}) // "";
 	push(@cols, &ui_radio("format_$i", lc($format),
 			      [ [ 'one-answer', $text{'servers_one'} ],
 				[ 'many-answers', $text{'servers_many'} ],

--- a/bind8/delete_recs.cgi
+++ b/bind8/delete_recs.cgi
@@ -45,7 +45,7 @@ else {
 
 	my %bumpedrev;
 	my @delr;
-	foreach my $d (sort { $b <=> $a } @d) {
+	foreach my $d (sort { ($b =~ /^(\d+)/)[0] <=> ($a =~ /^(\d+)/)[0] } @d) {
 		my ($num, $id) = split(/\//, $d, 2);
 		my $r = &find_record_by_id(\@recs, $id, $num);
 		next if (!$r);
@@ -77,7 +77,7 @@ else {
 		# Delete the actual record
 		&lock_file(&make_chroot($r->{'file'}));
 		&delete_record($r->{'file'}, $r);
-		splice(@recs, $d, 1);
+		splice(@recs, $num, 1);
 		push(@delr, $r);
 		}
 	&bump_soa_record($zone->{'file'}, \@recs);

--- a/bind8/edit_recs.cgi
+++ b/bind8/edit_recs.cgi
@@ -172,6 +172,7 @@ for(my $i=0; $i<@_; $i++) {
 	else {
 		$name = $r->{'name'};
 		}
+	$name //= "";
 	my @cols;
 	$name = &html_escape($name);
 	my $id = &record_id($r);

--- a/bind8/save_record.cgi
+++ b/bind8/save_record.cgi
@@ -488,6 +488,7 @@ else {
 		}
 	else {
 		# For other record types, just save the lines
+		$in{'values'} //= "";
 		$in{'values'} =~ s/\r//g;
 		my @vlines = split(/\n/, $in{'values'});
 		$vals = join(" ",map { $_ =~ /\s|;/ ? "\"$_\"" : $_ } @vlines);


### PR DESCRIPTION
I think this fixes all the bind8 `undefined` warnings I see in the `miniserv.error` log for our old name servers. Based on my understanding of the code and testing this doesn't change any behavior.

Also fixes an issue in bulk delete where we sort/splice on a non-numeric value in `delete_recs.cgi`. This might change behavior, as I'm not sure what actually happens when you sort/splice on a non-numeric value, but, it seems to now work as it is intended to work based on my understanding of it (but, I never noticed it not working right before).

I kind of suspect we can drop the `no warnings 'uninitialized';` at the top of `bind8-lib.pl` now.