### PR TITLE
acl perlcritic test and fixes

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,0 +1,6 @@
+severity = 5
+
+# Octal file permission literals (0700, 0640, etc.) are the standard Perl
+# idiom for chmod/mkdir/permission helpers throughout this codebase. The
+# policy flags chmod 0700 itself, so it is too coarse for our use.
+[-ValuesAndExpressions::ProhibitLeadingZeros]

--- a/acl/acl-lib.pl
+++ b/acl/acl-lib.pl
@@ -11,7 +11,7 @@ Library for editing webmin users, passwords and access rights.
 
 =cut
 
-BEGIN { push(@INC, ".."); };
+BEGIN { push(@INC, ".."); };    ## no critic
 use strict;
 use warnings;
 no warnings 'redefine';
@@ -352,7 +352,8 @@ each of which is a hash reference in the same format as their module.info files.
 sub list_module_infos
 {
 my @mods = grep { &check_os_support($_) } &get_all_module_infos();
-return sort { $a->{'desc'} cmp $b->{'desc'} } @mods;
+my @sorted = sort { $a->{'desc'} cmp $b->{'desc'} } @mods;
+return @sorted;
 }
 
 =head2 create_user(&details, [clone])
@@ -1331,12 +1332,12 @@ my ($miniserv) = @_;
 my $sfile = $miniserv->{'sessiondb'} ? $miniserv->{'sessiondb'} :
 	    $miniserv->{'pidfile'} =~ /^(.*)\/[^\/]+$/ ? "$1/sessiondb"
 						     : return;
-eval "use SDBM_File";
+eval { require SDBM_File; SDBM_File->import; 1 };
 dbmopen(%sessiondb, $sfile, 0700);
 eval { $sessiondb{'1111111111'} = 'foo bar' };
 if ($@) {
 	dbmclose(%sessiondb);
-	eval "use NDBM_File";
+	eval { require NDBM_File; NDBM_File->import; 1 };
 	dbmopen(%sessiondb, $sfile, 0700);
 	}
 else {
@@ -1422,10 +1423,10 @@ Creates a new session ID that's already logged in as the given user
 sub create_session_user
 {
 my ($miniserv, $username, $lifetime) = @_;
-return undef if (&is_readonly_mode());
+return if (&is_readonly_mode());
 &open_session_db($miniserv);
 my $sid = &generate_random_session_id();
-return undef if (!$sid);
+return if (!$sid);
 my $t = time();
 $sessiondb{$sid} = "$username $t 127.0.0.1".($lifetime ? " ".$lifetime : "");
 dbmclose(%sessiondb);
@@ -1693,7 +1694,7 @@ elsif (&has_command("ssleay")) {
 	return &has_command("ssleay");
 	}
 else {
-	return undef;
+	return;
 	}
 }
 
@@ -1854,7 +1855,7 @@ if ($miniserv{'pass_oldblock'} && $user) {
 		last if ($c++ > $miniserv{'pass_oldblock'});
 		}
 	}
-return undef;
+return;
 }
 
 =head2 hash_session_id(sid)
@@ -1891,11 +1892,11 @@ my $use_md5 = &md5_perl_module();
 $use_md5 || &error("No Perl MD5 hashing module found!");
 
 # Add the password
-my $ctx = eval "new $use_md5";
+my $ctx = $use_md5->new;
 $ctx->add($passwd);
 
 # Add some more stuff from the hash of the password and salt
-my $ctx1 = eval "new $use_md5";
+my $ctx1 = $use_md5->new;
 $ctx1->add($passwd);
 $ctx1->add($passwd);
 my $final = $ctx1->digest();
