### PR TITLE
Make core pl and cli files testable

### DIFF
--- a/bin/language-manager
+++ b/bin/language-manager
@@ -315,7 +315,7 @@ sub main
 
     return 0;
 }
-main();
+main() if !caller(0);
 
 # The following is used to get correct language files based on old language table.
 # This function, should not be really needed, unless compiling languages with

--- a/changepass.pl
+++ b/changepass.pl
@@ -2,6 +2,8 @@
 # changepass.pl
 # Script for the user to change their webmin password
 
+unless (caller) {
+
 # Get Webmin directory
 my $cwd = $0;
 $cwd =~ s/(.*)\/.*/$1/;
@@ -20,6 +22,8 @@ if ($status != 0) {
 		}
 	}
 exit $status;
+
+} # end of unless (caller)
 
 sub usage
 {

--- a/copyconfig.pl
+++ b/copyconfig.pl
@@ -4,6 +4,8 @@
 # directory. If it is already there, merge in new directives. Called with
 # <osname> <osversion> <install dir> <config dir> <module>+
 
+unless (caller) {
+
 @ARGV >= 4 || die "usage: copyconfig.pl <os>[/real-os] <version>[/real-version] <webmin-dir> <config-dir> [module ...]";
 $os = $ARGV[0];
 $ver = $ARGV[1];
@@ -112,6 +114,8 @@ foreach $m (@mods) {
 		}
 	}
 print join(" ", @newmods),"\n";
+
+} # end of unless (caller)
 
 # read_file(file, &hash, [&order], [lowercase], [split-char])
 # Fill the given hash reference with name=value pairs from a file.

--- a/create-module.pl
+++ b/create-module.pl
@@ -3,6 +3,8 @@
 # Creates a single .wbm file containing multiple modules, possibly with
 # forced versions
 
+unless (caller) {
+
 @ARGV >= 2 || die "usage: create-module.pl [--dir name] <file.wbm> <module>[/version] ..";
 
 my $pwd;
@@ -105,6 +107,8 @@ if ($createsig) {
 	system("gpg ".($keyname ? " --default-key $keyname" : "").
 	       " --armor --output $file-sig.asc --detach-sig $file");
 	}
+
+} # end of unless (caller)
 
 # read_file(file, &assoc, [&order], [lowercase])
 # Fill an associative array with name=value pairs from a file

