### PR TITLE
Make perlcritic happy again

### DIFF
--- a/nftables/nftables-lib.pl
+++ b/nftables/nftables-lib.pl
@@ -1175,7 +1175,8 @@ foreach my $svc (read_etc_service_defs($services_file)) {
 foreach my $svc (setup_quick_service_defs()) {
 	merge_quick_service(\%defs, $svc);
 	}
-return sort { lc($a->{'label'}) cmp lc($b->{'label'}) } values %defs;
+my @sorted = sort { lc($a->{'label'}) cmp lc($b->{'label'}) } values %defs;
+return @sorted;
 }
 
 # service_search_text(&service)
@@ -2543,7 +2544,7 @@ foreach my $service (@services) {
 	my $port = $map->{lc($proto || '')}->{lc($service)};
 	return $port if (defined($port));
 	}
-return undef;
+return;
 }
 
 # read_etc_services([services-file])
@@ -2616,12 +2617,12 @@ return 0;
 sub configured_port_from_address
 {
 my ($value, $default) = @_;
-return undef if (!defined($value) || $value eq '');
+return if (!defined($value) || $value eq '');
 return $1 if ($value =~ /^(\d+)$/);
 return $1 if ($value =~ /^\[[^\]]+\]:(\d+)$/);
 return $1 if ($value =~ /^[^:]+:(\d+)$/);
 return $default if (defined($default) && $value =~ /\S/);
-return undef;
+return;
 }
 
 # address_is_loopback(address)


### PR DESCRIPTION
Tests in `nftables` are failing, due to perlcritic errors:

```
$ prove t/
t/perlcritic.t .. 25/?
#   Failed test './nftables-lib.pl perlcritic'
#   at t/perlcritic.t line 55.
#          got: '4'
#     expected: '0'
# "return" statement followed by "sort" at line 1178, column 1. Behavior is undefined if called in scalar context.
# "return" statement with explicit "undef" at line 2546, column 1. See page 199 of PBP.
# "return" statement with explicit "undef" at line 2619, column 1. See page 199 of PBP.
# "return" statement with explicit "undef" at line 2624, column 1. See page 199 of PBP.
# Looks like you failed 1 test of 33.
t/perlcritic.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/33 subtests
t/run-tests.t ... ok

Test Summary Report
-------------------
t/perlcritic.t (Wstat: 256 (exited 1) Tests: 33 Failed: 1)
  Failed test:  25
  Non-zero exit status: 1
Files=2, Tests=227,  2 wallclock secs ( 0.01 usr  0.00 sys +  2.73 cusr  0.06 csys =  2.80 CPU)
Result: FAIL
```

This PR fixes those.