@@ -1944,12 +1945,12 @@ Returns a Perl module for MD5 hashing, or undef if none.
 sub md5_perl_module
 {
 my $use_md5;
-eval "use MD5";
+eval { require MD5; MD5->import; 1 };
 if (!$@) {
         $use_md5 = "MD5";
         }
 else {
-        eval "use Digest::MD5";
+        eval { require Digest::MD5; Digest::MD5->import; 1 };
         if (!$@) {
                 $use_md5 = "Digest::MD5";
                 }
@@ -2106,16 +2107,16 @@ my ($str, $notablecheck) = @_;
 my ($proto, $user, $pass, $host, $prefix, $args) = &split_userdb_string($str);
 if ($proto eq "mysql" || $proto eq "postgresql") {
 	# Load DBI driver
-	eval 'use DBI;';
+	eval { require DBI; DBI->import; 1 };
 	return &text('sql_emod', 'DBI') if ($@);
 	if ($proto eq "mysql") {
-		eval 'use DBD::mysql;';
+		eval { require DBD::mysql; DBD::mysql->import; 1 };
 		return &text('sql_emod', 'DBD::mysql') if ($@);
 		my $drh = DBI->install_driver("mysql");
 		return $text{'sql_emysqldriver'} if (!$drh);
 		}
 	else {
-		eval 'use DBD::Pg;';
+		eval { require DBD::Pg; DBD::Pg->import; 1 };
 		return &text('sql_emod', 'DBD::Pg') if ($@);
 		my $drh = DBI->install_driver("Pg");
 		return $text{'sql_epostgresqldriver'} if (!$drh);
@@ -2147,11 +2148,11 @@ if ($proto eq "mysql" || $proto eq "postgresql") {
 			}
 		}
 	&disconnect_userdb($str, $dbh);
-	return undef;
+	return;
 	}
 elsif ($proto eq "ldap") {
 	# Load LDAP module
-	eval 'use Net::LDAP;';
+	eval { require Net::LDAP; Net::LDAP->import; 1 };
 	return &text('sql_emod', 'Net::LDAP') if ($@);
 
 	# Try to connect
@@ -2185,7 +2186,7 @@ elsif ($proto eq "ldap") {
 		$found || return &text('sql_eldapdn', $prefix);
 		}
 	&disconnect_userdb($str, $dbh);
-	return undef;
+	return;
 	}
 else {
 	return "Unknown user database type $proto";
@@ -2279,8 +2280,8 @@ if (!$miniserv) {
 	$miniserv = { };
 	&get_miniserv_config($miniserv);
 	}
-foreach $a (split(/\s+/, $miniserv->{'anonymous'})) {
-        if ($a =~ /^([^=]+)=(\S+)$/ && $2 eq $user) {
+foreach my $tok (split(/\s+/, $miniserv->{'anonymous'})) {
+        if ($tok =~ /^([^=]+)=(\S+)$/ && $2 eq $user) {
 		push(@rv, $1);
 		}
 	}
@@ -2294,7 +2295,7 @@ sub get_safe_acl
 my ($m) = @_;
 my $mdir = &module_root_directory($m);
 my %rv;
-&read_file_cached("$mdir/safeacl", \%rv) || return undef;
+&read_file_cached("$mdir/safeacl", \%rv) || return;
 return \%rv;
 }
 
@@ -2308,17 +2309,19 @@ sub generate_random_session_id
 my $sid;
 
 # Try /dev/urandom, but with a timeout
-$SIG{ALRM} = sub { close(RANDOM) };
+my $randomfh;
+$SIG{ALRM} = sub { close($randomfh) if ($randomfh) };
 alarm(5);
-if (open(RANDOM, "/dev/urandom")) {
+if (open($randomfh, "<", "/dev/urandom")) {
 	my $tmpsid;
-	if (read(RANDOM, $tmpsid, 16) == 16) {
+	if (read($randomfh, $tmpsid, 16) == 16) {
 		$sid = lc(unpack('h*',$tmpsid));
 		if ($sid !~ /^[0-9a-fA-F]{32}$/) {
 			$sid = 'bad';
 			}
 		}
-	close(RANDOM);
+	close($randomfh);
+	undef($randomfh);
 	}
 alarm(0);
 
@@ -2336,7 +2339,7 @@ return $sid eq 'bad' ? undef : $sid;
 # Generate an ID string that can be used for a password reset link
 sub generate_random_id
 {
-if (open(my $RANDOM, "</dev/urandom")) {
+if (open(my $RANDOM, "<", "/dev/urandom")) {
 	my $sid;
 	my $tmpsid;
 	if (read($RANDOM, $tmpsid, 16) == 16) {
@@ -2345,7 +2348,9 @@ if (open(my $RANDOM, "</dev/urandom")) {
 	close($RANDOM);
 	return $sid;
 	}
-return undef;
+# Explicit undef: callers consume this in hash-literal value position,
+# where bare 'return' would yield () and shift the surrounding pairing.
+return undef;    ## no critic (ProhibitExplicitReturnUndef)
 }
 
 # obsfucate_email(email)

--- a/acl/backup_config.pl
+++ b/acl/backup_config.pl
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require 'acl-lib.pl';
+require 'acl-lib.pl';    ## no critic
 our ($config_directory, %gconfig);
 
 # backup_config_files()
@@ -43,7 +43,7 @@ return @rv;
 # Called before the files are actually read
 sub pre_backup
 {
-return undef;
+return;
 }
 
 # post_backup(&files)
@@ -52,7 +52,7 @@ sub post_backup
 {
 unlink("$config_directory/config.aclbackup");
 unlink("$config_directory/miniserv.conf.aclbackup");
-return undef;
+return;
 }
 
 # pre_restore(&files)
@@ -66,7 +66,7 @@ foreach my $u (&list_users(), &list_groups()) {
 		       glob("$config_directory/*/$u->{'name'}.acl"));
 		}
 	}
-return undef;
+return;
 }
 
 # post_restore(&files)
@@ -101,7 +101,7 @@ foreach my $k (keys %aclbackup) {
 &put_miniserv_config(\%miniserv);
 
 &restart_miniserv();
-return undef;
+return;
 }
 
 1;

--- a/acl/cert_form.cgi
+++ b/acl/cert_form.cgi
@@ -5,11 +5,11 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 &ui_print_header(undef, $text{'cert_title'}, "", undef, undef, undef, undef,
 		 undef, undef, "language=VBSCRIPT onload='postLoad()'");
-eval "use Net::SSLeay";
+eval { require Net::SSLeay; Net::SSLeay->import; 1 };
 
 print "<p>$text{'cert_msg'}<p>\n";
 if ($ENV{'SSL_USER'}) {

--- a/acl/cert_issue.cgi
+++ b/acl/cert_issue.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $module_config_directory, $base_remote_user);
 &ReadParse();
 

--- a/acl/cert_output.cgi
+++ b/acl/cert_output.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 
 &ReadParse();

--- a/acl/cgi_args.pl
+++ b/acl/cgi_args.pl
@@ -27,5 +27,5 @@ elsif ($cgi eq 'edit_acl.cgi') {
 		}
 	return 'none';
 	}
-return undef;
+return;
 }

--- a/acl/convert.cgi
+++ b/acl/convert.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $config_directory);
 &ReadParse();
 &error_setup($text{'convert_err'});

--- a/acl/convert_form.cgi
+++ b/acl/convert_form.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'sync'} && $access{'create'} || &error($text{'convert_ecannot'});
 &ui_print_header(undef, $text{'convert_title'}, "");

--- a/acl/delete_group.cgi
+++ b/acl/delete_group.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user);
 &ReadParse();
 &error_setup($text{'gdelete_err'});

--- a/acl/delete_groups.cgi
+++ b/acl/delete_groups.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user);
 &ReadParse();
 &error_setup($text{'gdeletes_err'});