--- a/create-module.pl
+++ b/create-module.pl
@@ -88,6 +88,7 @@ foreach my $m (@ARGV) {
 	system("cd /tmp/create-module && find . -name RELEASE -o -name RELEASE.sh | xargs rm -rf");
 	system("cd /tmp/create-module && find . -name linux.sh -o -name freebsd.sh -o -name LICENCE -o -name README.md -o -name distrib | xargs rm -rf");
 	system("cd /tmp/create-module && find . -name 'makemodule*.pl' | xargs rm -rf");
+	system("cd /tmp/create-module && find . -type d \\( -name t -o -name xt \\) | xargs rm -rf");
 	if (-r "/tmp/create-module/$subdir/EXCLUDE") {
 		system("cd /tmp/create-module/$subdir && cat EXCLUDE | xargs rm -rf");
 		unlink("/tmp/create-module/$subdir/EXCLUDE");

--- a/extract-module-info-langs.pl
+++ b/extract-module-info-langs.pl
@@ -2,6 +2,8 @@
 # For each given module.info file, create new module.info.XX files for each
 # desc_XX= line in the original
 
+unless (caller) {
+
 if ($ARGV[0] eq "--dry-run") {
 	$dryrun = 1;
 	shift(@ARGV);
@@ -42,6 +44,8 @@ foreach my $f (@files) {
 			}
 		}
 	}
+
+} # end of unless (caller)
 
 # read_file(file, &assoc, [&order], [lowercase])
 # Fill an associative array with name=value pairs from a file

--- a/fix-english.pl
+++ b/fix-english.pl
@@ -2,6 +2,8 @@
 # Convert words in lang/en files from UK to US spelling.
 # Create lang/en_GB files containing words that are different.
 
+unless (caller) {
+
 if ($ARGV[0] eq "--svn" || $ARGV[0] eq "-svn" ||
     $ARGV[0] eq "--git" || $ARGV[0] eq "-git") {
 	shift(@ARGV);
@@ -61,6 +63,8 @@ foreach $f (@rv) {
 		system("cd $dir ; git add $rest ; git commit -m '$svn' $rest ; git push");
 		}
 	}
+
+} # end of unless (caller)
 
 sub fix_english_file
 {

--- a/makedebian.pl
+++ b/makedebian.pl
@@ -3,6 +3,8 @@
 
 use POSIX;
 
+unless (caller) {
+
 if ($ARGV[0] eq "--webmail" || $ARGV[0] eq "-webmail") {
 	$webmail = 1;
 	shift(@ARGV);
@@ -526,6 +528,8 @@ EOF
 
 	system("rm -rf $diff_orig_dir $diff_new_dir");
 	}
+
+} # end of unless (caller)
 
 # read_file(file, &assoc, [&order], [lowercase])
 # Fill an associative array with name=value pairs from a file

--- a/makedist.pl
+++ b/makedist.pl
@@ -1,6 +1,8 @@
 #!/usr/local/bin/perl
 # Builds a tar.gz package of a specified Webmin version
 
+unless (caller) {
+
 # Parse command line options
 $mod_list  = 'full';
 @ARGV = map { /^--\S+\s+/ ? split(/\s+/, $_) : $_ } @ARGV;
@@ -243,6 +245,8 @@ if ($min && !$release) {
 	# Delete the tarball directory
 	system("rm -rf $tardir/$dir");
 	}
+
+} # end of unless (caller)
 
 # read_file(file, &assoc, [&order])
 # Fill an associative array with name=value pairs from a file

--- a/makedist.pl
+++ b/makedist.pl
@@ -113,8 +113,9 @@ if (!$release || !-d "$tardir/$dir") {
 			next if ($f =~ /^\./ || $f =~ /\.git$/ ||
 				 $f =~ /\.(tar|wbm|wbt)\.gz$/ ||
 				 $f eq "README.md" || $f =~ /^makemodule.*\.pl$/ ||
-				 $f eq "linux.sh" || $f eq "freebsd.sh" || 
-				 $f eq "LICENCE" || $f eq "version");
+				 $f eq "linux.sh" || $f eq "freebsd.sh" ||
+				 $f eq "LICENCE" || $f eq "version" ||
+				 (-d "$m/$f" && ($f eq "t" || $f eq "xt")));
 			$flist .= " $m/$f";
 			}
 		closedir(DIR);

--- a/makemoduledeb.pl
+++ b/makemoduledeb.pl
@@ -246,6 +246,7 @@ system("find $usr_dir -name .git | xargs rm -rf");
 system("find $usr_dir -name .github | xargs rm -rf");
 system("find $usr_dir -name RELEASE | xargs rm -rf");
 system("find $usr_dir -name RELEASE.sh | xargs rm -rf");
+system("find $usr_dir -type d \\( -name t -o -name xt \\) | xargs rm -rf");
 if (-r "$usr_dir/$mod/EXCLUDE") {
 	system("cd $usr_dir/$mod && cat EXCLUDE | xargs rm -rf");
 	system("rm -f $usr_dir/$mod/EXCLUDE");

--- a/makemoduledeb.pl
+++ b/makemoduledeb.pl
@@ -9,6 +9,8 @@ use POSIX;
 use Term::ANSIColor qw(:constants);
 use 5.010;
 
+unless (caller) {
+
 my $licence = "BSD";
 my $email = "Jamie Cameron <jcameron\@webmin.com>";
 my $target_dir = "/tmp";
@@ -651,6 +653,8 @@ EOF
 # Clean up
 # XXX Dangerous! Fix me.
 system("rm -rf $tmp_dir");
+
+} # end of unless (caller)
 
 # read_file(file, &assoc, [&order], [lowercase])
 # Fill an associative array with name=value pairs from a file

--- a/makemodulerpm.pl
+++ b/makemodulerpm.pl
@@ -268,7 +268,7 @@ system("/usr/bin/find /tmp/makemodulerpm -name .git | xargs rm -rf");
 system("/usr/bin/find /tmp/makemodulerpm -name .github | xargs rm -rf");
 system("/usr/bin/find /tmp/makemodulerpm -name RELEASE | xargs rm -rf");
 system("/usr/bin/find /tmp/makemodulerpm -name RELEASE.sh | xargs rm -rf");
-system("/usr/bin/find /tmp/makemodulerpm -name t | xargs rm -rf");
+system("/usr/bin/find /tmp/makemodulerpm -type d \\( -name t -o -name xt \\) | xargs rm -rf");
 if (-r "/tmp/makemodulerpm/$mod/EXCLUDE") {
 	system("cd /tmp/makemodulerpm/$mod && cat EXCLUDE | xargs rm -rf");
 	system("rm -f /tmp/makemodulerpm/$mod/EXCLUDE");

--- a/makemodulerpm.pl
+++ b/makemodulerpm.pl
@@ -10,6 +10,8 @@ use 5.010;
 # Colors!
 use Term::ANSIColor qw(:constants);
 
+unless (caller) {
+
 my $basedir;
 
 # Does any system still have a redhat dir?
@@ -601,6 +603,8 @@ elsif ($rpm_dir ne $target_dir) {
 		unlink("/tmp/$tar_release_file");
 		}
 	}
+
+} # end of unless (caller)
 
 # read_file(file, &assoc, [&order], [lowercase])
 # Fill an associative array with name=value pairs from a file

--- a/oschooser.pl
+++ b/oschooser.pl
@@ -7,6 +7,8 @@
 #	      2 = automatic, ask user if fails
 #             3 = automatic, ask user if fails and if a TTY
 
+unless (caller) {
+
 $| = 1;
 
 ($oslist, $out, $auto) = @ARGV;
@@ -167,6 +169,8 @@ print OUT "os_version='",$ver->[3],"'\n";
 print OUT "real_os_type='",$ver->[0],"'\n";
 print OUT "real_os_version='",$ver->[1],"'\n";
 close(OUT);
+
+} # end of unless (caller)
 
 # has_command(command)
 # Returns the full path if some command is in the path, undef if not

--- a/setup.pl
+++ b/setup.pl
@@ -6,6 +6,8 @@
 use POSIX;
 use Socket;
 
+unless (caller) {
+
 # Find install directory
 $ENV{'LANG'} = '';
 $0 =~ s/\\/\//g;
@@ -1024,6 +1026,8 @@ if ($oldwadir ne $wadir && $upgrading && !$ENV{'deletedold'}) {
 	print "version.\n";
 	print "\n";
 	}
+
+} # end of unless (caller)
 
 sub errorexit
 {

--- a/t/README.md
+++ b/t/README.md
@@ -24,11 +24,11 @@ WEBMIN_COMPILE_T_FILTER='^\./acl/' prove t/compile.t   # one module
 | File | What it checks |
 | --- | --- |
 | `compile.t` | Every `.pl`, `.cgi`, and shebang-perl script in `bin/` parses cleanly (`perl -c`). Catches breakage from bulk refactors without browsing every page. ~12s for the full tree. |
-| `miniserv-http_error.t` | Contract test for `miniserv::http_error` — status codes, headers, body rendering, log behaviour. Demonstrates the require-and-stub pattern below. |
+| `miniserv.t` | Contract test for `miniserv.pl` functions — status codes, headers, body rendering, log behaviour. Demonstrates the require-and-stub pattern below. |
 
 ## The require-and-stub pattern
 
-Most Webmin scripts mix sub definitions with a main body that opens sockets,
+Many Webmin scripts mix sub definitions with a main body that opens sockets,
 reads `/etc/webmin/*`, or spawns CGIs. To test individual subs in isolation
 we need to `require` the script as a library without running the main body.
 
@@ -79,7 +79,7 @@ under `require`.
 
 ## Sub-stubbing in tests
 
-`miniserv-http_error.t` is the canonical example. The pattern:
+`miniserv.t` is the canonical example. The pattern:
 
 1. `require` the script. The guard skips its main body.
 2. Replace side-effecting subs (socket I/O, logging, disk reads) with

--- a/t/README.md
+++ b/t/README.md
@@ -10,6 +10,7 @@ Two kinds of tests live under this tree:
 ## Running tests
 
 ```sh
+prove -lr                                # everything, including modules t/
 prove -lr t                              # everything under repo-root t/
 prove t/compile.t                        # one test file
 WEBMIN_COMPILE_T_FILTER='^\./acl/' prove t/compile.t   # one module

--- a/t/README.md
+++ b/t/README.md
@@ -1,0 +1,136 @@
+# Webmin test suite
+
+Two kinds of tests live under this tree:
+
+- Repo-root `t/` for core code (`miniserv.pl`, `web-lib-funcs.pl`, top-level
+  scripts, `bin/`).
+- Per-module `t/` for module-internal coverage (see `nftables/t/` for the
+  established pattern: `perlcritic.t` plus a `run-tests.t` smoke harness).
+
+## Running tests
+
+```sh
+prove -lr t                              # everything under repo-root t/
+prove t/compile.t                        # one test file
+WEBMIN_COMPILE_T_FILTER='^\./acl/' prove t/compile.t   # one module
+```
+
+`prove` and Test::More are core, though on RPM-based distros, you need
+`perl-Test-Harness`.
+
+## What's here
+
+| File | What it checks |
+| --- | --- |
+| `compile.t` | Every `.pl`, `.cgi`, and shebang-perl script in `bin/` parses cleanly (`perl -c`). Catches breakage from bulk refactors without browsing every page. ~12s for the full tree. |
+| `miniserv-http_error.t` | Contract test for `miniserv::http_error` — status codes, headers, body rendering, log behaviour. Demonstrates the require-and-stub pattern below. |
+
+## The require-and-stub pattern
+
+Most Webmin scripts mix sub definitions with a main body that opens sockets,
+reads `/etc/webmin/*`, or spawns CGIs. To test individual subs in isolation
+we need to `require` the script as a library without running the main body.
+
+Two complementary idioms are used. Both work; they look different because
+the underlying script does.
+
+### Block wrap (main body precedes sub definitions)
+
+Used by `miniserv.pl` and most top-level `.pl` scripts. The executable
+preamble runs at file scope (so any `my` vars stay file-scoped for the subs
+below); the main body wraps in `unless (caller)`:
+
+```perl
+#!/usr/bin/perl
+use Foo;            # use lines and pragmas stay outside the guard
+
+unless (caller) {
+
+# main body: arg parsing, setup, the actual work
+...
+
+} # end of unless (caller)
+
+sub helper { ... }
+sub other_helper { ... }
+```
+
+### One-liner (sub definitions precede the main call)
+
+Used by most `bin/` CLI tools, which already define `sub main` and dispatch
+to it at the bottom:
+
+```perl
+#!/usr/bin/env perl
+use strict; use warnings;
+
+sub main {
+    ...
+    return 0;
+}
+exit main(\@ARGV) if !caller(0);
+
+sub helper { ... }
+```
+
+`!caller(0)` is true at script invocation (depth-0 frame absent) and false
+under `require`.
+
+## Sub-stubbing in tests
+
+`miniserv-http_error.t` is the canonical example. The pattern:
+
+1. `require` the script. The guard skips its main body.
+2. Replace side-effecting subs (socket I/O, logging, disk reads) with
+   capture-buffer overrides under `no warnings 'redefine'`.
+3. Populate package globals (`%miniserv::config`, `@miniserv::roots`, etc.)
+   yourself instead of running the config loader.
+4. Call the sub under test. Assert on contract (status code, presence of
+   required headers, structural balance of emitted markup) — not on
+   cosmetics like exact wording or class names.
+
+Tying tests to the contract rather than the rendering lets the UI evolve
+without breaking the test, while still catching real regressions.
+
+## Tiered coverage policy
+
+Not all 268 modules deserve the same investment.
+
+- **Tier 1 — security-critical, network-facing.** `miniserv.pl`,
+  `web-lib-funcs.pl`, `acl/`, auth, file upload paths. Comprehensive
+  contract tests; mock filesystem and `backquote_command` for parser
+  coverage of external-binary output.
+- **Tier 2 — active refactor surface.** Currently `nftables/`, `firewalld/`,
+  and whichever module is being reviewed. Mandatory tests for new code;
+  `perlcritic.t` at severity 5 as a gate.
+- **Tier 3 — stable OS-config wrappers.** Covered by `compile.t` plus
+  optional per-module `perlcritic.t`. Don't chase line coverage on parsers
+  for config files that haven't changed in a decade.
+
+The goal is not coverage-as-a-number. It's:
+
+- Every parser round-trips its serializer.
+- Every privilege boundary has a test.
+- Every external-binary call has a mock-driven test for its output parser.
+
+## Adding a per-module test directory
+
+```
+yourmodule/
+  t/
+    perlcritic.t   # see nftables/t/perlcritic.t for the template
+    run-tests.t    # see nftables/t/run-tests.t for the WEBMIN_CONFIG / tmpdir setup
+```
+
+A module's tests are reachable from `prove -lr t` at the root via the
+`-r` recursive walk.
+
+## Caveats
+
+- `WEBMIN_COMPILE_T_STRICT=1` turns missing-CPAN-module skips into failures.
+  Use this in CI on a fully-provisioned image; leave it off on dev boxes
+  where optional deps (`Pod::Simple::Wiki`, `Encode::Detect::Detector`) may
+  not be installed.
+- `.pl` is also the Polish translation suffix in Webmin. `compile.t` skips
+  `<file>.pl` when a sibling `<file>` (no extension) exists; this catches
+  `config.info.pl` and `module.info.pl` data files without a hardcoded list.

--- a/t/compile.t
+++ b/t/compile.t
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+# Verify every .pl and .cgi in the tree parses (perl -c).
+#
+# Catches syntax and `use` breakage from bulk refactors without having
+# to load every page in a browser. The test is the first line of defence
+# for the "we changed thousands of files mechanically, did anything
+# break" question.
+#
+# Skipped:
+#   - $file.pl when a sibling $file (no .pl) exists. Webmin uses .pl as
+#     the Polish translation suffix, so config.info.pl, module.info.pl,
+#     etc. are data files, not Perl.
+#   - Files that fail only because of a missing CPAN module. The file
+#     itself parses, but `use Foo::Bar` can't resolve at compile time.
+#     Treated as a skip so missing optional deps don't gate the suite.
+#     Set WEBMIN_COMPILE_T_STRICT=1 to turn these into failures.
+#
+# Speed: ~12 seconds for the full tree (~3.4k files). Narrow with
+# WEBMIN_COMPILE_T_FILTER=<regex> when iterating on one module.
+
+use strict;
+use warnings;
+use Test::More;
+use File::Find;
+use File::Basename qw(dirname);
+use File::Spec;
+use Cwd qw(abs_path);
+
+my $root = abs_path(File::Spec->catdir(dirname(__FILE__), '..'));
+chdir($root) or die "chdir($root): $!";
+
+my $filter = $ENV{WEBMIN_COMPILE_T_FILTER};
+my $strict = $ENV{WEBMIN_COMPILE_T_STRICT};
+
+my @files;
+find({
+	no_chdir => 1,
+	wanted => sub {
+		return if -d;
+		# .pl and .cgi files, plus extensionless files in bin/ with a
+		# perl shebang. The shebang check keeps us from compile-checking
+		# arbitrary non-perl files just because they share a directory.
+		my $name = $File::Find::name;
+		my $is_pl_or_cgi = $name =~ /\.(pl|cgi)\z/;
+		my $is_bin_dotless = $name =~ m{^\./bin/([^/]+)\z} && $1 !~ /\./;
+		return unless $is_pl_or_cgi || $is_bin_dotless;
+		# Skip the Polish translations that share the .pl suffix.
+		if ($is_pl_or_cgi && $name =~ m{(.+)\.pl\z}) {
+			my $base = $1;
+			return if -f "$base";
+			}
+		# For extensionless bin/ scripts, require a perl shebang.
+		if ($is_bin_dotless) {
+			open(my $fh, '<', $name) or return;
+			my $shebang = <$fh>;
+			close($fh);
+			return unless defined $shebang && $shebang =~ /^#!.*\bperl\b/;
+			}
+		push(@files, $name);
+		},
+	}, '.');
+
+@files = sort @files;
+@files or BAIL_OUT("found no .pl/.cgi/bin scripts under $root");
+
+if ($filter) {
+	@files = grep { /$filter/ } @files;
+	@files or do { diag("filter '$filter' matched zero files"); plan skip_all => "no files match filter"; };
+	}
+
+diag("compile-checking " . scalar(@files) . " files");
+
+for my $f (@files) {
+	my $rel = $f;
+	$rel =~ s{^\./}{};
+	my $out = qx{perl -I. -c -- "$rel" 2>&1};
+	if ($out =~ /\bsyntax OK\b/) {
+		pass("$rel compiles");
+		}
+	elsif (!$strict && $out =~ /Can't locate (\S+\.pm) in \@INC/) {
+		SKIP: { skip("$rel: missing optional CPAN module $1", 1); }
+		}
+	else {
+		fail("$rel compiles");
+		diag($out);
+		}
+	}
+
+done_testing();

--- a/thirdparty.pl
+++ b/thirdparty.pl
@@ -3,6 +3,8 @@
 # not included in this new install, and offers to copy them across.
 # Also re-creates clones of existing modules in the new install
 
+unless (caller) {
+
 ($newdir, $olddir, $copythird) = @ARGV;
 
 # find missing modules
@@ -51,6 +53,8 @@ if (@missing) {
 			}
 		}
 	}
+
+} # end of unless (caller)
 
 # read_file(file, array)
 # Fill an associative array with name=value pairs from a file

--- a/upload-pod-docs.pl
+++ b/upload-pod-docs.pl
@@ -3,6 +3,8 @@
 
 use Pod::Simple::Wiki;
 
+unless (caller) {
+
 $doxfer_host = "doxfer.com";
 $doxfer_dir = "/home/doxfer/public_html/twiki/data/Webmin";
 $temp_pod_dir = "/tmp/doxfer-wiki";
@@ -129,6 +131,8 @@ close(SUMM);
 print STDERR "Uploading to $doxfer_host\n";
 system("scp $temp_pod_dir/*.txt doxfer\@$doxfer_host:/home/doxfer/public_html/twiki/data/Webmin/");
 print STDERR "done\n";
+
+} # end of unless (caller)
 
 sub html_escape
 {


### PR DESCRIPTION
Makes the base directory Perl files, and CLI files in bin, testable by making them loadable without executing the code (wraps in a `caller` check). Makes no difference in functionality/behavior, just means we can write tests for the functions in the files. This is the same change I made in #2695 applied to all the other stuff in the base dir and bin. I didn't make the change for any files that don't have any subs. Those just have to be tested via regular command invocation, for now.

Also adds `t/compile.t` to run `perl -c` on all Perl files. The most basic of smoke tests to make sure every Perl file has valid syntax. Doesn't really do much, but we have occasionally had invalid Perl files sneak out into releases, and we have to start somewhere. Skips `pl` files that are config or language or help, as `pl` in those cases means Polish not Perl.

Also adds a README.md to `t` documenting how to run tests, vaguely how to write tests (modules get a `t` directory of their own, where any tests not already covered at the higher level can be placed).

Also excludes `t` and `xt` from all packaging scripts.