### PR TITLE
Fix ping status PID check to use 16 bits for comparison

### DIFF
--- a/status/ping-monitor.pl
+++ b/status/ping-monitor.pl
@@ -176,7 +176,8 @@ sub ping_icmp
 				      $len_msg));
 		    if (($from_type == $ICMP_ECHOREPLY) &&
 			($from_ip eq $ip) &&
-			($from_pid == $$) && # Does the packet check out?
+			# ping uses only 16 bits for the PID
+			($from_pid == ($$ & 0xffff)) && # Does the packet check out?
 			($from_seq == $ping_seq))
 		    {
 			$ret = 1;                   # It's a winner


### PR DESCRIPTION
If `/proc/sys/kernel/pid_max` exceeds 16 bits then the ping check could incorrectly fail.

Source: https://man7.org/linux/man-pages/man8/ping.8.html#ID_COLLISIONS