--- a/acl/delete_session.cgi
+++ b/acl/delete_session.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, %sessiondb);
 &ReadParse();
 $access{'sessions'} || &error($text{'sessions_ecannot'});

--- a/acl/delete_user.cgi
+++ b/acl/delete_user.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user);
 &ReadParse();
 &error_setup($text{'delete_err'});

--- a/acl/delete_users.cgi
+++ b/acl/delete_users.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user);
 &ReadParse();
 &error_setup($in{'joingroup'} ? $text{'udeletes_jerr'} : $text{'udeletes_err'});

--- a/acl/edit_acl.cgi
+++ b/acl/edit_acl.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user, %gconfig);
 &ReadParse();
 $access{'acl'} || &error($text{'acl_emod'});

--- a/acl/edit_group.cgi
+++ b/acl/edit_group.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $config_directory);
 &ReadParse();
 $access{'groups'} || &error($text{'gedit_ecannot'});

--- a/acl/edit_pass.cgi
+++ b/acl/edit_pass.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'pass'} || &error($text{'pass_ecannot'});
 &ui_print_header(undef, $text{'pass_title'}, "");

--- a/acl/edit_sql.cgi
+++ b/acl/edit_sql.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'sql'} || &error($text{'sql_ecannot'});
 &ui_print_header(undef, $text{'sql_title'}, "");

