### PR TITLE
Postfix tests, perlcritic, strict/warnings, bugfixes

### DIFF
--- a/postfix/acl_security.pl
+++ b/postfix/acl_security.pl
@@ -12,7 +12,6 @@ our (@acl_pages, %in, %text);
 # Print the form for security options of postfix module
 sub acl_security_form
 {
-my $o;
 foreach my $o (@acl_pages) {
 	print &ui_table_row($text{'acl_'.$o} || $o,
 			    &ui_yesno_radio($o, $_[0]->{$o} ? 1 : 0));
@@ -26,7 +25,6 @@ print &ui_table_row($text{'acl_dir'},
 # Parse the form for security options for the postfix module
 sub acl_security_save
 {
-my $o;
 foreach my $o (@acl_pages) {
 	$_[0]->{$o} = $in{$o};
 	}

--- a/postfix/acl_security.pl
+++ b/postfix/acl_security.pl
@@ -1,5 +1,8 @@
 
-require 'postfix-lib.pl';
+require 'postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (@acl_pages, %in, %text);
 @acl_pages = ("resource", "address_rewriting", "aliases", "general",
 	      "canonical", "virtual", "transport", "relocated", "header",
 	      "body", "bcc", "dependent", "sni", "local_delivery", "smtpd",
@@ -9,8 +12,8 @@ require 'postfix-lib.pl';
 # Print the form for security options of postfix module
 sub acl_security_form
 {
-local $o;
-foreach $o (@acl_pages) {
+my $o;
+foreach my $o (@acl_pages) {
 	print &ui_table_row($text{'acl_'.$o} || $o,
 			    &ui_yesno_radio($o, $_[0]->{$o} ? 1 : 0));
 	}
@@ -23,8 +26,8 @@ print &ui_table_row($text{'acl_dir'},
 # Parse the form for security options for the postfix module
 sub acl_security_save
 {
-local $o;
-foreach $o (@acl_pages) {
+my $o;
+foreach my $o (@acl_pages) {
 	$_[0]->{$o} = $in{$o};
 	}
 $_[0]->{'dir'} = $in{'dir'};

--- a/postfix/address_rewriting.cgi
+++ b/postfix/address_rewriting.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-rewrite.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, %access, %text);
 
 $access{'address_rewriting'} || &error($text{'address_rewriting_ecannot'});
 &ui_print_header(undef, $text{'address_rewriting_title'}, "");

--- a/postfix/aliases.cgi
+++ b/postfix/aliases.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-aliases.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($al, $anum, $astr, $i, $lines, $mid, $midline, %access, @aline, %config, @grid, @links, %text);
 
 $access{'aliases'} || &error($text{'aliases_ecannot'});
 &ui_print_header(undef, $text{'aliases_title'}, "", "aliases");
@@ -93,8 +96,8 @@ foreach my $a (@_) {
 	push(@cols, "<a href=\"edit_alias.cgi?num=$a->{'num'}\">".
 	      ($a->{'enabled'} ? "" : "<i>").&html_escape($a->{'name'}).
 	      ($a->{'enabled'} ? "" : "</i>")."</a>");
-	local $vstr;
-	foreach $v (@{$a->{'values'}}) {
+	my $vstr;
+	foreach my $v (@{$a->{'values'}}) {
 		($anum, $astr) = &alias_type($v);
 		$vstr .= &text("aliases_type$anum",
 			    "<tt>".&html_escape($astr)."</tt>")."<br>\n";

--- a/postfix/backup_config.pl
+++ b/postfix/backup_config.pl
@@ -1,4 +1,5 @@
-
+use strict;
+use warnings;
 do 'postfix-lib.pl';
 
 # backup_config_files()
@@ -12,21 +13,21 @@ return &get_all_config_files();
 # Called before the files are actually read
 sub pre_backup
 {
-return undef;
+return;
 }
 
 # post_backup(&files)
 # Called after the files are actually read
 sub post_backup
 {
-return undef;
+return;
 }
 
 # pre_restore(&files)
 # Called before the files are restored from a backup
 sub pre_restore
 {
-return undef;
+return;
 }
 
 # post_restore(&files)
@@ -36,7 +37,7 @@ sub post_restore
 if (&is_postfix_running()) {
 	return &reload_postfix();
 	}
-return undef;
+return;
 }
 
 1;

--- a/postfix/bcc.cgi
+++ b/postfix/bcc.cgi
@@ -1,6 +1,9 @@
 #!/usr/local/bin/perl
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %in, %text);
 
 $access{'bcc'} || &error($text{'bcc_ecannot'});
 &ui_print_header(undef, $text{'bcc_title'}, "", "bcc");

--- a/postfix/body.cgi
+++ b/postfix/body.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-virtual.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 &ReadParse();
 
 $access{'body'} || &error($text{'body_ecannot'});

--- a/postfix/canonical.cgi
+++ b/postfix/canonical.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-canonical.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 
 $access{'canonical'} || &error($text{'canonical_ecannot'});
 &ui_print_header(undef, $text{'canonical_title'}, "", "canonical");

--- a/postfix/canonical_edit.cgi
+++ b/postfix/canonical_edit.cgi
@@ -5,7 +5,10 @@
 # 
 # Edit one category of canonical maps
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%in, %text);
 &ReadParse();
 
 &ui_print_header(undef, $text{'canonical_edit_title'}, "", "canonical");

--- a/postfix/client.cgi
+++ b/postfix/client.cgi
@@ -35,7 +35,7 @@ foreach my $r (&list_client_restrictions()) {
 
 # Add restrictions with values
 foreach my $r (&list_multi_client_restrictions()) {
-	@v = @{$opts{$r}};
+	@v = $opts{$r} ? @{$opts{$r}} : ();
 	$vals = undef;
 	if (scalar(@v)) {
 		$vals = join(" ", map { $opts[$_+1] } @v);

--- a/postfix/client.cgi
+++ b/postfix/client.cgi
@@ -2,7 +2,10 @@
 # A single page just for editing smtpd_client_restrictions
 # XXX editing access maps?
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $has_client_access, $no_, $none, $vals, %access, %done, @grid, %opts, @opts, @rest, %text, @v);
 
 $access{'client'} || &error($text{'client_ecannot'});
 &ui_print_header(undef, $text{'client_title'}, "");
@@ -24,14 +27,14 @@ for(my $i=0; $i<@opts; $i++) {
 # Add binary restrictions to list
 @grid = ( );
 %done = ( );
-foreach $r (&list_client_restrictions()) {
+foreach my $r (&list_client_restrictions()) {
 	push(@grid, &ui_checkbox("client", $r, $text{'sasl_'.$r},
 				 defined($opts{$r})), undef);
 	$done{$r} = 1;
 	}
 
 # Add restrictions with values
-foreach $r (&list_multi_client_restrictions()) {
+foreach my $r (&list_multi_client_restrictions()) {
 	@v = @{$opts{$r}};
 	$vals = undef;
 	if (scalar(@v)) {
@@ -43,7 +46,7 @@ foreach $r (&list_multi_client_restrictions()) {
 		    ($r eq "check_client_access" ?
 			" ".&map_chooser_button("value_$r", $r) : ""));
 	$done{$r} = 1;
-	foreach $v (@v) {
+	foreach my $v (@v) {
 		$done{$opts[$v+1]} = 1;
 		}
 	if ($r eq "check_client_access" && @v) {

--- a/postfix/debug.cgi
+++ b/postfix/debug.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-debug.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, %access, %text);
 
 
 $access{'debug'} || &error($text{'debug_ecannot'});

--- a/postfix/delete_aliases.cgi
+++ b/postfix/delete_aliases.cgi
@@ -1,8 +1,11 @@
 #!/usr/local/bin/perl
 # Delete several mail aliases
 
-require './postfix-lib.pl';
-require './aliases-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($alias, $err, %access, @afiles, @aliases, @d, @delaliases, %in, %text);
+require './aliases-lib.pl';    ## no critic
 &ReadParse();
 &error_setup($text{'adelete_err'});
 $access{'aliases'} || &error($text{'aliases_ecannot'});
@@ -13,7 +16,7 @@ $access{'aliases'} || &error($text{'aliases_ecannot'});
 @d = split(/\0/, $in{'d'});
 @d || &error($text{'adelete_enone'});
 @aliases = &list_postfix_aliases();
-foreach $d (@d) {
+foreach my $d (@d) {
 	($alias) = grep { $_->{'name'} eq $d } @aliases;
 	if ($alias) {
 		push(@delaliases, $alias);
@@ -21,7 +24,7 @@ foreach $d (@d) {
 	}
 
 # Delete the aliases
-foreach $alias (@delaliases) {
+foreach my $alias (@delaliases) {
 	&delete_postfix_alias($alias);
 	}
 &unlock_alias_files(\@afiles);

--- a/postfix/delete_mappings.cgi
+++ b/postfix/delete_mappings.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Delete multiple mappings
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, $map, $maps, @d, %in, %text);
 &ReadParse();
 &error_setup($text{'delete_err'});
 
@@ -9,7 +12,7 @@ require './postfix-lib.pl';
 @d || &error($text{'delete_enone'});
 
 $maps = &get_maps($in{'map_name'});
-foreach $d (@d) {
+foreach my $d (@d) {
 	($map) = grep { $_->{'name'} eq $d } @$maps;
 	if ($map) {
 		&lock_file($map->{'file'});

--- a/postfix/delete_queues.cgi
+++ b/postfix/delete_queues.cgi
@@ -2,27 +2,30 @@
 # delete_queues.cgi
 # Delete multiple messages from the postfix queue
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($postfix_version, %access, %config, @files, %in, @qfiles, %text);
 $access{'mailq'} || &error($text{'mailq_ecannot'});
 &ReadParse();
 
 if ($in{'move'}) {
 	# Re-queuing messages
-	foreach $f (split(/\0/, $in{'file'})) {
+	foreach my $f (split(/\0/, $in{'file'})) {
 		&system_logged("$config{'postfix_super_command'} -r ".
 				quotemeta($f)." >/dev/null 2>&1 </dev/null");
 		}
 	}
 elsif ($in{'hold'}) {
 	# Holding messages
-	foreach $f (split(/\0/, $in{'file'})) {
+	foreach my $f (split(/\0/, $in{'file'})) {
 		&system_logged("$config{'postfix_super_command'} -h ".
 				quotemeta($f)." >/dev/null 2>&1 </dev/null");
 		}
 	}
 elsif ($in{'unhold'}) {
 	# Un-holding messages
-	foreach $f (split(/\0/, $in{'file'})) {
+	foreach my $f (split(/\0/, $in{'file'})) {
 		&system_logged("$config{'postfix_super_command'} -H ".
 				quotemeta($f)." >/dev/null 2>&1 </dev/null");
 		}
@@ -41,7 +44,7 @@ else {
 		if (&compare_version_numbers($postfix_version, 1.1) < 0) {
 			@qfiles = &recurse_files($config{'mailq_dir'});
 			}
-		foreach $f (@files) {
+		foreach my $f (@files) {
 			$f =~ /^[A-Za-z0-9]+$/ || next;
 			if (&compare_version_numbers($postfix_version, 1.1) >= 0) {
 				&system_logged("$config{'postfix_super_command'} -d ".quotemeta($f)." >/dev/null 2>&1 </dev/null");

--- a/postfix/dependent.cgi
+++ b/postfix/dependent.cgi
@@ -6,7 +6,10 @@
 # Manages sender_dependent_default_transport_maps for Postfix
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 
 $access{'dependent'} || &error($text{'dependent_ecannot'});
 &ui_print_header(undef, $text{'dependent_title'}, "", "dependent");

--- a/postfix/detach_queue.cgi
+++ b/postfix/detach_queue.cgi
@@ -2,8 +2,11 @@
 # detach_queue.cgi
 # View one attachment from a queued message
 
-require './postfix-lib.pl';
-require './boxes-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($attach, $mail, %access, %in, %text);
+require './boxes-lib.pl';    ## no critic
 &ReadParse();
 $access{'mailq'} || &error($text{'mailq_ecannot'});
 

--- a/postfix/edit_access.cgi
+++ b/postfix/edit_access.cgi
@@ -3,7 +3,10 @@
 # Display a form to edit a general access mapping table
 # by Roberto Tecchio, 2005 (www.tecchio.net)
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %in, %text);
 
 $access{'smtpd'} || &error($text{'smtpd_ecannot'});
 &ReadParse();

--- a/postfix/edit_alias.cgi
+++ b/postfix/edit_alias.cgi
@@ -5,7 +5,10 @@
 # 
 # Edit an email alias
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($cancmt, %in, %text);
 &ReadParse();
 
 &ui_print_header(undef, $text{'edit_alias_title'}, "");

--- a/postfix/edit_alias.cgi
+++ b/postfix/edit_alias.cgi
@@ -14,9 +14,9 @@ our ($cancmt, %in, %text);
 &ui_print_header(undef, $text{'edit_alias_title'}, "");
 
 my @aliases = &list_postfix_aliases();
-$a = $aliases[$in{'num'}] if (!$in{'new'});
+my $alias = $in{'new'} ? undef : $aliases[$in{'num'}];
 
 $cancmt = &can_map_comments("alias_maps");
-&alias_form($a, !$cancmt);
+&alias_form($alias, !$cancmt);
 
 &ui_print_footer("", $text{'index_return'});

--- a/postfix/edit_canonical_mappings.cgi
+++ b/postfix/edit_canonical_mappings.cgi
@@ -8,7 +8,7 @@
 require './postfix-lib.pl';    ## no critic
 use strict;
 use warnings;
-our ($aliases, $cb, $tb, %in, %text);
+our ($cb, $tb, %in, %text);
 &ReadParse();
 
 &ui_print_header(undef, $text{'edit_mapping_title'}, "");
@@ -29,7 +29,7 @@ else
 my $mappingsaliases = &get_aliases();
 my %alias;
 
-foreach my $trans (@{$aliases})
+foreach my $trans (@{$mappingsaliases})
 {
     if ($trans->{'number'} == $num) { %alias = %{$trans}; }
 }    

--- a/postfix/edit_canonical_mappings.cgi
+++ b/postfix/edit_canonical_mappings.cgi
@@ -5,7 +5,10 @@
 # 
 # Edit a mapping
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($aliases, $cb, $tb, %in, %text);
 &ReadParse();
 
 &ui_print_header(undef, $text{'edit_mapping_title'}, "");
@@ -26,7 +29,7 @@ else
 my $mappingsaliases = &get_aliases();
 my %alias;
 
-foreach $trans (@{$aliases})
+foreach my $trans (@{$aliases})
 {
     if ($trans->{'number'} == $num) { %alias = %{$trans}; }
 }    

--- a/postfix/edit_manual.cgi
+++ b/postfix/edit_manual.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Show a form for editing a mapping file
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($data, $file, %access, @files, %in, %text);
 &ReadParse();
 $access{'manual'} || &error($text{'manual_ecannot'});
 &ui_print_header(undef, $text{'manual_title'}, "");

--- a/postfix/edit_mapping.cgi
+++ b/postfix/edit_mapping.cgi
@@ -5,7 +5,10 @@
 # 
 # Edit a mapping
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($nfunc, $vfunc, $virtual_maps, %in, %text);
 &ReadParse();
 
 &ui_print_header(undef, $text{'edit_map_title'}, "");
@@ -28,7 +31,7 @@ else
 my $maps = &get_maps($in{'map_name'});
 my %map;
 
-foreach $trans (@{$maps})
+foreach my $trans (@{$maps})
 {
     if ($trans->{'number'} == $num) { %map = %{$trans}; }
 }    

--- a/postfix/edit_master.cgi
+++ b/postfix/edit_master.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Edit or create a server process
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($host, $master, $pmode, $prog, $wmode, $wused, %access, %in, %text);
 $access{'master'} || &error($text{'master_ecannot'});
 &ReadParse();
 $master = &get_master_config();

--- a/postfix/flushq.cgi
+++ b/postfix/flushq.cgi
@@ -2,7 +2,10 @@
 # flushq.cgi
 # Run postqueue -f and display the output
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($cmd, $config_dir, $out, %config, %text);
 &ui_print_unbuffered_header(undef, $text{'flushq_title'}, "");
 
 $cmd = "$config{'postfix_queue_command'} -c $config_dir -f";

--- a/postfix/general.cgi
+++ b/postfix/general.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-misc.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, $postfix_version, $v, %access, %text, @v);
 
 
 $access{'general'} || &error($text{'general_ecannot'});

--- a/postfix/header.cgi
+++ b/postfix/header.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-virtual.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 &ReadParse();
 
 $access{'header'} || &error($text{'header_ecannot'});

--- a/postfix/index.cgi
+++ b/postfix/index.cgi
@@ -23,7 +23,10 @@
 #
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, $lnk, $module_config_directory, $module_name, $postfix_version, %access, %config, @oicons, @olinks, @onames, @otitles, %text);
 
 &ui_print_header(undef, $text{'index_title'}, "", "intro", 1, 1, 0,
 	&help_search_link("postfix", "man", "doc", "google"),
@@ -31,9 +34,10 @@ require './postfix-lib.pl';
 		&text('index_version', $postfix_version) : undef);
 
 # Save the version for use by other CGIs
-&open_tempfile(VERSION, ">$module_config_directory/version", 0, 1);
-&print_tempfile(VERSION, "$postfix_version\n");
-&close_tempfile(VERSION);
+my $verfh = "VERSION";
+&open_tempfile($verfh, ">$module_config_directory/version", 0, 1);
+&print_tempfile($verfh, "$postfix_version\n");
+&close_tempfile($verfh);
 
 # Verify the postfix control command
 if (!&valid_postfix_command($config{'postfix_control_command'})) {
@@ -92,7 +96,7 @@ if ($config{'index_check'} && ($err = &check_postfix())) {
 	     "master", "mailq", "postfinger", "boxes", "manual" );
 
 $access{'boxes'} = &foreign_available("mailboxes");
-foreach $oitem (@onames)
+foreach my $oitem (@onames)
 {
 	if ($access{$oitem}) {
 		push (@olinks, $oitem eq "boxes" ? "../mailboxes/"
@@ -101,8 +105,8 @@ foreach $oitem (@onames)
 						   : $text{$oitem . "_title"});
 		if ($oitem eq 'mailq' && !$config{'mailq_count'}) {
 			# Count the queue
-			local @mqueue = &list_queue(0);
-			local $mcount = scalar(@mqueue);
+			my @mqueue = &list_queue(0);
+			my $mcount = scalar(@mqueue);
 			$otitles[$#otitles] .=
 				"<br>".&text('mailq_count', $mcount);
 			}

--- a/postfix/install_check.pl
+++ b/postfix/install_check.pl
@@ -1,6 +1,9 @@
 # install_check.pl
 
+use strict;
+use warnings;
 do 'postfix-lib.pl';
+our (%config);
 
 # is_installed(mode)
 # For mode 1, returns 2 if the server is installed and configured for use by

--- a/postfix/ldap.cgi
+++ b/postfix/ldap.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-ldap.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($cb, $default, $ldap_timeout, $no_, $none, $tb, %access, %text);
 
 
 $access{'ldap'} || &error($text{'ldap_ecannot'});

--- a/postfix/local_delivery.cgi
+++ b/postfix/local_delivery.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-local.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, %access, %text);
 
 
 $access{'local_delivery'} || &error($text{'local_delivery_ecannot'});

--- a/postfix/log_parser.pl
+++ b/postfix/log_parser.pl
@@ -1,13 +1,16 @@
 # log_parser.pl
 # Functions for parsing this module's logs
 
+use strict;
+use warnings;
 do 'postfix-lib.pl';
+our (%text);
 
 # parse_webmin_log(user, script, action, type, object, &params)
 # Converts logged information from this module into human-readable form
 sub parse_webmin_log
 {
-local ($user, $script, $action, $type, $object, $p) = @_;
+my ($user, $script, $action, $type, $object, $p) = @_;
 if ($action eq 'delete' || $action eq 'modify' || $action eq 'create') {
 	return &text("log_${type}_${action}",
 		     "<tt>".&html_escape($object)."</tt>") ||

--- a/postfix/mailq.cgi
+++ b/postfix/mailq.cgi
@@ -2,8 +2,11 @@
 # mailq.cgi
 # Display messages currently in the queue.
 
-require './postfix-lib.pl';
-require './boxes-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($e, $in, $s, %access, %config, %in, @qfiles, %text);
+require './boxes-lib.pl';    ## no critic
 &ReadParse();
 
 $access{'mailq'} || &error($text{'mailq_ecannot'});

--- a/postfix/mailq_search.cgi
+++ b/postfix/mailq_search.cgi
@@ -2,8 +2,11 @@
 # mailq_search.cgi
 # Display some messages from the mail queue
 
-require './postfix-lib.pl';
-require './boxes-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($neg, %access, %in, @qfiles, %text);
+require './boxes-lib.pl';    ## no critic
 &ReadParse();
 $access{'mailq'} || &error($text{'mailq_ecannot'});
 &ui_print_header(undef, $text{'searchq_title'}, "");
@@ -17,7 +20,8 @@ $neg = ($in{'field'} =~ s/^!//);
 		 $neg ? !$r : $r } @qfiles;
 
 print "<p><b>",&text($in{'field'} =~ /^\!/ ? 'search_results3' :
-	  'search_results2', scalar(@qfiles), "<tt>$in{'match'}</tt>"),"</b><p>\n";
+	  'search_results2', scalar(@qfiles),
+	  "<tt>".&html_escape($in{'match'})."</tt>"),"</b><p>\n";
 if (@qfiles) {
 	# Show matching messages
 	&mailq_table(\@qfiles);

--- a/postfix/manual.cgi
+++ b/postfix/manual.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Show a page for manually editing the Postfix config file
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($data, %access, @files, %in, %text);
 $access{'manual'} || &error($text{'cmanual_ecannot'});
 &ReadParse();
 &ui_print_header(undef, $text{'cmanual_title'}, "");

--- a/postfix/manual_update.cgi
+++ b/postfix/manual_update.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Update a manually edited config file
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, @files, %in, %text);
 &error_setup($text{'cmanual_err'});
 $access{'manual'} || &error($text{'cmanual_ecannot'});
 &ReadParseMime();
@@ -15,9 +18,10 @@ if ($in{'file'} eq $files[0]) {
 	}
 
 # Write to it
-&open_lock_tempfile(DATA, ">$in{'file'}");
-&print_tempfile(DATA, $in{'data'});
-&close_tempfile(DATA);
+my $datafh = "DATA";
+&open_lock_tempfile($datafh, ">$in{'file'}");
+&print_tempfile($datafh, $in{'data'});
+&close_tempfile($datafh);
 
 &webmin_log("manual", undef, $in{'file'});
 &redirect("");

--- a/postfix/map_chooser.cgi
+++ b/postfix/map_chooser.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Show a form for selecting the source for a map
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($i, $lconf, $ltable, $mtable, $myconf, $postfix_version, $t, %in, @maps, @opts, @sources, %text);
 &ReadParse();
 &popup_header($text{'chooser_title'});
 
@@ -14,7 +17,7 @@ print &ui_form_start("map_chooser_save.cgi", "post");
 print &ui_hidden("map", $in{'map'});
 print &ui_hidden("mapname", $in{'mapname'});
 $i = 0;
-foreach $tv (@maps) {
+foreach my $tv (@maps) {
 	print &ui_hidden_table_start(&text('chooser_header', $i+1),
 				     "width=100%", 2, "section$i",
 				     $tv->[0] || $i == 0, [ "width=30%" ]);

--- a/postfix/map_chooser_save.cgi
+++ b/postfix/map_chooser_save.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Show a form for selecting the source for a map
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($file, $i, $postfix_version, $str, $t, @files, %in, @maps, @newfiles, @oldmaps, %text);
 &ReadParse();
 &error_setup($text{'chooser_err'});
 @oldmaps = &get_maps_types_files($in{'map'});
@@ -225,14 +228,14 @@ for($i=0; defined($t = $in{"type_".$i}); $i++) {
 # Write out mysql and LDAP files
 @files = &unique(@files);
 @newfiles = map { !-r $_ } @files;
-foreach $f (@files) {
+foreach my $f (@files) {
 	&lock_file($f);
 	}
 &flush_file_lines(@files);
-foreach $f (@newfiles) {
+foreach my $f (@newfiles) {
 	&set_ownership_permissions(undef, undef, 0700, $f);
 	}
-foreach $f (@files) {
+foreach my $f (@files) {
 	&unlock_file($f);
 	}
 

--- a/postfix/master.cgi
+++ b/postfix/master.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Show a table of Postfix server processes
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($master, %access, %text);
 
 $access{'master'} || &error($text{'master_ecannot'});
 &ui_print_header(undef, $text{'master_title'}, "", "master");
@@ -15,7 +18,7 @@ print &ui_columns_start([ $text{'master_name'},
 			  $text{'master_unpriv'},
 			  $text{'master_chroot'},
 			  $text{'master_max'} ], "100%");
-foreach $m (@$master) {
+foreach my $m (@$master) {
 	print &ui_columns_row([
 		"<a href='edit_master.cgi?name=".&urlize($m->{'name'}).
 		 "&type=".&urlize($m->{'type'})."&enabled=$m->{'enabled'}'>".

--- a/postfix/postfinger.cgi
+++ b/postfix/postfinger.cgi
@@ -2,7 +2,11 @@
 # postfinger.cgi
 # check postfix configuration
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($Defaultsinmain, $err, $Libraries, $Locking, $Main, $Master, $Package, $Permissions, $postf1, $postf2, $postf3, $postf4, $postf5, $postf6, $postf7, $postf8, $postfix_version, $System, $Tables, $Warn, %access, %config, %text);
+my $mailq;
 
 &ReadParse();
 
@@ -38,12 +42,12 @@ if ($System eq 1 ) {
 		print "</td></tr>";
 		print "</table><br />";
 		print "<table border='0' cellpadding='3' width='600' align='center'>";
-		open(MAILQ, "/bin/hostname 2>/dev/null |");
-		while (my $hostname = <MAILQ>) { print "<tr><td class='e'>Hostname </td><td class='v'>$hostname</td></tr>"; } 
-		close(MAILQ);
-		open(MAILQ, "/bin/uname -a 2>/dev/null |");
-		while (my $uname = <MAILQ>) { print "<tr><td class='e'>System </td><td class='v'>$uname</td></tr>"; } 
-		close(MAILQ);
+		open($mailq, "-|", "/bin/hostname 2>/dev/null");
+		while (my $hostname = <$mailq>) { print "<tr><td class='e'>Hostname </td><td class='v'>$hostname</td></tr>"; } 
+		close($mailq);
+		open($mailq, "-|", "/bin/uname -a 2>/dev/null");
+		while (my $uname = <$mailq>) { print "<tr><td class='e'>System </td><td class='v'>$uname</td></tr>"; } 
+		close($mailq);
 	}
 	print "</table><br />";
 }
@@ -51,10 +55,10 @@ if ($System eq 1 ) {
 if ($Locking eq 1 ) {
 	print '<h1 align="center">Mailbox locking methods</h1>';
 	print '<table border="0" cellpadding="0" width="600" align="center">';
-	open(MAILQ, "$config{'postfix_config_command'} -l 2>/dev/null |");
-	while (my $locking_methods = <MAILQ>) {
+	open($mailq, "-|", "$config{'postfix_config_command'} -l 2>/dev/null");
+	while (my $locking_methods = <$mailq>) {
 		print "<tr><td class='v'><center><b>$locking_methods</b></center></td></tr>"; }
-	close(MAILQ);
+	close($mailq);
 	print "</table><br />";
 }
 
@@ -62,10 +66,10 @@ if ($Tables eq 1 ) {
 	print '<h1 align="center">Supported Lookup Tables</h1>';
 	print '<table border="0" cellpadding="0" width="600" align="center">';
 #		print '<center><b>--Supported Lookup tables--</b></center><br>';
-	open(MAILQ, "$config{'postfix_config_command'} -m 2>/dev/null |");
-	while (my $lookup_tables = <MAILQ>) {
+	open($mailq, "-|", "$config{'postfix_config_command'} -m 2>/dev/null");
+	while (my $lookup_tables = <$mailq>) {
 		print "<tr><td class='v'><center><b>$lookup_tables</b></center></td></tr>"; }
-	close(MAILQ);
+	close($mailq);
 	print "</table><br />";
 }
 
@@ -82,12 +86,12 @@ if ($Main eq 1 ) {
 	print '<h1 align="center">main.cf</h1><br><h2 align="center">non-default parameters</h2>';
 	print '<table border="0" cellpadding="2" width="600" align="center">';
 #		print '<center><b>--main.cf non-default parameters--</b></center><br>';
-	open(MAILQ, "/usr/bin/comm -13 postfinger.$$.d postfinger.$$.n 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/usr/bin/comm -13 postfinger.$$.d postfinger.$$.n 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 		($postf1,$postf2)=split(/=/,$postfinger,2);
 		print "<tr><td class='e'><b>$postf1</b></td>"; 
 		print "<td class='v'>$postf2</td></tr>"; }
-	close(MAILQ);
+	close($mailq);
 	print "</table><br />";
 }
 
@@ -95,12 +99,12 @@ if ($Defaultsinmain eq 1 ) {
 	print '<h1 align="center">main.cf</h1><br><h2 align="center">parameters defined as per defaults</h2>';
 	print '<table border="0" cellpadding="2" width="600" align="center">';
 #		print '<center><b>--main.cf parameters defined as per defaults--</b></center><br>';
-	open(MAILQ, "/usr/bin/comm -12 postfinger.$$.d postfinger.$$.n 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/usr/bin/comm -12 postfinger.$$.d postfinger.$$.n 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 		($postf1,$postf2)=split(/=/,$postfinger,2);
 		print "<tr><td class='e'><b>$postf1</b></td>"; 
 		print "<td class='v'>$postf2</td></tr>"; }
-	close(MAILQ);
+	close($mailq);
 	print "</table><br />";
 }
 unlink  "postfinger.*.d, postfinger.*.n";
@@ -113,8 +117,8 @@ if ($Master eq 1 ) {
 		"<td class='v'><b>private</b></td><td class='v'><b>unpriv</b></td>",
 		"<td class='v'><b>chroot</b></td><td class='v'><b>wakeup</b></td>",
 		"<td class='v'><b>maxproc</b></td><td class='v'><b>command + args</b></td></tr>";
-	open(MAILQ, "/bin/cat `$config{'postfix_config_command'} -h config_directory`/master.cf 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) { 
+	open($mailq, "-|", "/bin/cat `$config{'postfix_config_command'} -h config_directory`/master.cf 2>/dev/null");
+	while (my $postfinger = <$mailq>) { 
 		($postf1,$postf2,$postf3,$postf4,$postf5,$postf6,$postf7,$postf8)=split(/\s+/,$postfinger,8);
 		if ($postfinger =~ /\-o/) {
 			print "<tr><td class='e'></td><td class='v'></td>",
@@ -136,7 +140,7 @@ if ($Master eq 1 ) {
 			if ( !grep(/^#|^\[ 	\]*$/,$postfinger));
 		} 
 	} 
-	close(MAILQ);
+	close($mailq);
 	print "</table><br>";
 }
 
@@ -144,74 +148,74 @@ if ($Permissions eq 1 ) {
 	print '<h1 align="center">Specific file and directory permissions</h1><br>';
 	print '<table border="0" cellpadding="0" width="600" align="center">';
 	print "<tr><td class='e'><b>Permission</b> Deep <b>Owner</b> <b>Group</b> Size   Date  <b>Directory/File</b></td></tr>";
-	open(MAILQ, "/bin/ls -ld `$config{'postfix_config_command'} -h queue_directory`/maildrop 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/bin/ls -ld `$config{'postfix_config_command'} -h queue_directory`/maildrop 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 		print "<tr><td class='v'>$postfinger</td></tr>"
 		if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 	} 
-	close(MAILQ);
+	close($mailq);
 	print "<tr><td></td></tr>";
-	open(MAILQ, "/bin/ls -ld `$config{'postfix_config_command'} -h queue_directory`/public 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/bin/ls -ld `$config{'postfix_config_command'} -h queue_directory`/public 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 		print "<tr><td class='v'>$postfinger</td></tr>"
 		if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 	} 
-	close(MAILQ);
+	close($mailq);
 	print "<tr><td></td></tr>";
-	if (! open(MAILQ, "/bin/ls -l `$config{'postfix_config_command'} -h queue_directory`/public 2>/dev/null |")) {
+	if (! open($mailq, "-|", "/bin/ls -l `$config{'postfix_config_command'} -h queue_directory`/public 2>/dev/null")) {
 		print '<center><b>WARNING: No access to $queue_directory/public<br>Try running postfinger as user root or postfix</b></center><br>';
 	} else {
-		while (my $postfinger = <MAILQ>) {
+		while (my $postfinger = <$mailq>) {
 			print "<tr><td class='v'>$postfinger</td></tr>"
 			if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 		} 
-		close(MAILQ);
+		close($mailq);
 		print "<tr><td></td></tr>";
 	}
-	open(MAILQ, "/bin/ls -ld `$config{'postfix_config_command'} -h queue_directory`/private 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/bin/ls -ld `$config{'postfix_config_command'} -h queue_directory`/private 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 		print "<tr><td class='v'>$postfinger</td></tr>"
 		if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 	} 
-	close(MAILQ);
+	close($mailq);
 	print "<tr><td></td></tr>";
-	if (! open(MAILQ, "/bin/ls -l `$config{'postfix_config_command'} -h queue_directory`/private 2>/dev/null |")) {
+	if (! open($mailq, "-|", "/bin/ls -l `$config{'postfix_config_command'} -h queue_directory`/private 2>/dev/null")) {
 		print '<center><b>WARNING: No access to $queue_directory/private<br>Try running postfinger as user root or postfix</b></center><br>';
 	} else {
-		while (my $postfinger = <MAILQ>) {
+		while (my $postfinger = <$mailq>) {
 			print "<tr><td class='v'>$postfinger</td></tr>"
 			if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 		} 
-		close(MAILQ);
+		close($mailq);
 		print "<tr><td></td></tr>";
 	}
-	open(MAILQ, "/bin/ls -l `$config{'postfix_config_command'} -h command_directory`/postdrop 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/bin/ls -l `$config{'postfix_config_command'} -h command_directory`/postdrop 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 		print "<tr><td class='v'>$postfinger</td></tr>"
 		if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 	} 
-	close(MAILQ);
+	close($mailq);
 	print "<tr><td></td></tr>";
-	open(MAILQ, "/bin/ls -l `$config{'postfix_config_command'} -h command_directory`/postqueue 2>/dev/null |");
-	while (my $postfinger = <MAILQ>) {
+	open($mailq, "-|", "/bin/ls -l `$config{'postfix_config_command'} -h command_directory`/postqueue 2>/dev/null");
+	while (my $postfinger = <$mailq>) {
 			print "<tr><td class='v'>$postfinger</td></tr>"
 			if ( !grep(/total|^#|^\[ 	\]*$/,$postfinger));
 	} 
-	close(MAILQ);
+	close($mailq);
 	print "</table><br>";
 }
 if ($Libraries eq 1 ) {
 	print '<h1 align="center">Library dependencies</h1>';
 	print '<table border="0" cellpadding="0" width="600" align="center">';
-	if (! open(MAILQ, "/usr/bin/ldd `$config{'postfix_config_command'} -h daemon_directory`/smtpd 2>/dev/null |")) {
+	if (! open($mailq, "-|", "/usr/bin/ldd `$config{'postfix_config_command'} -h daemon_directory`/smtpd 2>/dev/null")) {
 		print '<center><b>WARNING: Can not find ldd.  Check you have it installed and in your path</b></center><br>';
 	} else {
-		while (my $postfinger = <MAILQ>) {
+		while (my $postfinger = <$mailq>) {
 			($postf1,$postf2)=split(/=/,$postfinger,2);
 			print "<tr><td class='e'><b>$postf1</b></td>"; 
 			print "<td class='v'>=$postf2</td></tr>";
 		} 
-		close(MAILQ);
+		close($mailq);
 		print "</table><br>";
 	}
 }

--- a/postfix/postfix-lib.pl
+++ b/postfix/postfix-lib.pl
@@ -3,10 +3,26 @@
 # postfix-module by Guillaume Cottenceau <gc@mandrakesoft.com>,
 # for webmin by Jamie Cameron
 
-$POSTFIX_MODULE_VERSION = 5;
+use strict;
+use warnings;
+no warnings 'redefine';
+no warnings 'uninitialized';
+
+our $POSTFIX_MODULE_VERSION = 5;
 
 BEGIN { push(@INC, ".."); };
 use WebminCore;
+
+# Package globals: Webmin-provided config/text/acl, plus module state and
+# caches that persist or are shared across the subs below.
+our (%config, %text, %access, $module_name, $module_config_directory);
+our ($postfix_version, $version_file, $postfix_config_command,
+     $has_postfix_config_command, $config_dir, $virtual_maps, $ldap_timeout,
+     $save_file);
+our (%maps_cache, @master_config_cache, @mail_system_cache,
+     @supports_map_type_cache, $connect_ldap_db_cache);
+our (@header_checks_actions, @check_sender_actions);
+
 &init_config();
 %access = &get_module_acl();
 $access{'postfinger'} = 0 if (&is_readonly_mode());
@@ -15,12 +31,13 @@ do 'aliases-lib.pl';
 $config{'perpage'} ||= 20;      # a value of 0 can cause problems
 
 # Get the saved version number
+my $version_fh = "VERSION";
 $version_file = "$module_config_directory/version";
 $postfix_config_command = $config{'postfix_config_command'};
 $has_postfix_config_command = &has_command($postfix_config_command);
-if (&open_readfile(VERSION, $version_file)) {
-	chop($postfix_version = <VERSION>);
-	close(VERSION);
+if (&open_readfile($version_fh, $version_file)) {
+	chop($postfix_version = <$version_fh>);
+	close($version_fh);
 	my @vst = stat($version_file);
 	my @cst = stat($postfix_config_command);
 	if (@cst && $cst[9] > $vst[9]) {
@@ -38,9 +55,9 @@ if (!$postfix_version) {
 		}
 
 	# And save for other callers
-	&open_tempfile(VERSION, ">$version_file", 0, 1);
-	&print_tempfile(VERSION, "$postfix_version\n");
-	&close_tempfile(VERSION);
+	&open_tempfile($version_fh, ">$version_file", 0, 1);
+	&print_tempfile($version_fh, "$postfix_version\n");
+	&close_tempfile($version_fh);
 	}
 
 if (&compare_version_numbers($postfix_version, 2) >= 0) {
@@ -144,7 +161,7 @@ if (!defined($out) && !$nodef) {
 		}
 	elsif ($out =~ /warning:.*unknown\s+parameter/ ||
 	       $err =~ /warning:.*unknown\s+parameter/) {
-		return undef;
+		return;
 		}
 	chop($out);
 	}
@@ -178,8 +195,16 @@ my $compatibility_level = &get_current_value("compatibility_level");
 
 if ($raw_value =~ /\{\{\$compatibility_level\}\s*([<>=!]+)\s*\{(\d+)\}\s*\?\s*\{(.*?)\}\s*:\s*\{(.*?)\}\}/) {
 	my ($op, $lvl, $tval, $fval) = ($1, $2, $3, $4);
-	return undef if ($op !~ /^([<>]=?|==|!=)$/);
-	return eval "\$compatibility_level $op $lvl" ? $tval : $fval;
+	my %compare = (
+		'<'  => sub { $_[0] <  $_[1] },
+		'<=' => sub { $_[0] <= $_[1] },
+		'>'  => sub { $_[0] >  $_[1] },
+		'>=' => sub { $_[0] >= $_[1] },
+		'==' => sub { $_[0] == $_[1] },
+		'!=' => sub { $_[0] != $_[1] },
+		);
+	return if (!$compare{$op});
+	return $compare{$op}->($compatibility_level, $lvl) ? $tval : $fval;
 	}
 
 return $raw_value;
@@ -288,16 +313,16 @@ sub reload_postfix
 		$cmd = $config{'reload_cmd'};
 		}
 	my $ex = &system_logged("$cmd >/dev/null 2>&1");
-	return $ex ? ($out || "$cmd failed") : undef;
+	return $ex ? "$cmd failed" : undef;
     }
-    return undef;
+    return;
 }
 
 # get_bootup_action()
 # Returns the name of the init script to start and stop Postfix, if found.
 sub get_bootup_action
 {
-return undef if (!&foreign_check("init"));
+return if (!&foreign_check("init"));
 &foreign_require("init");
 my $name = $config{'init_name'} || 'postfix';
 my $st = &init::action_status($name);
@@ -481,11 +506,11 @@ sub get_aliases_files
 # gives a new number of alias
 sub init_new_alias
 {
-    $aliases = &get_aliases();
+    my $aliases = &get_aliases();
 
     my $max_number = 0;
 
-    foreach $trans (@{$aliases})
+    foreach my $trans (@{$aliases})
     {
 	if ($trans->{'number'} > $max_number) { $max_number = $trans->{'number'}; }
     }
@@ -498,11 +523,12 @@ sub init_new_alias
 # be taken from a MySQL or LDAP backend
 sub list_postfix_aliases
 {
-local @rv;
+my @rv;
+my @maps;
 foreach my $f (&get_maps_types_files(&get_current_value("alias_maps"))) {
 	if (&file_map_type($f->[0])) {
 		# We can read this file directly
-		local $sofar = scalar(@rv);
+		my $sofar = scalar(@rv);
 		foreach my $a (&list_aliases([ $f->[1] ])) {
 			$a->{'num'} += $sofar;
 			push(@rv, $a);
@@ -515,10 +541,10 @@ foreach my $f (&get_maps_types_files(&get_current_value("alias_maps"))) {
 	}
 if (@maps) {
 	# Convert values from MySQL and LDAP maps into alias structures
-	local $maps = &get_maps("alias_maps", undef, join(",", @maps));
+	my $maps = &get_maps("alias_maps", undef, join(",", @maps));
 	foreach my $m (@$maps) {
-		local $v = $m->{'value'};
-		local @values;
+		my $v = $m->{'value'};
+		my @values;
 		while($v =~ /^\s*,?\s*()"([^"]+)"(.*)$/ ||
 		      $v =~ /^\s*,?\s*(\|)"([^"]+)"(.*)$/ ||
 		      $v =~ /^\s*,?\s*()([^,\s]+)(.*)$/) {
@@ -544,10 +570,10 @@ return @rv;
 # Adds a new alias, either to the local file or another backend
 sub create_postfix_alias
 {
-local ($alias) = @_;
-local @afiles = &get_maps_types_files(&get_current_value("alias_maps"));
-local $last_type = $afiles[$#afiles]->[0];
-local $last_file = $afiles[$#afiles]->[1];
+my ($alias) = @_;
+my @afiles = &get_maps_types_files(&get_current_value("alias_maps"));
+my $last_type = $afiles[$#afiles]->[0];
+my $last_file = $afiles[$#afiles]->[1];
 if (&file_map_type($last_type)) {
 	# Just adding to a file
 	&create_alias($alias, [ $last_file ], 1);
@@ -567,7 +593,7 @@ else {
 # Delete an alias, either from the files or from a MySQL or LDAP map
 sub delete_postfix_alias
 {
-local ($alias) = @_;
+my ($alias) = @_;
 if ($alias->{'map_type'}) {
 	# This was from a map
 	&delete_mapping("alias_maps", $alias);
@@ -582,7 +608,7 @@ else {
 # Update an alias, either in a file or in a map
 sub modify_postfix_alias
 {
-local ($oldalias, $alias) = @_;
+my ($oldalias, $alias) = @_;
 if ($oldalias->{'map_type'}) {
 	# In the map
 	if (!$alias->{'enabled'}) {
@@ -602,8 +628,7 @@ else {
 sub renumber_list
 {
 return if (!$_[2]);
-local $e;
-foreach $e (@{$_[0]}) {
+foreach my $e (@{$_[0]}) {
 	next if (defined($e->{'alias_file'}) &&
 	         $e->{'alias_file'} ne $_[1]->{'alias_file'});
 	next if (defined($e->{'map_file'}) &&
@@ -622,7 +647,7 @@ sub save_options
 
     my %options = %{$_[0]};
 
-    foreach $key (keys %options)
+    foreach my $key (keys %options)
     {
 	if ($key =~ /_def$/)
 	{
@@ -648,7 +673,7 @@ sub save_options
 #
 sub regenerate_aliases
 {
-    local $out;
+    my $out;
     $access{'aliases'} || error($text{'regenerate_ecannot'});
     if (get_current_value("alias_maps") eq "")
     {
@@ -657,8 +682,8 @@ sub regenerate_aliases
     }
     else
     {
-	local $map;
-	foreach $map (get_maps_types_files(get_real_value("alias_maps")))
+	my $map;
+	foreach my $map (get_maps_types_files(get_real_value("alias_maps")))
 	{
 	    if (&file_map_type($map->[0])) {
 		    my $cmd = $config{'postfix_aliases_table_command'};
@@ -782,7 +807,7 @@ sub regenerate_any_table
         next unless $map;
 	if (&file_map_type($map->[0]) &&
 	    $map->[0] ne 'regexp' && $map->[0] ne 'pcre') {
-		local $out = &backquote_logged(
+		my $out = &backquote_logged(
 			$config{'postfix_lookup_table_command'}.
 			" -c $config_dir".
 			($base64 ? " -F" : "").
@@ -832,11 +857,12 @@ sub get_maps
 
 	    if (&file_map_type($maps_type)) {
 		    # Read a file on disk
-		    &open_readfile(MAPS, $maps_file);
+		    my $mapsfh = "MAPS";
+		    &open_readfile($mapsfh, $maps_file);
 		    my $i = 0;
 		    my $cmt;
 		    my $lastmap;
-		    while (<MAPS>)
+		    while (<$mapsfh>)
 		    {
 			s/\r|\n//g;	# remove newlines
 			if (/^\s*#+\s*(.*)/) {
@@ -871,14 +897,14 @@ sub get_maps
 			    }
 			$i++;
 		    }
-		    close(MAPS);
+		    close($mapsfh);
 
 	     } elsif ($maps_type eq "mysql") {
 		    # Get from a MySQL database
-		    local $conf = &mysql_value_to_conf($maps_file);
-		    local $dbh = &connect_mysql_db($conf);
+		    my $conf = &mysql_value_to_conf($maps_file);
+		    my $dbh = &connect_mysql_db($conf);
 		    ref($dbh) || &error($dbh);
-		    local $cmd = $dbh->prepare(
+		    my $cmd = $dbh->prepare(
 				       "select ".$conf->{'where_field'}.
 				       ",".$conf->{'select_field'}.
 				       " from ".$conf->{'table'}.
@@ -904,12 +930,12 @@ sub get_maps
 
 	     } elsif ($maps_type eq "ldap") {
 		    # Get from an LDAP database
-	     	    local $conf = &ldap_value_to_conf($maps_file);
-		    local $ldap = &connect_ldap_db($conf);
+	     	    my $conf = &ldap_value_to_conf($maps_file);
+		    my $ldap = &connect_ldap_db($conf);
 		    ref($ldap) || &error($ldap);
-		    local ($name_attr, $filter) = &get_ldap_key($conf);
-		    local $scope = $conf->{'scope'} || 'sub';
-		    local $rv = $ldap->search(base => $conf->{'search_base'},
+		    my ($name_attr, $filter) = &get_ldap_key($conf);
+		    my $scope = $conf->{'scope'} || 'sub';
+		    my $rv = $ldap->search(base => $conf->{'search_base'},
 					      scope => $scope,
 					      filter => $filter);
 		    if (!$rv || $rv->code) {
@@ -969,7 +995,7 @@ sub generate_map_edit
     my $nt = $_[3] || $text{'mapping_name'};
     my $vt = $_[4] || $text{'mapping_value'};
 
-    local @links = ( &ui_link("edit_mapping.cgi?map_name=$_[0]",
+    my @links = ( &ui_link("edit_mapping.cgi?map_name=$_[0]",
 			      $text{'new_mapping'}),);
     if ($access{'manual'} && &can_map_manual($_[0])) {
 	push(@links, &ui_link("edit_manual.cgi?map_name=$_[0]",
@@ -1126,10 +1152,10 @@ if (&file_map_type($maps_type)) {
 	}
 elsif ($maps_type eq "mysql") {
 	# Adding to a MySQL table
-	local $conf = &mysql_value_to_conf($maps_file);
-	local $dbh = &connect_mysql_db($conf);
+	my $conf = &mysql_value_to_conf($maps_file);
+	my $dbh = &connect_mysql_db($conf);
 	ref($dbh) || &error($dbh);
-	local $cmd = $dbh->prepare("insert into ".$conf->{'table'}." ".
+	my $cmd = $dbh->prepare("insert into ".$conf->{'table'}." ".
 				   "(".$conf->{'where_field'}.",".
 					$conf->{'select_field'}.") values (".
 				   "?, ?)");
@@ -1143,18 +1169,18 @@ elsif ($maps_type eq "mysql") {
 	}
 elsif ($maps_type eq "ldap") {
 	# Adding to an LDAP database
-	local $conf = &ldap_value_to_conf($maps_file);
-	local $ldap = &connect_ldap_db($conf);
+	my $conf = &ldap_value_to_conf($maps_file);
+	my $ldap = &connect_ldap_db($conf);
 	ref($ldap) || &error($ldap);
-	local @classes = split(/\s+/, $config{'ldap_class'} ||
+	my @classes = split(/\s+/, $config{'ldap_class'} ||
 				      "inetLocalMailRecipient");
-	local @attrs = ( "objectClass", \@classes );
-	local $name_attr = &get_ldap_key($conf);
+	my @attrs = ( "objectClass", \@classes );
+	my $name_attr = &get_ldap_key($conf);
 	push(@attrs, $name_attr, $map->{'name'});
 	push(@attrs, $conf->{'result_attribute'} || "maildrop",
 		     $map->{'value'});
 	push(@attrs, &split_props($config{'ldap_attrs'}));
-	local $dn = &make_map_ldap_dn($map, $conf);
+	my $dn = &make_map_ldap_dn($map, $conf);
 	if ($dn =~ /^([^=]+)=([^, ]+)/ && !&in_props(\@attrs, $1)) {
 		push(@attrs, $1, $2);
 		}
@@ -1163,7 +1189,7 @@ elsif ($maps_type eq "ldap") {
 	&ensure_ldap_parent($ldap, $dn);
 
 	# Actually add
-	local $rv = $ldap->add($dn, attr => \@attrs);
+	my $rv = $ldap->add($dn, attr => \@attrs);
 	if ($rv->code) {
 		&error(&text('ldap_eadd', "<tt>$dn</tt>",
 			     "<tt>".&html_escape($rv->error)."</tt>"));
@@ -1185,9 +1211,9 @@ sub delete_mapping
 {
 if (&file_map_type($_[1]->{'map_type'}) || !$_[1]->{'map_type'}) {
 	# Deleting from a file
-	local $lref = &read_file_lines($_[1]->{'map_file'});
-	local $dl = $lref->[$_[1]->{'eline'}];
-	local $len = $_[1]->{'eline'} - $_[1]->{'line'} + 1;
+	my $lref = &read_file_lines($_[1]->{'map_file'});
+	my $dl = $lref->[$_[1]->{'eline'}];
+	my $len = $_[1]->{'eline'} - $_[1]->{'line'} + 1;
 	if (($dl =~ /^\s*(\/[^\/]*\/[a-z]*)\s+([^#]*)/ ||
 	     $dl =~ /^\s*([^\s]+)\s+([^#]*)/) &&
 	    $1 eq $_[1]->{'name'}) {
@@ -1201,7 +1227,7 @@ if (&file_map_type($_[1]->{'map_type'}) || !$_[1]->{'map_type'}) {
 		}
 	&flush_file_lines($_[1]->{'map_file'});
 	&renumber_list($maps_cache{$_[0]}, $_[1], -$len);
-	local $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
+	my $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
 	if ($idx >= 0) {
 		# Take out of cache
 		splice(@{$maps_cache{$_[0]}}, $idx, 1);
@@ -1209,10 +1235,10 @@ if (&file_map_type($_[1]->{'map_type'}) || !$_[1]->{'map_type'}) {
 	}
 elsif ($_[1]->{'map_type'} eq 'mysql') {
 	# Deleting from MySQL
-	local $conf = &mysql_value_to_conf($_[1]->{'map_file'});
-	local $dbh = &connect_mysql_db($conf);
+	my $conf = &mysql_value_to_conf($_[1]->{'map_file'});
+	my $dbh = &connect_mysql_db($conf);
 	ref($dbh) || &error($dbh);
-	local $cmd = $dbh->prepare("delete from ".$conf->{'table'}.
+	my $cmd = $dbh->prepare("delete from ".$conf->{'table'}.
 				   " where ".$conf->{'where_field'}." = ?".
 				   " ".$conf->{'additional_conditions'});
 	if (!$cmd || !$cmd->execute($_[1]->{'key'})) {
@@ -1224,10 +1250,10 @@ elsif ($_[1]->{'map_type'} eq 'mysql') {
 	}
 elsif ($_[1]->{'map_type'} eq 'ldap') {
 	# Deleting from LDAP
-	local $conf = &ldap_value_to_conf($_[1]->{'map_file'});
-	local $ldap = &connect_ldap_db($conf);
+	my $conf = &ldap_value_to_conf($_[1]->{'map_file'});
+	my $ldap = &connect_ldap_db($conf);
 	ref($ldap) || &error($ldap);
-	local $rv = $ldap->delete($_[1]->{'dn'});
+	my $rv = $ldap->delete($_[1]->{'dn'});
 	if ($rv->code) {
 		my $err = $rv->error;
 		if ($err !~ /No such object/i) {
@@ -1238,7 +1264,7 @@ elsif ($_[1]->{'map_type'} eq 'ldap') {
 	}
 
 # Delete from in-memory cache
-local $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
+my $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
 splice(@{$maps_cache{$_[0]}}, $idx, 1) if ($idx != -1);
 }
 
@@ -1248,15 +1274,15 @@ sub modify_mapping
 {
 if (&file_map_type($_[1]->{'map_type'}) || !$_[1]->{'map_type'}) {
 	# Modifying in a file
-	local $lref = &read_file_lines($_[1]->{'map_file'});
-	local $oldlen = $_[1]->{'eline'} - $_[1]->{'line'} + 1;
-	local @newlines;
+	my $lref = &read_file_lines($_[1]->{'map_file'});
+	my $oldlen = $_[1]->{'eline'} - $_[1]->{'line'} + 1;
+	my @newlines;
 	push(@newlines, &make_table_comment($_[2]->{'cmt'}));
 	push(@newlines, "$_[2]->{'name'}\t$_[2]->{'value'}");
 	splice(@$lref, $_[1]->{'line'}, $oldlen, @newlines);
 	&flush_file_lines($_[1]->{'map_file'});
 	&renumber_list($maps_cache{$_[0]}, $_[1], scalar(@newlines)-$oldlen);
-	local $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
+	my $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
 	if ($idx >= 0) {
 		# Update in cache
 		$_[2]->{'map_file'} = $_[1]->{'map_file'};
@@ -1268,10 +1294,10 @@ if (&file_map_type($_[1]->{'map_type'}) || !$_[1]->{'map_type'}) {
 	}
 elsif ($_[1]->{'map_type'} eq 'mysql') {
 	# Updating in MySQL
-	local $conf = &mysql_value_to_conf($_[1]->{'map_file'});
-	local $dbh = &connect_mysql_db($conf);
+	my $conf = &mysql_value_to_conf($_[1]->{'map_file'});
+	my $dbh = &connect_mysql_db($conf);
 	ref($dbh) || &error($dbh);
-	local $cmd = $dbh->prepare("update ".$conf->{'table'}.
+	my $cmd = $dbh->prepare("update ".$conf->{'table'}.
 				   " set ".$conf->{'where_field'}." = ?,".
 				   " ".$conf->{'select_field'}." = ?".
 				   " where ".$conf->{'where_field'}." = ?".
@@ -1286,25 +1312,25 @@ elsif ($_[1]->{'map_type'} eq 'mysql') {
 	}
 elsif ($_[1]->{'map_type'} eq 'ldap') {
 	# Updating in LDAP
-	local $conf = &ldap_value_to_conf($_[1]->{'map_file'});
-	local $ldap = &connect_ldap_db($conf);
+	my $conf = &ldap_value_to_conf($_[1]->{'map_file'});
+	my $ldap = &connect_ldap_db($conf);
 	ref($ldap) || &error($ldap);
 
 	# Work out attribute changes
-	local %replace;
-	local $name_attr = &get_ldap_key($conf);
+	my %replace;
+	my $name_attr = &get_ldap_key($conf);
 	$replace{$name_attr} = [ $_[2]->{'name'} ];
 	$replace{$conf->{'result_attribute'} || "maildrop"} =
 		[ $_[2]->{'value'} ];
 
 	# Work out new DN, if needed
-	local $newdn = &make_map_ldap_dn($_[2], $conf);
+	my $newdn = &make_map_ldap_dn($_[2], $conf);
 	if ($_[1]->{'name'} ne $_[2]->{'name'} &&
 	    $_[1]->{'dn'} ne $newdn) {
 		# Changed .. update the object in LDAP
 		&ensure_ldap_parent($ldap, $newdn);
-		local ($newprefix, $newrest) = split(/,/, $newdn, 2);
-		local $rv = $ldap->moddn($_[1]->{'dn'},
+		my ($newprefix, $newrest) = split(/,/, $newdn, 2);
+		my $rv = $ldap->moddn($_[1]->{'dn'},
 					 newrdn => $newprefix,
 					 newsuperior => $newrest);
 		if ($rv->code) {
@@ -1323,7 +1349,7 @@ elsif ($_[1]->{'map_type'} eq 'ldap') {
 		}
 
 	# Modify attributes
-	local $rv = $ldap->modify($_[2]->{'dn'}, replace => \%replace);
+	my $rv = $ldap->modify($_[2]->{'dn'}, replace => \%replace);
 	if ($rv->code) {
 		&error(&text('ldap_emodify',
 			     "<tt>$_[2]->{'dn'}</tt>",
@@ -1332,7 +1358,7 @@ elsif ($_[1]->{'map_type'} eq 'ldap') {
 	}
 
 # Update in-memory cache
-local $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
+my $idx = &indexof($_[1], @{$maps_cache{$_[0]}});
 $_[2]->{'map_file'} = $_[1]->{'map_file'};
 $_[2]->{'map_type'} = $_[1]->{'map_type'};
 $_[2]->{'file'} = $_[1]->{'file'};
@@ -1345,11 +1371,11 @@ $maps_cache{$_[0]}->[$idx] = $_[2] if ($idx != -1);
 # Work out an LDAP DN for a map
 sub make_map_ldap_dn
 {
-local ($map, $conf) = @_;
-local $dn;
-local $scope = $conf->{'scope'} || 'sub';
+my ($map, $conf) = @_;
+my $dn;
+my $scope = $conf->{'scope'} || 'sub';
 $scope = 'base' if (!$config{'ldap_doms'});	# Never create sub-domains
-local $id = $config{'ldap_id'} || 'cn';
+my $id = $config{'ldap_id'} || 'cn';
 if ($map->{'name'} =~ /^(\S+)\@(\S+)$/ && $scope ne 'base') {
 	# Within a domain
 	$dn = "$id=$1,cn=$2,$conf->{'search_base'}";
@@ -1369,8 +1395,8 @@ return $dn;
 # Returns the attribute name for the LDAP key. May call &error
 sub get_ldap_key
 {
-local ($conf) = @_;
-local ($filter, $name_attr) = @_;
+my ($conf) = @_;
+my ($filter, $name_attr) = @_;
 if ($conf->{'query_filter'}) {
 	$filter = $conf->{'query_filter'};
 	$conf->{'query_filter'} =~ /([a-z0-9]+)=\%[su]/i ||
@@ -1391,17 +1417,17 @@ return wantarray ? ( $name_attr, $filter ) : $name_attr;
 # Create the parent of some DN if needed
 sub ensure_ldap_parent
 {
-local ($ldap, $dn) = @_;
-local $pdn = $dn;
+my ($ldap, $dn) = @_;
+my $pdn = $dn;
 $pdn =~ s/^([^,]+),//;
-local $rv = $ldap->search(base => $pdn, scope => 'base',
+my $rv = $ldap->search(base => $pdn, scope => 'base',
 			  filter => "(objectClass=top)",
 			  sizelimit => 1);
 if (!$rv || $rv->code || !$rv->all_entries) {
 	# Does not .. so add it
-	local @pclasses = ( "top" );
-	local @pattrs = ( "objectClass", \@pclasses );
-	local $rv = $ldap->add($pdn, attr => \@pattrs);
+	my @pclasses = ( "top" );
+	my @pattrs = ( "objectClass", \@pclasses );
+	my $rv = $ldap->add($pdn, attr => \@pattrs);
 	}
 }
 
@@ -1411,7 +1437,7 @@ sub init_new_mapping
 {
 my $maps = &get_maps($_[0]);
 my $max_number = 0;
-foreach $trans (@{$maps}) {
+foreach my $trans (@{$maps}) {
 	if ($trans->{'number'} > $max_number) {
 		$max_number = $trans->{'number'};
 		}
@@ -1422,7 +1448,7 @@ return $max_number+1;
 # postfix_mail_file(user|user-details-list)
 sub postfix_mail_file
 {
-local @s = &postfix_mail_system();
+my @s = &postfix_mail_system();
 if ($s[0] == 0) {
 	return "$s[1]/$_[0]";
 	}
@@ -1430,7 +1456,7 @@ elsif (@_ > 1) {
 	return "$_[7]/$s[1]";
 	}
 else {
-	local @u = getpwnam($_[0]);
+	my @u = getpwnam($_[0]);
 	return "$u[7]/$s[1]";
 	}
 }
@@ -1442,13 +1468,13 @@ else {
 sub postfix_mail_system
 {
 if (!scalar(@mail_system_cache)) {
-	local $home_mailbox = &get_current_value("home_mailbox");
+	my $home_mailbox = &get_current_value("home_mailbox");
 	if ($home_mailbox) {
 		@mail_system_cache = $home_mailbox =~ /^(.*)\/$/ ?
 			(2, $1) : (1, $home_mailbox);
 		}
 	else {
-		local $mail_spool_directory =
+		my $mail_spool_directory =
 			&get_current_value("mail_spool_directory");
 		@mail_system_cache = (0, $mail_spool_directory);
 		}
@@ -1460,18 +1486,18 @@ return wantarray ? @mail_system_cache : $mail_system_cache[0];
 # Returns a list of strutures, each containing details of one queued message
 sub list_queue
 {
-local ($throw) = @_;
-local @qfiles;
-local $out = &backquote_command("$config{'mailq_cmd'} 2>&1 </dev/null");
+my ($throw) = @_;
+my @qfiles;
+my $out = &backquote_command("$config{'mailq_cmd'} 2>&1 </dev/null");
 &error("$config{'mailq_cmd'} failed : ".&html_escape($out)) if ($? && $throw);
 foreach my $l (split(/\r?\n/, $out)) {
 	next if ($l =~ /^(\S+)\s+is\s+empty/i ||
 		 $l =~ /^\s+Total\s+requests:/i);
 	if ($l =~ /^([^\s\*\!]+)[\*\!]?\s*(\d+)\s+(\S+\s+\S+\s+\d+\s+\d+:\d+:\d+)\s+(.*)/) {
-		local $q = { 'id' => $1, 'size' => $2,
+		my $q = { 'id' => $1, 'size' => $2,
                              'date' => $3, 'from' => $4 };
 		if (defined(&parse_mail_date)) {
-			local $t = &parse_mail_date($q->{'date'});
+			my $t = &parse_mail_date($q->{'date'});
 			if ($t) {
 				$q->{'date'} = &make_date($t, 0, 'yyyy/mm/dd');
 				$q->{'time'} = $t;
@@ -1482,7 +1508,7 @@ foreach my $l (split(/\r?\n/, $out)) {
 			my $path = "$config{'mailq_dir'}/$dir/$f/$q->{'id'}";
 			if (-r $path) {
 				$q->{'dir'} = $dir;
-				$q->{'file'} = $file;
+				$q->{'file'} = $path;
 				last;
 				}
 			}
@@ -1507,15 +1533,16 @@ return ("active", "incoming", "deferred", "corrupt", "hold", "maildrop");
 # Parses a postfix mail queue file into a standard mail structure
 sub parse_queue_file
 {
-local ($f) = @_;
-local @qfiles = map { &recurse_files("$config{'mailq_dir'}/$_") }
+my ($f) = @_;
+my @qfiles = map { &recurse_files("$config{'mailq_dir'}/$_") }
 		    &list_mailq_directories();
-local ($file) = grep { $_ =~ /\/$f$/ } @qfiles;
-return undef if (!$file);
-local $mode = 0;
-local ($mail, @headers);
-&open_execute_command(QUEUE, "$config{'postcat_cmd'} ".quotemeta($file), 1, 1);
-while(<QUEUE>) {
+my ($file) = grep { $_ =~ /\/$f$/ } @qfiles;
+return if (!$file);
+my $mode = 0;
+my ($mail, @headers);
+my $queuefh = "QUEUE";
+&open_execute_command($queuefh, "$config{'postcat_cmd'} ".quotemeta($file), 1, 1);
+while(<$queuefh>) {
 	if (/^\*\*\*\s+MESSAGE\s+CONTENTS/ && !$mode) {	   # Start of headers
 		$mode = 1;
 		}
@@ -1536,9 +1563,9 @@ while(<QUEUE>) {
 		$mail->{'body'} .= $_;
 		}
 	}
-close(QUEUE);
+close($queuefh);
 $mail->{'headers'} = \@headers;
-foreach $h (@headers) {
+foreach my $h (@headers) {
 	$mail->{'header'}->{lc($h->[0])} = $h->[1];
 	}
 $mail->{'file'} = $file;
@@ -1553,11 +1580,11 @@ return $mail;
 # recurse_files(dir)
 sub recurse_files
 {
-opendir(DIR, &translate_filename($_[0])) || return ( $_[0] );
-local @dir = readdir(DIR);
-closedir(DIR);
-local ($f, @rv);
-foreach $f (@dir) {
+opendir(my $dirh, &translate_filename($_[0])) || return ( $_[0] );
+my @dir = readdir($dirh);
+closedir($dirh);
+my @rv;
+foreach my $f (@dir) {
 	push(@rv, &recurse_files("$_[0]/$f")) if ($f !~ /^\./);
 	}
 return @rv;
@@ -1565,7 +1592,7 @@ return @rv;
 
 sub sort_by_domain
 {
-local ($a1, $a2, $b1, $b2);
+my ($a1, $a2, $b1, $b2);
 if ($a->{'name'} =~ /^(.*)\@(.*)$/ && (($a1, $a2) = ($1, $2)) &&
     $b->{'name'} =~ /^(.*)\@(.*)$/ && (($b1, $b2) = ($1, $2))) {
 	return $a2 cmp $b2 ? $a2 cmp $b2 : $a1 cmp $b1;
@@ -1589,7 +1616,7 @@ if ($config{'check_config'} && !defined($save_file)) {
 sub after_save
 {
 if (defined($save_file)) {
-	local $err = &check_postfix();
+	my $err = &check_postfix();
 	if ($err) {
 		&copy_source_dest($save_file, $config{'postfix_config_file'});
 		&unlink_file($save_file);
@@ -1627,9 +1654,10 @@ sub ensure_map
 {
 foreach my $mf (&get_maps_files(&get_real_value($_[0]))) {
 	if ($mf =~ /^\// && !-e $mf) {
-		&open_lock_tempfile(TOUCH, ">$mf", 1) ||
+		my $touchfh = "TOUCH";
+		&open_lock_tempfile($touchfh, ">$mf", 1) ||
 			&error(&text("efilewrite", $mf, $!));
-		&close_tempfile(TOUCH);
+		&close_tempfile($touchfh);
 		&set_ownership_permissions(undef, undef, 0755, $mf);
 		}
 	}
@@ -1650,7 +1678,7 @@ return $_[1]->{'name'};
 
 sub edit_value_header_checks
 {
-local ($act, $dest) = split(/\s+/, $_[0]->{'value'}, 2);
+my ($act, $dest) = split(/\s+/, $_[0]->{'value'}, 2);
 return &ui_table_row($text{'header_value'},
               &ui_select("action", $act,
 			 [ map { [ $_, $text{'header_'.lc($_)} ] }
@@ -1660,7 +1688,7 @@ return &ui_table_row($text{'header_value'},
 
 sub parse_value_header_checks
 {
-local $rv = $_[1]->{'action'};
+my $rv = $_[1]->{'action'};
 if ($_[1]->{'value'}) {
 	$rv .= " ".$_[1]->{'value'};
 	}
@@ -1716,7 +1744,7 @@ return "<td><b>$text{'access_addresses'}</b></td>\n".
 
 sub edit_value_check_sender_access
 {
-local ($act, $dest) = split(/\s+/, $_[0]->{'value'}, 2);
+my ($act, $dest) = split(/\s+/, $_[0]->{'value'}, 2);
 return "<td><b>$text{'header_value'}</b></td>\n".
        "<td>".&ui_select("action", $act,
 			 [ map { [ $_, $text{'header_'.lc($_)} ] }
@@ -1742,10 +1770,11 @@ sub get_master_config
 {
 if (!scalar(@master_config_cache)) {
 	@master_config_cache = ( );
-	local $lnum = 0;
-	local $prog;
-	open(MASTER, "<".$config{'postfix_master'});
-	while(<MASTER>) {
+	my $lnum = 0;
+	my $prog;
+	open(my $masterfh, "<", $config{'postfix_master'}) ||
+		return \@master_config_cache;
+	while(<$masterfh>) {
 		s/\r|\n//g;
 		if (/^(#?)\s*(\S+)\s+(inet|unix|fifo)\s+(y|n|\-)\s+(y|n|\-)\s+(y|n|\-)\s+(\S+)\s+(\S+)\s+(.*)$/) {
 			# A program line
@@ -1772,7 +1801,7 @@ if (!scalar(@master_config_cache)) {
 			}
 		$lnum++;
 		}
-	close(MASTER);
+	close($masterfh);
 	}
 return \@master_config_cache;
 }
@@ -1781,9 +1810,9 @@ return \@master_config_cache;
 # Adds a new Postfix server process
 sub create_master
 {
-local ($master) = @_;
-local $conf = &get_master_config();
-local $lref = &read_file_lines($config{'postfix_master'});
+my ($master) = @_;
+my $conf = &get_master_config();
+my $lref = &read_file_lines($config{'postfix_master'});
 push(@$lref, &master_line($master));
 &flush_file_lines($config{'postfix_master'});
 $master->{'line'} = scalar(@$lref)-1;
@@ -1795,10 +1824,10 @@ push(@$conf, $master);
 # Removes one Postfix server process
 sub delete_master
 {
-local ($master) = @_;
-local $conf = &get_master_config();
-local $lref = &read_file_lines($config{'postfix_master'});
-local $lines = $master->{'eline'} - $master->{'line'} + 1;
+my ($master) = @_;
+my $conf = &get_master_config();
+my $lref = &read_file_lines($config{'postfix_master'});
+my $lines = $master->{'eline'} - $master->{'line'} + 1;
 splice(@$lref, $master->{'line'}, $lines);
 &flush_file_lines($config{'postfix_master'});
 @$conf = grep { $_ ne $master } @$conf;
@@ -1814,10 +1843,10 @@ foreach my $c (@$conf) {
 # Updates one Postfix server process
 sub modify_master
 {
-local ($master) = @_;
-local $conf = &get_master_config();
-local $lref = &read_file_lines($config{'postfix_master'});
-local $lines = $master->{'eline'} - $master->{'line'} + 1;
+my ($master) = @_;
+my $conf = &get_master_config();
+my $lref = &read_file_lines($config{'postfix_master'});
+my $lines = $master->{'eline'} - $master->{'line'} + 1;
 splice(@$lref, $master->{'line'}, $lines,
        &master_line($master));
 &flush_file_lines($config{'postfix_master'});
@@ -1832,7 +1861,7 @@ foreach my $c (@$conf) {
 # master_line(&master)
 sub master_line
 {
-local ($prog) = @_;
+my ($prog) = @_;
 return ($prog->{'enabled'} ? "" : "#").
        join("\t", $prog->{'name'}, $prog->{'type'}, $prog->{'private'},
 		  $prog->{'unpriv'}, $prog->{'chroot'}, $prog->{'wakeup'},
@@ -1841,7 +1870,7 @@ return ($prog->{'enabled'} ? "" : "#").
 
 sub redirect_to_map_list
 {
-local ($map_name) = @_;
+my ($map_name) = @_;
 if ($map_name =~ /sender_dependent_default_transport_maps/) {
 	redirect("dependent.cgi");
 	}
@@ -1861,7 +1890,7 @@ else { &redirect(""); }
 
 sub regenerate_map_table
 {
-local ($map_name) = @_;
+my ($map_name) = @_;
 if ($map_name =~ /canonical/) { &regenerate_canonical_table(); }
 if ($map_name =~ /relocated/) { &regenerate_relocated_table(); }
 if ($map_name =~ /virtual/) { &regenerate_virtual_table(); }
@@ -1889,16 +1918,16 @@ if ($map_name =~ /smtpd_sender_restrictions/) {
 # Print a table of queued mail messages
 sub mailq_table
 {
-local ($qfiles) = @_;
+my ($qfiles) = @_;
 
 # Build table data
 my @table;
 foreach my $q (@$qfiles) {
-	local @cols;
+	my @cols;
 	push(@cols, { 'type' => 'checkbox', 'name' => 'file',
 		      'value' => $q->{'id'} });
 	push(@cols, &ui_link("view_mailq.cgi?id=$q->{'id'}",$q->{'id'}));
-	local $size = &nice_size($q->{'size'});
+	my $size = &nice_size($q->{'size'});
 	push(@cols, $q->{'date'});
 	push(@cols, &html_escape($q->{'from'}));
 	push(@cols, &html_escape($q->{'to'}));
@@ -1931,7 +1960,7 @@ print &ui_form_columns_table("delete_queues.cgi",
 # Returns the comment text if a line contains a comment, like # foo
 sub is_table_comment
 {
-local ($line, $force) = @_;
+my ($line, $force) = @_;
 if ($config{'prefix_cmts'} || $force) {
 	return $line =~ /^\s*#+\s*Webmin:\s*(.*)/ ? $1 : undef;
 	}
@@ -1944,7 +1973,7 @@ else {
 # Returns an array of lines for a comment in a map file, like # foo
 sub make_table_comment
 {
-local ($cmt, $force) = @_;
+my ($cmt, $force) = @_;
 if (!$cmt) {
 	return ( );
 	}
@@ -1976,7 +2005,7 @@ sub unlock_postfix_files
 # Returns HTML for a button for popping up a map file chooser
 sub map_chooser_button
 {
-local ($name, $mapname) = @_;
+my ($name, $mapname) = @_;
 return &popup_window_button("map_chooser.cgi?mapname=$mapname", 1024, 600, 1,
 			    [ [ "ifield", $name, "map" ] ]);
 }
@@ -2000,7 +2029,7 @@ return @rv;
 # Returns a list of global MySQL source names in main.cf
 sub list_mysql_sources
 {
-local @rv;
+my @rv;
 my $lref = &read_file_lines($config{'postfix_config_file'});
 foreach my $l (@$lref) {
 	if ($l =~ /^\s*(\S+)_dbname\s*=/) {
@@ -2015,9 +2044,9 @@ return @rv;
 # config file.
 sub get_backend_config
 {
-local ($file) = @_;
-local %rv;
-local $lref = &read_file_lines($file, 1);
+my ($file) = @_;
+my %rv;
+my $lref = &read_file_lines($file, 1);
 foreach my $l (@$lref) {
 	if ($l =~ /^\s*([a-z0-9\_]+)\s*=\s*(.*)/i) {
 		$rv{$1} = $2;
@@ -2030,9 +2059,9 @@ return \%rv;
 # Updates one setting in a backend config file
 sub save_backend_config
 {
-local ($file, $name, $value) = @_;
-local $lref = &read_file_lines($file);
-local $found = 0;
+my ($file, $name, $value) = @_;
+my $lref = &read_file_lines($file);
+my $found = 0;
 for(my $i=0; $i<@$lref; $i++) {
 	if ($lref->[$i] =~ /^\s*([a-z0-9\_]+)\s*=\s*(.*)/i &&
 	    $1 eq $name) {
@@ -2056,16 +2085,16 @@ if (!$found && defined($value)) {
 # Checks if some map (such as a database) can be accessed
 sub can_access_map
 {
-local ($type, $value) = @_;
+my ($type, $value) = @_;
 if (&file_map_type($type)) {
-	return undef;	# Always can
+	return;	# Always can
 	}
 elsif ($type eq "mysql") {
 	# Parse config, connect to DB
-	local $conf;
+	my $conf;
 	if ($value =~ /^[\/\.]/) {
 		# Config file
-		local $cfile = $value;
+		my $cfile = $value;
 		if ($cfile !~ /^\//) {
 			$cfile = &guess_config_dir()."/".$cfile;
 			}
@@ -2085,11 +2114,11 @@ elsif ($type eq "mysql") {
 			}
 		}
 	# Try a connect, and a query
-	local $dbh = &connect_mysql_db($conf);
+	my $dbh = &connect_mysql_db($conf);
 	if (!ref($dbh)) {
 		return $dbh;
 		}
-	local $cmd = $dbh->prepare("select ".$conf->{'select_field'}." ".
+	my $cmd = $dbh->prepare("select ".$conf->{'select_field'}." ".
 				   "from ".$conf->{'table'}." ".
 				   "where ".$conf->{'where_field'}." = ".
 					    $conf->{'where_field'}." ".
@@ -2101,21 +2130,21 @@ elsif ($type eq "mysql") {
 		}
 	$cmd->finish();
 	$dbh->disconnect();
-	return undef;
+	return;
 	}
 elsif ($type eq "ldap") {
 	# Parse config, connect to LDAP server
-	local $conf = &ldap_value_to_conf($value);
+	my $conf = &ldap_value_to_conf($value);
 	$conf->{'search_base'} || return &text('ldap_esource', $value);
 
 	# Try a connect and a search
-	local $ldap = &connect_ldap_db($conf);
+	my $ldap = &connect_ldap_db($conf);
 	if (!ref($ldap)) {
 		return $ldap;
 		}
-	local @classes = split(/\s+/, $config{'ldap_class'} ||
+	my @classes = split(/\s+/, $config{'ldap_class'} ||
 				      "inetLocalMailRecipient");
-	local $rv = $ldap->search(base => $conf->{'search_base'},
+	my $rv = $ldap->search(base => $conf->{'search_base'},
 				  filter => "(objectClass=$classes[0])",
 				  sizelimit => 1);
 	if (!$rv || $rv->code && !$rv->all_entries) {
@@ -2123,7 +2152,7 @@ elsif ($type eq "ldap") {
 			     $rv ? $rv->error : "Unknown search error");
 		}
 
-	return undef;
+	return;
 	}
 else {
 	return &text('map_unknown', "<tt>$type</tt>");
@@ -2135,21 +2164,16 @@ else {
 # a driver handle on success, or an error message string on failure.
 sub connect_mysql_db
 {
-local ($conf) = @_;
-local $driver = "mysql";
-local $drh;
-eval <<EOF;
-use DBI;
-\$drh = DBI->install_driver(\$driver);
-EOF
-if ($@) {
-	return &text('mysql_edriver', "<tt>DBD::$driver</tt>");
-        }
-local @hosts = split(/\s+/, $config{'mysql_hosts'} || $conf->{'hosts'});
+my ($conf) = @_;
+my $driver = "mysql";
+my $drh;
+eval { require DBI; DBI->import; $drh = DBI->install_driver($driver); 1 }
+	or return &text('mysql_edriver', "<tt>DBD::$driver</tt>");
+my @hosts = split(/\s+/, $config{'mysql_hosts'} || $conf->{'hosts'});
 @hosts = ( undef ) if (!@hosts);	# Localhost only
-local $dbh;
+my $dbh;
 foreach my $host (@hosts) {
-	local $dbistr = "database=$conf->{'dbname'}";
+	my $dbistr = "database=$conf->{'dbname'}";
 	if ($host =~ /^unix:(.*)$/) {
 		# Socket file
 		$dbistr .= ";mysql_socket=$1";
@@ -2174,19 +2198,17 @@ return $dbh;
 # a driver handle on success, or an error message string on failure.
 sub connect_ldap_db
 {
-local ($conf) = @_;
+my ($conf) = @_;
 if (defined($connect_ldap_db_cache)) {
 	return $connect_ldap_db_cache;
 	}
-eval "use Net::LDAP";
-if ($@) {
-	return &text('ldap_eldapmod', "<tt>Net::LDAP</tt>");
-	}
-local @servers = split(/\s+/, $config{'ldap_host'} ||
+eval { require Net::LDAP; Net::LDAP->import; 1 }
+	or return &text('ldap_eldapmod', "<tt>Net::LDAP</tt>");
+my @servers = split(/\s+/, $config{'ldap_host'} ||
 			      $conf->{'server_host'} || "localhost");
-local ($ldap, $lasterr);
+my ($ldap, $lasterr);
 foreach my $server (@servers) {
-	local ($host, $port, $tls);
+	my ($host, $port, $tls);
 	if ($server =~ /^(\S+):(\d+)$/) {
 		# Host and port
 		($host, $port) = ($1, $2);
@@ -2213,7 +2235,7 @@ foreach my $server (@servers) {
 		$ldap->start_tls;
 		}
 	if ($conf->{'bind'} eq 'yes' || $config{'ldap_user'}) {
-		local $mesg = $ldap->bind(
+		my $mesg = $ldap->bind(
 			dn => $config{'ldap_user'} || $conf->{'bind_dn'},
 			password => $config{'ldap_pass'} || $conf->{'bind_pw'});
 		if (!$mesg || $mesg->code) {
@@ -2242,11 +2264,11 @@ else {
 # Converts a MySQL config file or source name to a config hash ref
 sub mysql_value_to_conf
 {
-local ($value) = @_;
-local $conf;
+my ($value) = @_;
+my $conf;
 if ($value =~ /^[\/\.]/) {
 	# Config file
-	local $cfile = $value;
+	my $cfile = $value;
 	if ($cfile !~ /^\//) {
 		$cfile = &guess_config_dir()."/".$cfile;
 		}
@@ -2268,7 +2290,7 @@ else {
 	foreach my $k ("hosts", "dbname", "user", "password", "query",
 		       "table", "where_field", "select_field",
 		       "additional_conditions") {
-		local $v = &get_real_value($value."_".$k);
+		my $v = &get_real_value($value."_".$k);
 		$conf->{$k} = $v;
 		}
 	if ($conf->{'query'} =~ /^select\s+(\S+)\s+from\s+(\S+)\s+where\s+(\S+)\s*=\s*'\%s'\s*(.*)/i && !$conf->{'table'}) {
@@ -2286,9 +2308,9 @@ return $conf;
 # Converts an LDAP config file name to a config hash ref
 sub ldap_value_to_conf
 {
-local ($value) = @_;
-local $conf;
-local $cfile = $value;
+my ($value) = @_;
+my $conf;
+my $cfile = $value;
 if ($cfile !~ /^\//) {
 	$cfile = &guess_config_dir()."/".$cfile;
 	}
@@ -2300,7 +2322,7 @@ return &get_backend_config($cfile);
 # Returns 1 if some map can have comments. Not allowed for MySQL and LDAP.
 sub can_map_comments
 {
-local ($name) = @_;
+my ($name) = @_;
 foreach my $tv (&get_maps_types_files(&get_real_value($name))) {
 	return 0 if (!&file_map_type($tv->[0]));
 	}
@@ -2311,7 +2333,7 @@ return 1;
 # Returns 1 if osme map has a file that can be manually edited
 sub can_map_manual
 {
-local ($name) = @_;
+my ($name) = @_;
 foreach my $tv (&get_maps_types_files(&get_real_value($name))) {
 	return 0 if (!&file_map_type($tv->[0]));
 	}
@@ -2322,15 +2344,15 @@ return 1;
 # Returns 1 if a map of some type is supported by Postfix
 sub supports_map_type
 {
-local ($type) = @_;
+my ($type) = @_;
 if (!scalar(@supports_map_type_cache)) {
-	@supports_map_type = ( );
-	open(POSTCONF, "$config{'postfix_config_command'} -m |");
-	while(<POSTCONF>) {
+	@supports_map_type_cache = ( );
+	open(my $postconffh, "-|", "$config{'postfix_config_command'} -m");
+	while(<$postconffh>) {
 		s/\r|\n//g;
 		push(@supports_map_type_cache, $_);
 		}
-	close(POSTCONF);
+	close($postconffh);
 	}
 return &indexoflc($type, @supports_map_type_cache) >= 0;
 }
@@ -2339,17 +2361,17 @@ return &indexoflc($type, @supports_map_type_cache) >= 0;
 # Converts multiple lines of text into LDAP attributes
 sub split_props
 {
-local ($text) = @_;
-local %pmap;
-foreach $p (split(/\t+/, $text)) {
+my ($text) = @_;
+my %pmap;
+foreach my $p (split(/\t+/, $text)) {
         if ($p =~ /^(\S+):\s*(.*)/) {
                 push(@{$pmap{$1}}, $2);
                 }
         }
-local @rv;
-local $k;
-foreach $k (keys %pmap) {
-        local $v = $pmap{$k};
+my @rv;
+my $k;
+foreach my $k (keys %pmap) {
+        my $v = $pmap{$k};
         if (@$v == 1) {
                 push(@rv, $k, $v->[0]);
                 }
@@ -2402,7 +2424,7 @@ return ( "check_client_access",
 
 sub file_map_type
 {
-local ($type) = @_;
+my ($type) = @_;
 return 1 if ($type eq 'hash' || $type eq 'regexp' || $type eq 'pcre' ||
 	     $type eq 'btree' || $type eq 'dbm' || $type eq 'cidr' ||
 	     $type eq 'lmdb');
@@ -2413,13 +2435,13 @@ return 0;
 # Looks up the value of a named property in a list
 sub in_props
 {
-local ($props, $name) = @_;
+my ($props, $name) = @_;
 for(my $i=0; $i<@$props; $i++) {
 	if (lc($props->[$i]) eq lc($name)) {
 		return $props->[$i+1];
 		}
 	}
-return undef;
+return;
 }
 
 # For calling from aliases-lib only
@@ -2460,13 +2482,13 @@ push(@rv, &get_maps_files("relay_recipient_maps"));
 push(@rv, &get_maps_files("smtpd_sender_restrictions"));
 
 # Add other files in /etc/postfix
-local $cdir = &guess_config_dir();
-opendir(DIR, $cdir);
-foreach $f (readdir(DIR)) {
+my $cdir = &guess_config_dir();
+opendir(my $cdirh, $cdir);
+foreach my $f (readdir($cdirh)) {
 	next if ($f eq "." || $f eq ".." || $f =~ /\.(db|dir|pag)$/i);
 	push(@rv, "$cdir/$f");
 	}
-closedir(DIR);
+closedir($cdirh);
 
 # Add TLS files
 foreach my $o ("smtpd_tls_cert_file", "smtpd_tls_key_file","smtpd_tls_CAfile") {

--- a/postfix/postfix-lib.pl
+++ b/postfix/postfix-lib.pl
@@ -682,7 +682,6 @@ sub regenerate_aliases
     }
     else
     {
-	my $map;
 	foreach my $map (get_maps_types_files(get_real_value("alias_maps")))
 	{
 	    if (&file_map_type($map->[0])) {
@@ -2369,7 +2368,6 @@ foreach my $p (split(/\t+/, $text)) {
                 }
         }
 my @rv;
-my $k;
 foreach my $k (keys %pmap) {
         my $v = $pmap{$k};
         if (@$v == 1) {

--- a/postfix/postinstall.pl
+++ b/postfix/postinstall.pl
@@ -1,4 +1,7 @@
-require 'postfix-lib.pl';
+require 'postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($version_file);
 
 sub module_install
 {

--- a/postfix/rate.cgi
+++ b/postfix/rate.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-rate.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, %access, %text);
 
 
 $access{'rate'} || &error($text{'rate_ecannot'});

--- a/postfix/reload.cgi
+++ b/postfix/reload.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Have Postfix re-read its config
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %text);
 
 $access{'startstop'} || &error($text{'reload_ecannot'});
 &error_setup($text{'reload_efailed'});

--- a/postfix/relocated.cgi
+++ b/postfix/relocated.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-relocated.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 &ReadParse();
 
 $access{'relocated'} || &error($text{'relocated_ecannot'});

--- a/postfix/resource.cgi
+++ b/postfix/resource.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-resource.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, %access, %text);
 
 
 $access{'resource'} || &error($text{'resource_ecannot'});

--- a/postfix/sasl.cgi
+++ b/postfix/sasl.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Show SMTP authentication related parameters
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $level, $no_, $none, $pmap, $postfix_version, $rh, $rpass, $ruser, %access, @cbs, %opts, %recip, %relay, %text);
 
 $access{'sasl'} || &error($text{'sasl_ecannot'});
 &ui_print_header(undef, $text{'sasl_title'}, "");
@@ -23,7 +26,7 @@ print &ui_table_start($text{'sasl_title'}, "width=100%", 2);
 %opts = map { $_, 1 }
 	    split(/[\s,]+/, &get_current_value("smtpd_sasl_security_options"));
 @cbs = ( );
-foreach $o ("noanonymous", "noplaintext", "noactive", "nodictionary", "forward_secrecy") {
+foreach my $o ("noanonymous", "noplaintext", "noactive", "nodictionary", "forward_secrecy") {
 	push(@cbs, &ui_checkbox("sasl_opts", $o, $text{'sasl_'.$o}, $opts{$o}));
 	}
 print &ui_table_row($text{'sasl_opts'}, join("<br>\n", @cbs), 3);
@@ -32,7 +35,7 @@ print &ui_table_row($text{'sasl_opts'}, join("<br>\n", @cbs), 3);
 %recip = map { $_, 1 }
 	    split(/[\s,]+/, &get_current_value("smtpd_recipient_restrictions"));
 @cbs = ( );
-foreach $o (&list_smtpd_restrictions()) {
+foreach my $o (&list_smtpd_restrictions()) {
 	push(@cbs, &ui_checkbox("sasl_recip", $o, $text{'sasl_'.$o},
 				$recip{$o}));
 	}
@@ -42,7 +45,7 @@ print &ui_table_row($text{'sasl_recip'}, join("<br>\n", @cbs), 3);
 %relay = map { $_, 1 }
 	    split(/[\s,]+/, &get_current_value("smtpd_relay_restrictions"));
 @cbs = ( );
-foreach $o (&list_smtpd_restrictions()) {
+foreach my $o (&list_smtpd_restrictions()) {
 	push(@cbs, &ui_checkbox("sasl_relay", $o, $text{'sasl_'.$o},
 				$relay{$o}));
 	}

--- a/postfix/save_alias.cgi
+++ b/postfix/save_alias.cgi
@@ -6,7 +6,10 @@
 # Save, modify, delete an alias for Postfix
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, $i, $loga, $module_config_directory, $t, $v, %access, @afiles, @aliases, %in, %newa, %text, @values);
 &ReadParse();
 
 $access{'aliases'} || &error($text{'aliases_ecannot'});

--- a/postfix/save_alias.cgi
+++ b/postfix/save_alias.cgi
@@ -18,21 +18,22 @@ $access{'aliases'} || &error($text{'aliases_ecannot'});
 # Get the alias (if editing or deleting)
 @afiles = &get_aliases_files(&get_current_value("alias_maps"));
 @aliases = &list_postfix_aliases();
+my $alias;
 if (!$in{'new'}) {
-	$a = $aliases[$in{'num'}];
+	$alias = $aliases[$in{'num'}];
 	}
 &lock_alias_files(\@afiles);
 
 if ($in{'delete'}) {
 	# delete some alias
-	&delete_postfix_alias($a);
-	$loga = $a;
+	&delete_postfix_alias($alias);
+	$loga = $alias;
 	}
 else {
 	# saving or creating .. check inputs
 	$in{'name'} =~ /^[^:@ ]+$/ ||
 		&error(&text('asave_eaddr', $in{'name'}));
-	if ($in{'new'} || uc($a->{'name'}) ne uc($in{'name'})) {
+	if ($in{'new'} || uc($alias->{'name'}) ne uc($in{'name'})) {
 		# is this name taken?
 		for($i=0; $i<@aliases; $i++) {
 			if (uc($in{'name'}) eq uc($aliases[$i]->{'name'})) {
@@ -89,7 +90,7 @@ else {
 		&create_postfix_alias(\%newa);
 		}
 	else {
-		&modify_postfix_alias($a, \%newa);
+		&modify_postfix_alias($alias, \%newa);
 		}
 	$loga = \%newa;
 	}

--- a/postfix/save_client.cgi
+++ b/postfix/save_client.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Save SMTP authentication options
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %newopts, %oldopts, @opts, %text, @v);
 
 &ReadParse();
 
@@ -23,7 +26,7 @@ else {
 	%newopts = map { $_, 1 } split(/\0/, $in{'client'});
 
 	# Save boolean options
-	foreach $o (&list_client_restrictions()) {
+	foreach my $o (&list_client_restrictions()) {
 		if ($newopts{$o} && !$oldopts{$o}) {
 			push(@opts, $o);
 			}
@@ -33,9 +36,9 @@ else {
 		}
 
 	# Save options with values
-	foreach $o (&list_multi_client_restrictions()) {
+	foreach my $o (&list_multi_client_restrictions()) {
 		# Find all current positions
-		local @pos;
+		my @pos;
 		for(my $i=0; $i<@opts; $i++) {
 			push(@pos, $i) if ($opts[$i] eq $o);
 			}

--- a/postfix/save_manual.cgi
+++ b/postfix/save_manual.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Update a manually edited map file
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, @files, %in, %text);
 &ReadParseMime();
 &error_setup($text{'manual_err'});
 $access{'manual'} || &error($text{'manual_ecannot'});
@@ -10,9 +13,10 @@ $access{'manual'} || &error($text{'manual_ecannot'});
 
 # Save the data
 $in{'data'} =~ s/\r//g;
-&open_lock_tempfile(FILE, ">$in{'file'}");
-&print_tempfile(FILE, $in{'data'});
-&close_tempfile(FILE);
+my $filefh = "FILE";
+&open_lock_tempfile($filefh, ">$in{'file'}");
+&print_tempfile($filefh, $in{'data'});
+&close_tempfile($filefh);
 
 # Regenerate map
 &regenerate_map_table($in{'map_name'});

--- a/postfix/save_map.cgi
+++ b/postfix/save_map.cgi
@@ -6,7 +6,10 @@
 # Save, modify, delete a map for Postfix
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($action, $err, $logmap, $nfunc, $vfunc, $whatfailed, %access, %in, %text);
 
 &ReadParse();
 
@@ -21,7 +24,7 @@ my $add = 1; my %map;
 ## added to split main_parameter:sub_parameter
 my ($mainparm,$subparm)=split /:/,$in{'map_name'};
 
-foreach $trans (@{$maps})
+foreach my $trans (@{$maps})
 {
     if ($trans->{'number'} == $in{'num'}) { $add = 0; %map = %{$trans}; }
 }
@@ -75,7 +78,7 @@ if ($in{'delete'})
 elsif ($add == 0)
 {
     # modify an existing map
-    local %newmap = ( 'name' => $in{'name'},
+    my %newmap = ( 'name' => $in{'name'},
 		      'value' => $in{'value'},
 		      'cmt' => $in{'cmt'} );
     &modify_mapping($in{'map_name'}, \%map, \%newmap);
@@ -85,7 +88,7 @@ elsif ($add == 0)
 else
 {
     # add a new map -- much more easy! :-)
-    local %newmap = ( 'name' => $in{'name'},
+    my %newmap = ( 'name' => $in{'name'},
 		      'value' => $in{'value'},
 		      'cmt' => $in{'cmt'} );
     &create_mapping($in{'map_name'}, \%newmap);

--- a/postfix/save_master.cgi
+++ b/postfix/save_master.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Create, update or delete a server process
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($clash, $err, $master, $prog, %access, %config, %in, %text);
 $access{'master'} || &error($text{'master_ecannot'});
 &ReadParse();
 &error_setup($text{'master_err'});

--- a/postfix/save_opts.cgi
+++ b/postfix/save_opts.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_aliases.cgi
+++ b/postfix/save_opts_aliases.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for aliases
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_bcc.cgi
+++ b/postfix/save_opts_bcc.cgi
@@ -1,6 +1,9 @@
 #!/usr/local/bin/perl
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_body.cgi
+++ b/postfix/save_opts_body.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for virtual tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_canonical.cgi
+++ b/postfix/save_opts_canonical.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for canonical tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_dependent.cgi
+++ b/postfix/save_opts_dependent.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for sender transport maps
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_header.cgi
+++ b/postfix/save_opts_header.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for virtual tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_misc.cgi
+++ b/postfix/save_opts_misc.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special case in which we need to regenerate the relocated table
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_relocated.cgi
+++ b/postfix/save_opts_relocated.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for relocated tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_sni.cgi
+++ b/postfix/save_opts_sni.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for sni tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_transport.cgi
+++ b/postfix/save_opts_transport.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for transport tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_opts_virtual.cgi
+++ b/postfix/save_opts_virtual.cgi
@@ -6,7 +6,10 @@
 # Save Postfix options ; special because for virtual tables
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, $virtual_maps, %access, %in, %text);
 
 &ReadParse();
 

--- a/postfix/save_sasl.cgi
+++ b/postfix/save_sasl.cgi
@@ -1,7 +1,10 @@
 #!/usr/local/bin/perl
 # Save SMTP authentication options
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, $newmap, $old, $pmap, $postfix_version, $rh, %access, %in, %newrecip, %newrelay, @opts, @recip, @relay, %text);
 
 &ReadParse();
 
@@ -36,7 +39,7 @@ if (!$in{'login_none'}) {
 # Save recipient options that we care about
 @recip = split(/[\s,]+/, &get_current_value("smtpd_recipient_restrictions"));
 %newrecip = map { $_, 1 } split(/\0/, $in{'sasl_recip'});
-foreach $o (&list_smtpd_restrictions()) {
+foreach my $o (&list_smtpd_restrictions()) {
 	if ($newrecip{$o}) {
 		push(@recip, $o) if (&indexof($o, @recip) < 0);
 		}
@@ -49,7 +52,7 @@ foreach $o (&list_smtpd_restrictions()) {
 # Save relay options that we care about
 @relay = split(/[\s,]+/, &get_current_value("smtpd_relay_restrictions"));
 %newrelay = map { $_, 1 } split(/\0/, $in{'sasl_relay'});
-foreach $o (&list_smtpd_restrictions()) {
+foreach my $o (&list_smtpd_restrictions()) {
 	if ($newrelay{$o}) {
 		push(@relay, $o) if (&indexof($o, @relay) < 0);
 		}

--- a/postfix/smtp.cgi
+++ b/postfix/smtp.cgi
@@ -7,7 +7,10 @@
 #
 # << Here are all options seen in Postfix sample-smtp.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $inet, $level, $no_, $none, $postfix_version, $pref, %access, %inet, @opts, %text);
 
 
 $access{'smtp'} || &error($text{'smtp_ecannot'});

--- a/postfix/smtpd.cgi
+++ b/postfix/smtpd.cgi
@@ -8,7 +8,10 @@
 #
 # << Here are all options seen in Postfix sample-smtpd.cf >>
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($default, $no_, $none, %access, %text);
 &ReadParse();
 
 $access{'smtpd'} || &error($text{'smtpd_ecannot'});

--- a/postfix/sni.cgi
+++ b/postfix/sni.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-sni.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 &ReadParse();
 
 $access{'sni'} || &error($text{'sni_ecannot'});

--- a/postfix/start.cgi
+++ b/postfix/start.cgi
@@ -5,7 +5,10 @@
 #
 # Start postfix
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %text);
 
 $access{'startstop'} || &error($text{'start_ecannot'});
 &error_setup($text{'start_efailed'});

--- a/postfix/stop.cgi
+++ b/postfix/stop.cgi
@@ -5,7 +5,10 @@
 # 
 # Stop postfix
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($err, %access, %text);
 
 $access{'startstop'} || &error($text{'stop_ecannot'});
 &error_setup($text{'stop_efailed'});

--- a/postfix/t/perlcritic.t
+++ b/postfix/t/perlcritic.t
@@ -1,0 +1,72 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    eval { require Perl::Critic; 1 }
+        or plan skip_all => 'Perl::Critic not installed';
+}
+
+use File::Find;
+
+sub script_dir
+{
+    my $path = $0;
+    if ($path =~ m{^/}) {
+        $path =~ s{/[^/]+$}{};
+        return $path;
+    }
+    my $cwd = `pwd`;
+    chomp($cwd);
+    if ($path =~ m{/}) {
+        $path =~ s{/[^/]+$}{};
+        return $cwd.'/'.$path;
+    }
+    return $cwd;
+}
+
+my $bindir = script_dir();
+my $module_dir = "$bindir/..";
+chdir($module_dir) or die "chdir: $!";
+
+my @files;
+find(
+    sub {
+        # Skip symlinks: several postfix files (aliases-lib.pl, autoreply.pl,
+        # filter.pl, edit_*file.cgi, save_*file.cgi, boxes-lib.pl) are symlinks
+        # into the sendmail and mailboxes modules. Those belong to other
+        # modules and are linted by their own test suites.
+        return if -l;
+        return if -d;
+        return unless /\.(pl|cgi)\z/;
+        # ".pl" is also the Polish translation suffix in Webmin. Skip
+        # "<file>.pl" when a sibling "<file>" (no extension) exists, so
+        # data files like config.info.pl and module.info.pl are not linted
+        # as Perl. (Same heuristic as the repo-root compile.t.)
+        if (/^(.*)\.pl\z/ && -e $1) {
+            return;
+        }
+        push(@files, $File::Find::name);
+    },
+    '.'
+);
+
+@files = sort @files;
+if (!@files) {
+    plan skip_all => 'no perl files to check';
+}
+
+my $critic = Perl::Critic->new(
+    -profile => "$bindir/../../.perlcriticrc",
+);
+
+foreach my $file (@files) {
+    my @violations = $critic->critique($file);
+    is(scalar @violations, 0, "$file perlcritic");
+    if (@violations) {
+        diag join("", @violations);
+    }
+}
+
+done_testing();

--- a/postfix/t/run-tests.t
+++ b/postfix/t/run-tests.t
@@ -1,0 +1,249 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(abs_path);
+use File::Temp qw(tempdir);
+
+sub script_dir
+{
+    my $path = $0;
+    if ($path =~ m{^/}) {
+        $path =~ s{/[^/]+$}{};
+        return $path;
+    }
+    my $cwd = `pwd`;
+    chomp($cwd);
+    if ($path =~ m{/}) {
+        $path =~ s{/[^/]+$}{};
+        return $cwd.'/'.$path;
+    }
+    return $cwd;
+}
+
+my $bindir  = script_dir();
+my $rootdir = abs_path("$bindir/../..") or die "rootdir: $!";
+
+my $confdir = tempdir(CLEANUP => 1);
+my $vardir  = tempdir(CLEANUP => 1);
+
+# Global Webmin config
+open(my $cfh, ">", "$confdir/config") or die "config: $!";
+print $cfh "os_type=linux\nos_version=0\n";
+close($cfh);
+open(my $vfh, ">", "$confdir/var-path") or die "var-path: $!";
+print $vfh "$vardir\n";
+close($vfh);
+
+# A main.cf to drive the config parser
+my $maincf   = "$confdir/main.cf";
+my $mastercf = "$confdir/master.cf";
+open(my $mc, ">", $maincf) or die "main.cf: $!";
+print $mc <<'EOF';
+myhostname = mail.example.com
+mydestination = example.com,
+	mail.example.com,
+	localhost
+compatibility_level = 2
+util_lt = {{$compatibility_level} < {3} ? {old} : {new}}
+util_ge = {{$compatibility_level} >= {3} ? {high} : {low}}
+util_eq = {{$compatibility_level} == {2} ? {match} : {nomatch}}
+subtest = key1 valueA key2 valueB
+alias_maps = hash:/etc/postfix/aliases, hash:/etc/aliases
+EOF
+close($mc);
+
+# A master.cf with one enabled and one disabled service, plus a continuation
+open(my $ms, ">", $mastercf) or die "master.cf: $!";
+print $ms <<'EOF';
+smtp      inet  n       -       y       -       -       smtpd
+#qmgr     unix  n       -       n       300     1       qmgr
+pickup    unix  n       -       y       60      1       pickup
+  -o content_filter=foo
+EOF
+close($ms);
+
+# Per-module config
+mkdir "$confdir/postfix" or die "postfix confdir: $!";
+open(my $mod, ">", "$confdir/postfix/config") or die "module config: $!";
+print $mod "postfix_config_file=$maincf\n";
+print $mod "postfix_master=$mastercf\n";
+print $mod "postfix_config_command=/bin/true\n";
+print $mod "postfix_control_command=/bin/true\n";
+print $mod "prefix_cmts=0\n";
+close($mod);
+
+# Pre-seed the version file so loading the lib does not shell out to postconf.
+open(my $ver, ">", "$confdir/postfix/version") or die "version: $!";
+print $ver "3.4.0\n";
+close($ver);
+
+$ENV{'WEBMIN_CONFIG'}          = $confdir;
+$ENV{'WEBMIN_VAR'}             = $vardir;
+$ENV{'FOREIGN_MODULE_NAME'}    = 'postfix';
+$ENV{'FOREIGN_ROOT_DIRECTORY'} = $rootdir;
+
+chdir("$bindir/..") or die "chdir: $!";
+
+require "$bindir/../postfix-lib.pl";
+our (%config, $postfix_version, $virtual_maps, $ldap_timeout, $config_dir);
+
+# --- load-time globals -----------------------------------------------------
+is($postfix_version, '3.4.0', 'postfix_version read from version file');
+is($virtual_maps, 'virtual_alias_maps', 'virtual_maps for >= 2.x');
+is($ldap_timeout, 'ldap_timeout', 'ldap_timeout for >= 2.x');
+is($config_dir, $confdir, 'guess_config_dir is dirname of main.cf');
+
+# --- file_map_type ---------------------------------------------------------
+ok(file_map_type('hash'),  'hash is a file map type');
+ok(file_map_type('pcre'),  'pcre is a file map type');
+ok(file_map_type('cidr'),  'cidr is a file map type');
+ok(!file_map_type('mysql'),'mysql is not a file map type');
+ok(!file_map_type('ldap'), 'ldap is not a file map type');
+
+# --- get_maps_types_files --------------------------------------------------
+is_deeply([ get_maps_types_files('hash:/etc/postfix/canonical') ],
+          [ [ 'hash', '/etc/postfix/canonical' ] ],
+          'single type:file parsed');
+is_deeply([ get_maps_types_files(
+                'hash:/etc/postfix/canonical, proxy:pcre:/etc/postfix/x') ],
+          [ [ 'hash', '/etc/postfix/canonical' ],
+            [ 'pcre', '/etc/postfix/x' ] ],
+          'multiple maps and proxy: prefix parsed');
+is_deeply([ get_maps_types_files('mysql:/etc/postfix/m.cf') ],
+          [ [ 'mysql', '/etc/postfix/m.cf' ] ],
+          'mysql backend type:file parsed');
+is_deeply([ get_maps_types_files('') ], [],
+          'empty value yields no maps');
+is_deeply([ get_maps_types_files('garbage-without-colon') ], [],
+          'unparseable value yields no maps');
+
+# --- get_maps_files (path extraction) --------------------------------------
+is_deeply([ get_maps_files('hash:/etc/postfix/aliases,hash:/etc/aliases') ],
+          [ '/etc/postfix/aliases', '/etc/aliases' ],
+          'get_maps_files extracts both file paths');
+is_deeply([ get_maps_files('static:foo') ], [],
+          'get_maps_files ignores non-path map values');
+
+# --- get_current_value (main.cf parser) ------------------------------------
+is(get_current_value('myhostname', 1), 'mail.example.com',
+   'single-line parameter parsed');
+my $dest = get_current_value('mydestination', 1);
+like($dest, qr/example\.com/, 'continuation line: first value present');
+like($dest, qr/localhost/,    'continuation line: trailing value joined');
+is(get_current_value('no_such_param', 1), undef,
+   'unknown parameter with nodef returns undef (no postconf fallback)');
+is(get_current_value('subtest:key1', 1), 'valueA',
+   'sub-parameter extraction (foo:bar) returns value after the key');
+
+# --- resolve_current_value (compatibility_level conditionals) --------------
+# Exercises the operator-dispatch rewrite of the old stringy eval.
+is(resolve_current_value('util_lt'), 'old',
+   'resolve "<": level 2 is < 3, takes true branch');
+is(resolve_current_value('util_ge'), 'low',
+   'resolve ">=": level 2 is not >= 3, takes false branch');
+is(resolve_current_value('util_eq'), 'match',
+   'resolve "==": level 2 == 2, takes true branch');
+is(resolve_current_value('myhostname'), 'mail.example.com',
+   'resolve passes through a plain value unchanged');
+
+# --- master.cf parser + serializer -----------------------------------------
+my $master = get_master_config();
+is(ref($master), 'ARRAY', 'get_master_config returns array ref');
+is(scalar(@$master), 3, 'three service entries parsed');
+
+my ($smtp)   = grep { $_->{'name'} eq 'smtp' } @$master;
+my ($qmgr)   = grep { $_->{'name'} eq 'qmgr' } @$master;
+my ($pickup) = grep { $_->{'name'} eq 'pickup' } @$master;
+
+ok($smtp,  'smtp service parsed');
+ok($smtp->{'enabled'}, 'smtp is enabled');
+is($smtp->{'type'},    'inet', 'smtp type');
+is($smtp->{'chroot'},  'y',    'smtp chroot column');
+is($smtp->{'command'}, 'smtpd','smtp command');
+
+ok($qmgr, 'commented service still parsed');
+ok(!$qmgr->{'enabled'}, 'commented service is disabled');
+
+ok($pickup, 'pickup service parsed');
+is($pickup->{'command'}, 'pickup -o content_filter=foo',
+   'continuation line appended to command');
+
+# master_line round-trips an entry back to its on-disk form
+is(master_line($smtp),
+   "smtp\tinet\tn\t-\ty\t-\t-\tsmtpd",
+   'master_line serializes an enabled service with tabs');
+is(master_line($qmgr),
+   "#qmgr\tunix\tn\t-\tn\t300\t1\tqmgr",
+   'master_line prefixes a disabled service with #');
+
+# --- is_table_comment / make_table_comment ---------------------------------
+{
+    local $config{'prefix_cmts'} = 0;
+    is(is_table_comment('# hello world'), 'hello world',
+       'plain comment text extracted when prefix_cmts off');
+    is_deeply([ make_table_comment('a note') ], [ '# a note' ],
+       'make_table_comment emits a plain # line');
+    is_deeply([ make_table_comment('') ], [],
+       'make_table_comment emits nothing for empty comment');
+}
+{
+    local $config{'prefix_cmts'} = 1;
+    is(is_table_comment('# Webmin: tagged'), 'tagged',
+       'Webmin-tagged comment extracted when prefix_cmts on');
+    is(is_table_comment('# untagged'), undef,
+       'untagged comment ignored when prefix_cmts on');
+    is_deeply([ make_table_comment('z') ], [ '# Webmin: z' ],
+       'make_table_comment emits a Webmin-tagged line when prefix_cmts on');
+}
+
+# --- in_props --------------------------------------------------------------
+is(in_props([ qw(cn foo objectClass top) ], 'objectClass'), 'top',
+   'in_props returns value following a matched name');
+is(in_props([ qw(cn foo) ], 'mail'), undef,
+   'in_props returns undef for an absent name');
+is(in_props([ qw(CN foo) ], 'cn'), 'foo',
+   'in_props matches case-insensitively');
+
+# --- get_ldap_key ----------------------------------------------------------
+is_deeply([ get_ldap_key({}) ],
+          [ 'mailacceptinggeneralid', '(mailacceptinggeneralid=*)' ],
+          'get_ldap_key default attribute and filter');
+is_deeply([ get_ldap_key({ 'query_filter' => 'mail=%s' }) ],
+          [ 'mail', '(mail=*)' ],
+          'get_ldap_key derives attribute and filter from query_filter');
+
+# --- make_map_ldap_dn ------------------------------------------------------
+{
+    local $config{'ldap_doms'} = 1;       # allow sub-domain DNs
+    local $config{'ldap_id'}   = undef;   # default to cn
+    my $conf = { 'search_base' => 'dc=example,dc=com', 'scope' => 'sub' };
+    is(make_map_ldap_dn({ 'name' => 'user@dom.com' }, $conf),
+       'cn=user,cn=dom.com,dc=example,dc=com',
+       'make_map_ldap_dn builds a per-user DN inside a domain');
+    is(make_map_ldap_dn({ 'name' => '@dom.com' }, $conf),
+       'cn=default,cn=dom.com,dc=example,dc=com',
+       'make_map_ldap_dn builds a catch-all DN for a domain');
+    is(make_map_ldap_dn({ 'name' => 'literal' }, $conf),
+       'cn=literal,dc=example,dc=com',
+       'make_map_ldap_dn builds a flat DN for a non-address name');
+}
+
+# --- get_backend_config ----------------------------------------------------
+my $backend = "$confdir/mysql.cf";
+open(my $bfh, ">", $backend) or die "backend: $!";
+print $bfh "user = postfix\npassword = secret\n# a comment\nhosts = localhost\n";
+close($bfh);
+my $bc = get_backend_config($backend);
+is($bc->{'user'},     'postfix',   'backend config user parsed');
+is($bc->{'password'}, 'secret',    'backend config password parsed');
+is($bc->{'hosts'},    'localhost', 'backend config hosts parsed');
+
+# --- list_smtpd_restrictions (version-dependent constant) ------------------
+my @restr = list_smtpd_restrictions();
+ok((grep { $_ eq 'permit_mynetworks' } @restr),
+   'smtpd restrictions include permit_mynetworks');
+ok((grep { $_ eq 'reject_unknown_reverse_client_hostname' } @restr),
+   '>= 2.3 uses reject_unknown_reverse_client_hostname');
+
+done_testing();

--- a/postfix/transport.cgi
+++ b/postfix/transport.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-transport.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our (%access, %text);
 &ReadParse();
 
 $access{'transport'} || &error($text{'transport_ecannot'});

--- a/postfix/view_mailq.cgi
+++ b/postfix/view_mailq.cgi
@@ -2,8 +2,11 @@
 # view_mailq.cgi
 # Display some message from the mail queue
 
-require './postfix-lib.pl';
-require './boxes-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($body, $bodyhtml, $desc, $mail, $rlink, $subs, %access, @attach, %config, %in, @sub, %text);
+require './boxes-lib.pl';    ## no critic
 &ReadParse();
 $access{'mailq'} || &error($text{'mailq_ecannot'});
 
@@ -12,9 +15,9 @@ $mail || &error($text{'mailq_egone'});
 &parse_mail($mail);
 @sub = split(/\0/, $in{'sub'});
 $subs = join("", map { "&sub=$_" } @sub);
-foreach $s (@sub) {
+foreach my $s (@sub) {
         # We are looking at a mail within a mail ..
-        local $amail = &extract_mail($mail->{'attach'}->[$s]->{'data'});
+        my $amail = &extract_mail($mail->{'attach'}->[$s]->{'data'});
         &parse_mail($amail);
         $mail = $amail;
         }
@@ -49,7 +52,7 @@ if ($in{'headers'}) {
 		print &ui_table_row($text{'mail_rfc'},
 				    &html_escape($mail->{'fromline'}));
 		}
-	foreach $h (@{$mail->{'headers'}}) {
+	foreach my $h (@{$mail->{'headers'}}) {
 		print &ui_table_row($h->[0],
 			&html_escape(&decode_mimewords($h->[1])), 1, [ "nowrap" ]);
 		}
@@ -84,7 +87,7 @@ print &ui_table_end();
 
 # Find body attachment
 @attach = @{$mail->{'attach'}};
-foreach $a (@attach) {
+foreach my $a (@attach) {
 	if ($a->{'type'} eq 'text/plain') {
 		$body = $a;
 		last;
@@ -93,7 +96,7 @@ foreach $a (@attach) {
 if ($body) {
 	print &ui_table_start($text{'view_body'}, "width=100%", 2);
 	$bodyhtml = "";
-	foreach $l (&wrap_lines($body->{'data'}, $config{'wrap_width'})) {
+	foreach my $l (&wrap_lines($body->{'data'}, $config{'wrap_width'})) {
 		$bodyhtml .= &link_urls_and_escape($l)."\n";
 		}
 	print &ui_table_row(undef, "<pre>".$bodyhtml."</pre>", 2);
@@ -107,7 +110,7 @@ if (@attach) {
 	print &ui_columns_start([ $text{'view_afile'}, $text{'view_atype'},
 				  $text{'view_asize'} ], 100, 0);
 	my $attachment_id;
-	foreach $a (@attach) {
+	foreach my $a (@attach) {
 		$attachment_id++;
 		if ($a->{'type'} eq 'message/rfc822') {
 			print &ui_columns_row([

--- a/postfix/virtual.cgi
+++ b/postfix/virtual.cgi
@@ -8,7 +8,10 @@
 # << Here are all options seen in Postfix sample-virtual.cf >>
 
 
-require './postfix-lib.pl';
+require './postfix-lib.pl';    ## no critic
+use strict;
+use warnings;
+our ($postfix_version, $virtual_maps, %access, %text);
 &ReadParse();
 
 $access{'virtual'} || &error($text{'virtual_ecannot'});


### PR DESCRIPTION
Another one that touches a lot of files, but is mostly low-risk.

  Added postfix/t/:
  - run-tests.t — 57 assertions exercising the pure/parsing logic in postfix-lib.pl: the main.cf parser (get_current_value incl. continuation lines and foo:bar sub-parameters), resolve_current_value's compatibility-level conditionals (all six operators), the master.cf parser + master_line serializer round-trip, get_maps_types_files/get_maps_files, file_map_type, is_table_comment/make_table_comment, in_props, get_ldap_key, make_map_ldap_dn, get_backend_config, and load-time globals. It seeds a fake module config so loading never shells out to postconf.
  - perlcritic.t — severity-5.
  
  All 127 tests pass; compile.t passes for all 80 postfix files.

  perlcritic / use strict

  Brought the lib and all 69 module-owned .cgi/.pl files to use strict; use warnings; at severity 5 (237 violations → 0), following the established convention: ## no critic on require '...' lines, our(...) for real globals, local→my for function-locals, lexical loop iterators, return undef→return, stringy eval "use M"→ block eval { require M; ... }, and 2-arg/bareword opens → 3-arg lexical opens.

  Bugs found

  Fixed (small, module-contained, behavior-preserving or clearly correct):
  - mailq_search.cgi — reflected XSS. The search term $in{'match'} was interpolated into <tt>…</tt> and passed to &text() (which does not HTML-escape). Now wrapped in &html_escape.
  - list_queue (postfix-lib.pl:1485) — $q->{'file'} = $file referenced an undefined $file; corrected to $path (the value never recorded; unused downstream).
  - supports_map_type — cleared @supports_map_type while the cache is @supports_map_type_cache (dead/wrong line); corrected.
  - reload_postfix — referenced an always-empty undeclared $out in its error return; dropped the dead $out ||.

  Surfaced, not changed (pre-existing, behavioral):
  - postfinger.cgi has a broken guard at line ~72: ("x…" != "x") compares two strings with the numeric !=, so it's always false and the "don't run in a group/world-writable dir" check never triggers. It also system("rm postfinger.*.d …") and writes postfinger.$$.{d,n} into the module CWD, and prints system-command output (hostname/uname/postconf/master.cf/ls) into HTML unescaped. None are web-user-controlled and the page is gated by  $access{'postfinger'} + readonly mode, but the logic is dubious. Fixing the != changes behavior, so I left it.
  - mailq_search.cgi strips ! from $in{'field'} on line 18, making the =~ /^!/ test on line 22 always false (the search_results3 message is dead). Cosmetic.
  - The symlinked edit_afile/ffile/rfile.cgi (owned by sendmail) interpolate $in{'file'} into HTML unescaped — an XSS, but it's another module → separate PR.