### PR TITLE
perlcritic fixes

### DIFF
--- a/nftables/acl_security.pl
+++ b/nftables/acl_security.pl
@@ -3,7 +3,7 @@ use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
 
-require 'nftables-lib.pl';
+require './nftables-lib.pl';    ## no critic (Modules::RequireBarewordIncludes)
 our (%in, %text);
 
 # acl_security_form(&options)
@@ -86,5 +86,6 @@ if (!$err) {
 		);
 		}
 	}
-return sort { $a->[1] cmp $b->[1] } @opts;
+my @sorted = sort { $a->[1] cmp $b->[1] } @opts;
+return @sorted;
 }

--- a/nftables/apply-boot.pl
+++ b/nftables/apply-boot.pl
@@ -11,7 +11,7 @@ $no_acl_check++;
 if ($0 =~ /^(.*\/)[^\/]+$/) {
 	chdir($1);
 	}
-require './nftables-lib.pl';
+require './nftables-lib.pl';    ## no critic (Modules::RequireBarewordIncludes)
 if ($module_name ne 'nftables') {
 	print STDERR "Command must be run with full path\n";
 	exit(5);

--- a/nftables/nftables-lib.pl
+++ b/nftables/nftables-lib.pl
@@ -153,9 +153,9 @@ return has_command($cmd);
 sub nft_version_text
 {
 my $cmd = get_nft_command();
-return undef if (!$cmd);
+return if (!$cmd);
 my $out = backquote_command(quotemeta($cmd)." --version 2>&1");
-return undef if ($? || !$out);
+return if ($? || !$out);
 $out =~ s/\r?\n.*$//s;
 $out =~ s/^\s+|\s+$//g;
 if ($out =~ /^nftables\s+v?(\S+)(?:\s+(.*))?$/i) {
@@ -170,7 +170,7 @@ return $out;
 # Returns an error message if nftables is not installed, undef if all is OK
 sub check_nftables
 {
-return undef if (get_nft_command());
+return if (get_nft_command());
 return text('index_ecommand', "<tt>nft</tt>");
 }
 


### PR DESCRIPTION
Fixes perlcritic errors in nftables.

`return undef` is a bug waiting to happen. It behaves differently depending on caller. e.g. `@varname = nft_version_txt()` would create an array with one element `[ undef ]`, which tests as true in Perl, which is definitely not what you want/expect. Hash context is even weirder. Only scalar context actually works as intended.