--- a/acl/edit_sync.cgi
+++ b/acl/edit_sync.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'sync'} && $access{'create'} && $access{'delete'} ||
 	&error($text{'sync_ecannot'});

--- a/acl/edit_unix.cgi
+++ b/acl/edit_unix.cgi
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'unix'} && $access{'create'} && $access{'delete'} ||
 	&error($text{'unix_ecannot'});

--- a/acl/edit_user.cgi
+++ b/acl/edit_user.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %gconfig, %access, $config_directory, $base_remote_user, $remote_user);
 &foreign_require("webmin", "webmin-lib.pl");
 
@@ -215,7 +215,10 @@ if ($access{'lang'}) {
 
 if ($access{'locale'}) {
 	# Current locale
-	eval "use DateTime; use DateTime::Locale; use DateTime::TimeZone;";
+	eval { require DateTime; DateTime->import;
+	       require DateTime::Locale; DateTime::Locale->import;
+	       require DateTime::TimeZone; DateTime::TimeZone->import;
+	       1 };
 	if (!$@ && $] > 5.011) {
 		my $locales = &list_locales();
 		my %localesrev = reverse %{$locales};

--- a/acl/forgot_form.cgi
+++ b/acl/forgot_form.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text);
 &foreign_require("webmin");
 &error_setup($text{'forgot_err'});

--- a/acl/forgot_send.cgi
+++ b/acl/forgot_send.cgi
@@ -37,7 +37,7 @@ my %link = ( 'id' => &generate_random_id(),
 	     'user' => $wuser->{'name'},
 	     'uuser' => $unixuser, );
 $link{'id'} || &error($text{'forgot_erandom'});
-&make_dir($main::forgot_password_link_dir, 0700);    ## no critic (ProhibitLeadingZeros)
+&make_dir($main::forgot_password_link_dir, 0700);
 my $linkfile = $main::forgot_password_link_dir."/".$link{'id'};
 &lock_file($linkfile);
 &write_file($linkfile, \%link);

--- a/acl/forgot_send.cgi
+++ b/acl/forgot_send.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %gconfig);
 &foreign_require("webmin");
 &error_setup($text{'forgot_err'});
@@ -37,7 +37,7 @@ my %link = ( 'id' => &generate_random_id(),
 	     'user' => $wuser->{'name'},
 	     'uuser' => $unixuser, );
 $link{'id'} || &error($text{'forgot_erandom'});
-&make_dir($main::forgot_password_link_dir, 0700);
+&make_dir($main::forgot_password_link_dir, 0700);    ## no critic (ProhibitLeadingZeros)
 my $linkfile = $main::forgot_password_link_dir."/".$link{'id'};
 &lock_file($linkfile);
 &write_file($linkfile, \%link);

--- a/acl/index.cgi
+++ b/acl/index.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %gconfig, %access, $base_remote_user);
 &ReadParse();
 &ui_print_header(undef, $text{'index_title'}, "", undef, 1, 1);

--- a/acl/list_sessions.cgi
+++ b/acl/list_sessions.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, %sessiondb);
 $access{'sessions'} || &error($text{'sessions_ecannot'});
 &ui_print_header(undef, $text{'sessions_title'}, "");

--- a/acl/makedn.cgi
+++ b/acl/makedn.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'pass'} || &error($text{'sql_ecannot'});
 &ReadParse();

--- a/acl/maketables.cgi
+++ b/acl/maketables.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'pass'} || &error($text{'sql_ecannot'});
 &ReadParse();

--- a/acl/postinstall.pl
+++ b/acl/postinstall.pl
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require 'acl-lib.pl';
+require 'acl-lib.pl';    ## no critic
 our ($config_directory);
 
 # Rename the .acl files for any groups to .gacl files

