### PR TITLE
Improve alpine mysql/mariadb default support

### DIFF
--- a/mysql/CHANGELOG
+++ b/mysql/CHANGELOG
@@ -1,3 +1,5 @@
+---- Changes since 2.641 ----
+Added defaults for alpine linux and fix package installs
 ---- Changes since 1.140 ----
 The not null flag and a default value can be specified for fields in new tables.
 The form for creating an initial table in a new database is now the same as the one for adding a table to an existing database.

--- a/mysql/config-alpine-linux
+++ b/mysql/config-alpine-linux
@@ -1,0 +1,25 @@
+start_cmd=rc-service mariadb start
+mysql=/usr/bin/mariadb
+mysqld=/usr/bin/mariadbd
+mysqldump=/usr/bin/mysqldump
+mysqlimport=/usr/bin/mariadb-import
+mysql_libs=/usr/lib/mariadb/plugin
+mysqladmin=/usr/bin/mariadb-admin
+mysqlshow=/usr/bin/mariadb-show
+perpage=25
+style=1
+add_mode=1
+nodbi=0
+access=*: *
+blob_mode=0
+date_subs=0
+passwd_mode=0
+mysql_data=/var/lib/mysql
+max_dbs=50
+my_cnf=/etc/my.cnf
+max_text=1000
+nopwd=0
+webmin_subs=0
+ssl=0
+stop_cmd=rc-service mariadb stop
+

--- a/software/CHANGELOG
+++ b/software/CHANGELOG
@@ -1,5 +1,5 @@
 ---- Changes since 2.641 ----
-Fix mysql/mariadb package installs
+Fix Alpine Linux mysql/mariadb package installs names due missing server utils (means at least Alpine Linux package installation is supported since Alpine linux v 3.16 up to edge)
 ---- Changes since 1.130 ----
 Packages can now be installed directly from yum, if installed.
 The entire system can also be upgraded from yum.

--- a/software/CHANGELOG
+++ b/software/CHANGELOG
@@ -1,3 +1,5 @@
+---- Changes since 2.641 ----
+Fix mysql/mariadb package installs
 ---- Changes since 1.130 ----
 Packages can now be installed directly from yum, if installed.
 The entire system can also be upgraded from yum.

--- a/software/apk-lib.pl
+++ b/software/apk-lib.pl
@@ -364,7 +364,7 @@ sub update_system_resolve
 my ($name) = @_;
 return $name eq "apache" ? "apache2" :
        $name eq "dhcpd" ? "dhcp" :
-       $name eq "mysql" ? "mariadb mariadb-client" :
+       $name eq "mysql" ? "mariadb mariadb-client mariadb-server-utils" :
        $name eq "postgresql" ? "postgresql postgresql-client" :
        $name eq "openldap" ? "openldap openldap-clients" :
        $name eq "ldap" ? "openldap openldap-clients" :


### PR DESCRIPTION
* The MySQL module in Alpine it lacks default values. This change uses the necessary values ​​for the module to function.
* These values ​​work for any version of Alpine Linux from 3.8 to Edge, since MariaDB is and always has been the default package.
* The tools server package was included in the package instalation
* Missing changelog entries were included
* closes #2758 