### PR TITLE
Fix encrypt_sha512 so it doesn't always fall back to crypt

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -6779,15 +6779,14 @@ return $newhash eq $hash;
 }
 
 # encrypt_sha512(password, [salt])
-# Hashes a password, possibly with the given salt, with SHA512
+# Hashes a password, possibly with the given salt, with SHA512. The salt
+# arg may be a full $6$salt$hash form (verification) or a bare $6$salt$
+# (fresh hashing) — either way it must be passed to crypt() intact so
+# crypt() selects SHA512. Only synthesise a new salt when none is given.
 sub encrypt_sha512
 {
 my ($passwd, $salt) = @_;
-if ($salt =~ /^\$6\$([^\$]+)/) {
-	# Extract actual salt from already encrypted password
-	$salt = $1;
-	}
-$salt ||= '$6$'.substr(time(), -8).'$';
+$salt = '$6$'.substr(time(), -8).'$' if (!$salt || $salt !~ /^\$6\$/);
 return crypt($passwd, $salt);
 }
 

--- a/t/miniserv.t
+++ b/t/miniserv.t
@@ -652,16 +652,6 @@ subtest 'unix_crypt_supports_sha512' => sub {
 };
 
 # encrypt_sha512 — $6$ SHA512-crypt via libc crypt()
-#
-# KNOWN BUG, intentionally failing here: miniserv.pl:6786 captures
-# /^\$6\$([^\$]+)/ and assigns the bare salt body back to $salt, stripping
-# the $6$ prefix that libc crypt() needs to select SHA512. crypt() then
-# falls back to DES and returns a 13-char hash. The function only "works"
-# in production because password_crypt falls through to unix_crypt with
-# the original (un-corrupted) salt when encrypt_sha512's output doesn't
-# match. The correct form is in useradmin/md5-lib.pl:218 — leave the full
-# $6$salt$ untouched, only synthesise a new salt when one is absent.
-# Fix is being tracked separately; these failures are the reminder.
 subtest 'encrypt_sha512' => sub {
 	plan skip_all => 'crypt() does not support SHA512 on this system'
 		if !$have_sha512;
@@ -671,16 +661,12 @@ subtest 'encrypt_sha512' => sub {
 	cmp_ok(length($h), '>', 50,
 	       'SHA512 output is much longer than DES (DES is 13 chars)');
 
-	# Behaviour we pin regardless of the bug above:
-	# - calling the function twice with the same args is deterministic
-	# - a different password produces a different hash
-	# - the no-salt path correctly synthesises a $6$ salt
 	is  (miniserv::encrypt_sha512('password', $h), $h,
 	     'deterministic for same (password, salt) — verification round-trip');
 	isnt(miniserv::encrypt_sha512('wrong', $h), $h,
 	     'different password → different hash');
 	like(miniserv::encrypt_sha512('password'), qr{^\$6\$},
-	     'no-salt path synthesises $6$ salt (and produces real SHA512)');
+	     'no-salt path synthesises $6$ salt');
 };
 
 # password_crypt — verifies a stored hash by recomputing


### PR DESCRIPTION
encrypt_sha512 now matches libc crypt() output byte-for-byte for $6$ inputs, and password_crypt's verification round-trip still behaves as callers expect (returns the stored hash on correct password, differs on wrong).

  Diff summary:
  - miniserv.pl:6783 — replaced the regex-extract-and-reassign with the same form used in useradmin/md5-lib.pl:218: pass the salt through to crypt() unmodified, only synthesize a fresh $6$…$ when the caller didn't supply one.
  - No changes needed elsewhere. All five callers within miniserv.pl (one in password_crypt, four password_crypt consumers) use the contract &password_crypt($pass, $stored) eq $stored, which still holds. External-module callers of encrypt_sha512 (acl/, useradmin/, ldap-useradmin/) were already routing to useradmin::encrypt_sha512 and never touched the broken function.

Note, this is duplicated code with the same function in `useradmin/md5-lib.pl`. Not sure if there's an easy/safe way to dedupe.