--- a/acl/save_acl.cgi
+++ b/acl/save_acl.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user, %gconfig,
      $config_directory);
 &ReadParse();
@@ -73,7 +73,7 @@ else {
 		&save_module_acl(\%maccess, $in{'_acl_user'},
 				 $in{'_acl_mod'},1);
 		}
-	&set_ownership_permissions(undef, undef, 0640, $aclfile);
+	&set_ownership_permissions(undef, undef, 0640, $aclfile);    ## no critic (ProhibitLeadingZeros)
 	&unlock_file($aclfile);
 
 	if ($in{'_acl_group'}) {

--- a/acl/save_acl.cgi
+++ b/acl/save_acl.cgi
@@ -73,7 +73,7 @@ else {
 		&save_module_acl(\%maccess, $in{'_acl_user'},
 				 $in{'_acl_mod'},1);
 		}
-	&set_ownership_permissions(undef, undef, 0640, $aclfile);    ## no critic (ProhibitLeadingZeros)
+	&set_ownership_permissions(undef, undef, 0640, $aclfile);
 	&unlock_file($aclfile);
 
 	if ($in{'_acl_group'}) {

--- a/acl/save_group.cgi
+++ b/acl/save_group.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $config_directory);
 &ReadParse();
 
@@ -131,7 +131,7 @@ if ($in{'old'} && $in{'acl_security_form'}) {
 	my $aclfile = "$config_directory/$in{'name'}.gacl";
 	&lock_file($aclfile);
 	&save_group_module_acl(\%uaccess, $in{'name'}, "", 1);
-	&set_ownership_permissions(undef, undef, 0640, $aclfile);
+	&set_ownership_permissions(undef, undef, 0640, $aclfile);    ## no critic (ProhibitLeadingZeros)
 	&unlock_file($aclfile);
 	}
 

--- a/acl/save_group.cgi
+++ b/acl/save_group.cgi
@@ -131,7 +131,7 @@ if ($in{'old'} && $in{'acl_security_form'}) {
 	my $aclfile = "$config_directory/$in{'name'}.gacl";
 	&lock_file($aclfile);
 	&save_group_module_acl(\%uaccess, $in{'name'}, "", 1);
-	&set_ownership_permissions(undef, undef, 0640, $aclfile);    ## no critic (ProhibitLeadingZeros)
+	&set_ownership_permissions(undef, undef, 0640, $aclfile);
 	&unlock_file($aclfile);
 	}
 

--- a/acl/save_pass.cgi
+++ b/acl/save_pass.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'pass'} || &error($text{'pass_ecannot'});
 &error_setup($text{'pass_err'});

--- a/acl/save_sql.cgi
+++ b/acl/save_sql.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'pass'} || &error($text{'sql_ecannot'});
 &ReadParse();

--- a/acl/save_sync.cgi
+++ b/acl/save_sync.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $module_config_directory);
 &ReadParse();
 $access{'sync'} && $access{'create'} && $access{'delete'} ||

--- a/acl/save_twofactor.cgi
+++ b/acl/save_twofactor.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user);
 &foreign_require("webmin");
 &error_setup($text{'twofactor_err'});

--- a/acl/save_unix.cgi
+++ b/acl/save_unix.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 &ReadParse();
 &error_setup($text{'unix_err'});
@@ -70,7 +70,7 @@ else {
 	}
 if ($in{'sudo'}) {
 	&has_command("sudo") || &error(&text('unix_esudo', "<tt>sudo</tt>"));
-	eval "use IO::Pty";
+	eval { require IO::Pty; IO::Pty->import; 1 };
 	$@ && &error(&text('unix_esudomod', "<tt>IO::Pty</tt>"));
 	}
 $miniserv{'sudo'} = $in{'sudo'};

--- a/acl/save_user.cgi
+++ b/acl/save_user.cgi
@@ -378,7 +378,7 @@ if ($in{'acl_security_form'} && !$newgroup && !$in{'safe'}) {
 	$uaccess{'rpc'} = $in{'rpc'};
 	&lock_file($aclfile);
 	&save_module_acl(\%uaccess, $in{'name'}, "", 1);
-	&set_ownership_permissions(undef, undef, 0640, $aclfile);    ## no critic (ProhibitLeadingZeros)
+	&set_ownership_permissions(undef, undef, 0640, $aclfile);
 	&unlock_file($aclfile);
 	}
 

