### PR TITLE
Reset auth state in keep-alive proxied requests

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1327,6 +1327,7 @@ $baseauthuser = undef;
 $authpass = undef;
 $session_id = undef;
 $already_session_id = undef;
+$already_authuser = undef;
 $miniserv_internal = undef;
 $querystring = undef;
 $queryargs = undef;

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1317,6 +1317,48 @@ $reqline = $request_uri = $page = undef;
 $authuser = undef;
 $validated = undef;
 
+# Reset all per-request state. Keep-alive lets one child handle many
+# requests on one TCP connection; behind a proxy that pools backend
+# connections, those requests can be from different clients. Anything
+# left set from the prior request would leak across that boundary -
+# most dangerously $baseauthuser, which feeds BASE_REMOTE_USER and the
+# Webmin ACL layer.
+$baseauthuser = undef;
+$authpass = undef;
+$session_id = undef;
+$already_session_id = undef;
+$miniserv_internal = undef;
+$querystring = undef;
+$queryargs = undef;
+$pathinfo = undef;
+$peername = undef;
+$uinfo = undef;
+$scriptname = undef;
+$cgi_pwd = undef;
+$full = undef;
+$realroot = undef;
+$foundroot = undef;
+$is_directory = undef;
+$nph_script = undef;
+$logout = undef;
+$failed_user = undef;
+$failed_save = undef;
+$twofactor_msg = undef;
+$timed_out = undef;
+$error_handler_recurse = undef;
+%cgiheader = ();
+@cgiheader = ();
+$doneheaders = undef;
+$headers = undef;
+@stfull = ();
+# Restore $host/$port to socket defaults; the Host: header overwrite
+# below should not persist if the next request omits Host.
+local $host = $host;
+local $port = $port;
+# Scope per-request mutation of %config so it cannot leak to later
+# requests on this connection (see $config{'session'} = 0 below).
+local $config{'session'} = $config{'session'};
+
 # check address against access list
 if (@deny && &ip_match($acptip, $localip, @deny) ||
     @allow && !&ip_match($acptip, $localip, @allow)) {


### PR DESCRIPTION
This should resolve the issue with proxies and keep-alive requests and accidental auth sharing across pooled connections.

I don't have a proxy setup for testing in the proxy path, but it's a very simple patch and it works fine in the usual non-proxied.

handle_request (now around lines 1320–1360) explicitly resets every per-request global at the top:

  - Auth state: $baseauthuser, $authpass, $session_id, $already_session_id, $uinfo, $peername
  - Request state: $querystring, $queryargs, $pathinfo, $miniserv_internal, $logout, $failed_user, $failed_save, $twofactor_msg, $timed_out, $error_handler_recurse
  - File-lookup state: $scriptname, $cgi_pwd, $full, $realroot, $foundroot, $is_directory, $nph_script, @stfull
  - CGI response state: %cgiheader, @cgiheader, $doneheaders, $headers

Two values use local so the existing in-function mutations auto-revert when handle_request returns:

  - local $host = $host; / local $port = $port; — the Host: header overwrite at lines 1517–1523 no longer persists when the next request omits that header.
  - local $config{'session'} = $config{'session'}; — the $config{'session'} = 0 mutation at line 1730 (triggered by Webmin-RPC user-agents, DAV paths, xmlrpc, etc.) is scoped to one request.

Notes for the security report

  - The earlier trusted_proxies work (commit 241abfe71) does not overlap with this issue. It hardens which TCP peers can supply forwarding/SSL headers; this fix hardens what survives between requests on one connection. Both are
  needed.
  - CGI responses still call &write_keep_alive(0), so in practice keep-alive across users is most likely on static-asset connection reuse (nginx upstream { keepalive N; }, Apache enablereuse=on). The fix closes the bug regardless
   of which path was hit first.
  - $checked_timeout, $verified_client, $ssl_con, $ssl_cn, $ssl_alts are intentionally not reset — they are per-connection, not per-request.

Note, we also have dead variables `$already_session_id`, `$already_authuser` which never contain a truthy value. This patch does not address that, to keep this clean and specifically about the security issue.

Also, this accidentally fixes the following subtle bugs in the non-proxied case, as well:

  - $querystring / $queryargs / $pathinfo — only set when the URL contains them. Before: GET /a.cgi?x=1 followed by GET /b.cgi on the same connection would send b.cgi a stale QUERY_STRING=x=1. Now correctly empty.
  - $failed_user / $failed_save / $twofactor_msg / $timed_out — login-failure decoration. Before: a failed login could leave &failed=olduser on subsequent unrelated login-page renders.
  - $logout, $error_handler_recurse, $miniserv_internal — internal flags that should always be per-request.
  - $config{'session'} = 0 (now local-scoped) — previously, one request from a User-Agent: webmin client (RPC), from a DAV path, or from /xmlrpc.cgi would permanently disable session auth for the rest of that child process's life. So a browser sharing the same backend process (which can happen even without a proxy, just by hitting the same child) could find session auth silently unavailable. Now correctly scoped.