### PR TITLE
Don't fork. systemd prefers one process.

### DIFF
--- a/webmin-systemd
+++ b/webmin-systemd
@@ -10,7 +10,7 @@ ExecStart=WEBMIN_LIBDIR/miniserv.pl --nofork WEBMIN_CONFIG/miniserv.conf
 ExecReload=WEBMIN_KILLCMD -HUP $MAINPID
 Restart=on-failure
 RestartSec=2s
-TimeoutStopSec=120s
+TimeoutStopSec=300s
 
 [Install]
 WantedBy=multi-user.target

--- a/webmin-systemd
+++ b/webmin-systemd
@@ -5,11 +5,10 @@ After=network.target network-online.target
 
 [Service]
 Environment="PERLLIB=WEBMIN_LIBDIR"
-ExecStart=WEBMIN_LIBDIR/miniserv.pl WEBMIN_CONFIG/miniserv.conf
+ExecStart=WEBMIN_LIBDIR/miniserv.pl --nofork WEBMIN_CONFIG/miniserv.conf
 ExecStop=WEBMIN_KILLCMD $MAINPID
 ExecReload=WEBMIN_KILLCMD -HUP $MAINPID
 PIDFile=WEBMIN_VAR/miniserv.pid
-Type=forking
 Restart=always
 RestartSec=2s
 TimeoutSec=15s

--- a/webmin-systemd
+++ b/webmin-systemd
@@ -6,13 +6,10 @@ After=network.target network-online.target
 [Service]
 Environment="PERLLIB=WEBMIN_LIBDIR"
 ExecStart=WEBMIN_LIBDIR/miniserv.pl --nofork WEBMIN_CONFIG/miniserv.conf
-ExecStop=WEBMIN_KILLCMD $MAINPID
 ExecReload=WEBMIN_KILLCMD -HUP $MAINPID
-PIDFile=WEBMIN_VAR/miniserv.pid
-Restart=always
+Restart=on-failure
 RestartSec=2s
-TimeoutSec=15s
-TimeoutStopSec=300s
+TimeoutStopSec=120s
 
 [Install]
 WantedBy=multi-user.target

--- a/webmin-systemd
+++ b/webmin-systemd
@@ -4,6 +4,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
+Type=simple
 Environment="PERLLIB=WEBMIN_LIBDIR"
 ExecStart=WEBMIN_LIBDIR/miniserv.pl --nofork WEBMIN_CONFIG/miniserv.conf
 ExecReload=WEBMIN_KILLCMD -HUP $MAINPID


### PR DESCRIPTION
systemd does not want services to fork.

New versions of systemd have a race condition when fork happens, because of more locked down PID checking. Restart loop and error is:

```
Jun 13 18:27:47 fqdn systemd[1]: Starting usermin.service - Usermin server daemon...
░░ Subject: A start job for unit usermin.service has begun execution
░░ Defined-By: systemd
░░ Support: https://wiki.almalinux.org/Help-and-Support
░░ 
░░ A start job for unit usermin.service has begun execution.
░░ 
░░ The job identifier is 303.
Jun 13 18:27:48 fqdn systemd[1]: usermin.service: Can't open PID file '/var/usermin/miniserv.pid' (yet?) after start: Permission denied
Jun 13 18:28:02 fqdn systemd[1]: usermin.service: start operation timed out. Terminating.
Jun 13 18:28:02 fqdn systemd[1]: usermin.service: Failed with result 'timeout'.
░░ Subject: Unit failed
░░ Defined-By: systemd
░░ Support: https://wiki.almalinux.org/Help-and-Support
░░ 
░░ The unit usermin.service has entered the 'failed' state with result 'timeout'.
Jun 13 18:28:02 fqdn systemd[1]: Failed to start usermin.service - Usermin server daemon.
░░ Subject: A start job for unit usermin.service has failed
░░ Defined-By: systemd
░░ Support: https://wiki.almalinux.org/Help-and-Support
░░ 
░░ A start job for unit usermin.service has finished with a failure.
```

There's no reason to do the fork dance, systemd handles all that (and can capture STDOUT to the journal, if we don't redirect it).

The changes and their reasons:

Type=simple - No longer a `forking` service. systemd directly controls the process.
ExecStop removed - systemd manages the process, it can stop it., we don't need `kill`.
Restart=on-failure - preferred over "always", which can cause a restart loop that can be destructive...if it's failing because memory is tight it can cause cascading failures or failures in other services, and repeated failure/start loops always consume resources. on-failure is the more correct behavior for a non-critical service.
TimeoutSec removed - No need for this. Never was a need for this to be custom.