--- a/acl/save_user.cgi
+++ b/acl/save_user.cgi
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $config_directory, $base_remote_user);
 &foreign_require("webmin", "webmin-lib.pl");
 &ReadParse();
@@ -378,7 +378,7 @@ if ($in{'acl_security_form'} && !$newgroup && !$in{'safe'}) {
 	$uaccess{'rpc'} = $in{'rpc'};
 	&lock_file($aclfile);
 	&save_module_acl(\%uaccess, $in{'name'}, "", 1);
-	&set_ownership_permissions(undef, undef, 0640, $aclfile);
+	&set_ownership_permissions(undef, undef, 0640, $aclfile);    ## no critic (ProhibitLeadingZeros)
 	&unlock_file($aclfile);
 	}
 

--- a/acl/schema.cgi
+++ b/acl/schema.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access);
 $access{'pass'} || &error($text{'sql_ecannot'});
 

--- a/acl/switch.cgi
+++ b/acl/switch.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, %sessiondb);
 &ReadParse();
 &can_edit_user($in{'user'}) && $access{'switch'} ||

--- a/acl/t/perlcritic.t
+++ b/acl/t/perlcritic.t
@@ -51,8 +51,7 @@ if (!@files) {
 }
 
 my $critic = Perl::Critic->new(
-    -severity => 5,
-    -profile => '',
+    -profile => "$bindir/../../.perlcriticrc",
 );
 
 foreach my $file (@files) {

--- a/acl/t/perlcritic.t
+++ b/acl/t/perlcritic.t
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    eval { require Perl::Critic; 1 }
+        or plan skip_all => 'Perl::Critic not installed';
+}
+
+use File::Find;
+
+sub script_dir
+{
+    my $path = $0;
+    if ($path =~ m{^/}) {
+        $path =~ s{/[^/]+$}{};
+        return $path;
+    }
+    my $cwd = `pwd`;
+    chomp($cwd);
+    if ($path =~ m{/}) {
+        $path =~ s{/[^/]+$}{};
+        return $cwd.'/'.$path;
+    }
+    return $cwd;
+}
+
+my $bindir = script_dir();
+my $module_dir = "$bindir/..";
+chdir($module_dir) or die "chdir: $!";
+
+my @files;
+find(
+    sub {
+        return if -d;
+        # Skip symlinks: shared libs (e.g. md5-lib.pl -> ../useradmin/md5-lib.pl)
+        # belong to the module that owns the underlying file.
+        return if -l;
+        return unless /\.(pl|cgi)\z/;
+        # *.info.pl is the Polish-locale translation of *.info, not Perl code.
+        return if /\.info\.pl\z/;
+        push(@files, $File::Find::name);
+    },
+    '.'
+);
+
+@files = sort @files;
+if (!@files) {
+    plan skip_all => 'no perl files to check';
+}
+
+my $critic = Perl::Critic->new(
+    -severity => 5,
+    -profile => '',
+);
+
+foreach my $file (@files) {
+    my @violations = $critic->critique($file);
+    is(scalar @violations, 0, "$file perlcritic");
+    if (@violations) {
+        diag join("", @violations);
+    }
+}
+
+done_testing();

--- a/acl/test_twofactor.cgi
+++ b/acl/test_twofactor.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %access, $base_remote_user);
 &foreign_require("webmin");
 &error_setup($text{'twofactor_terr'});

--- a/acl/twofactor.pl
+++ b/acl/twofactor.pl
@@ -1,6 +1,10 @@
 #!/usr/local/bin/perl
 # Validate the OTP for some user
 
+use strict;
+use warnings;
+no warnings 'once';
+our $module_name;
 $main::no_acl_check = 1;
 $main::no_referers_check = 1;
 $ENV{'WEBMIN_CONFIG'} = "/etc/webmin";
@@ -8,17 +12,17 @@ $ENV{'WEBMIN_VAR'} = "/var/webmin";
 if ($0 =~ /^(.*\/)[^\/]+$/) {
         chdir($1);
         }
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 $module_name eq 'acl' || die "Command must be run with full path";
 
 # Check command-line args
 @ARGV == 5 || die "Usage: $0 user provider id token api-key";
-($user, $provider, $id, $token, $apikey) = @ARGV;
+my ($user, $provider, $id, $token, $apikey) = @ARGV;
 
 # Call the provider validation function
 &foreign_require("webmin");
-$func = "webmin::validate_twofactor_".$provider;
-$err = &$func($id, $token, $apikey);
+my $func = "webmin::validate_twofactor_".$provider;
+my $err = &$func($id, $token, $apikey);
 if ($err) {
 	$err =~ s/\r|\n/ /g;
 	print $err,"\n";

--- a/acl/twofactor.pl
+++ b/acl/twofactor.pl
@@ -21,8 +21,10 @@ my ($user, $provider, $id, $token, $apikey) = @ARGV;
 
 # Call the provider validation function
 &foreign_require("webmin");
-my $func = "webmin::validate_twofactor_".$provider;
-my $err = &$func($id, $token, $apikey);
+my $method = "validate_twofactor_".$provider;
+my $code = webmin->can($method)
+	or die "Unknown twofactor provider: $provider\n";
+my $err = $code->($id, $token, $apikey);
 if ($err) {
 	$err =~ s/\r|\n/ /g;
 	print $err,"\n";

--- a/acl/twofactor_form.cgi
+++ b/acl/twofactor_form.cgi
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 no warnings 'uninitialized';
-require './acl-lib.pl';
+require './acl-lib.pl';    ## no critic
 our (%in, %text, %config, %access, $base_remote_user);
 &foreign_require("webmin");
 &error_setup($text{'twofactor_err'});

--- a/nftables/t/perlcritic.t
+++ b/nftables/t/perlcritic.t
@@ -46,8 +46,7 @@ if (!@files) {
 }
 
 my $critic = Perl::Critic->new(
-    -severity => 5,
-    -profile => '',
+    -profile => "$bindir/../../.perlcriticrc",
 );
 
 foreach my $file (@files) {


### PR DESCRIPTION
Adds `t/perlcritic.t` to `acl` module, makes all module files pass perlcritic (severity 5), and adds a `.perlcriticrc` to exclude `ProhibitLeadingZeros` (as making that rule happy makes octal usage in directory/file functions uglier, and we have a million of those).

The one maybe suspicious looking change is the removal of the `eval` on 1895 and 1899 in `acl-lib.pl`. There's already a hard error `$use_md5 || &error("No Perl MD5 hashing module found!");` before that, so the `eval` can never do anything useful, and a stringy eval is a `perlcritic` severity 5 error, and if somehow `$use_md5` was something that can't instantiate new, it's still `die`s on usage  in a following line, eval can't prevent an error in this case, and we don't want to prevent the fatal error; there's no way to ignore the error and do something good.

So, the previous code was kind of a bug-like. At least making the error harder to understand should execution ever somehow reach that location without something good in `$use_md5`.

The other eval changes are more verbose, but they enable compile-time syntax checking while the string form doesn't, it's protected against code injection (if a user is able to influence the string being evaled), also faster (string eval is a fresh compilation each time it's hit, block form compiles once), and static analysis can see the dependency.

The most common change is adding `## no critic` for various `require` and other idioms that come from Webmin's unusual module usage. Changing those requires larger code changes than I'd like to make in a simple perlcritic pass.

All callers of altered functions (e.g. the `return undef;` -> `return;` change), except one, have been checked to be sure they don't expect the old semantics; there are no array or hash context users that would be surprised by the change.

The one function (`generate_random_id`) that gets called in a list context has been given `## no critic`. That can be fixed in a future PR by either explicitly forcing to a scalar or by putting the ID in a variable first.

Also a minor change in `twofactor.pl` to use `UNIVERSAL->can` (https://perldoc.perl.org/UNIVERSAL) to satisfy the strict refs requirement while doing the right thing. This also provides a better error than what would happen previously in cases where `$provider` is non-existent.

All unit tests pass, and I've poked around in the module with no evidence of trouble. I believe all changes are safe.