### PR TITLE
Register SNI callback on all SSL contexts, not just the default

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -4827,18 +4827,18 @@ foreach my $ip (keys %ssl_contexts) {
 # Ref: https://github.com/virtualmin/virtualmin-gpl/pull/1229
 if (defined(&Net::SSLeay::CTX_set_tlsext_servername_callback)) {
 	foreach my $ctx_key (keys %ssl_contexts) {
-	Net::SSLeay::CTX_set_tlsext_servername_callback(
-	    $ssl_contexts{$ctx_key}->{'ctx'},
-	    sub {
-		my $ssl = shift;
-		my $h = Net::SSLeay::get_servername($ssl);
-		my $c = $ssl_contexts{$h} ||
-			$h =~ /^[^\.]+\.(.*)$/ && $ssl_contexts{"*.$1"};
-		if ($c) {
-			Net::SSLeay::set_SSL_CTX($ssl, $c->{'ctx'});
-			}
-		});
-	}
+		Net::SSLeay::CTX_set_tlsext_servername_callback(
+		    $ssl_contexts{$ctx_key}->{'ctx'},
+		    sub {
+			my $ssl = shift;
+			my $h = Net::SSLeay::get_servername($ssl);
+			my $c = $ssl_contexts{$h} ||
+				$h =~ /^[^\.]+\.(.*)$/ && $ssl_contexts{"*.$1"};
+			if ($c) {
+				Net::SSLeay::set_SSL_CTX($ssl, $c->{'ctx'});
+				}
+			});
+		}
 	}
 return undef;
 }

--- a/miniserv.pl
+++ b/miniserv.pl
@@ -4823,10 +4823,12 @@ foreach my $ip (keys %ssl_contexts) {
 		}
 	}
 
-# Setup per-hostname SSL contexts on the main IP
+# Setup per-hostname SSL contexts on all IPs, not just the default
+# Ref: https://github.com/virtualmin/virtualmin-gpl/pull/1229
 if (defined(&Net::SSLeay::CTX_set_tlsext_servername_callback)) {
+	foreach my $ctx_key (keys %ssl_contexts) {
 	Net::SSLeay::CTX_set_tlsext_servername_callback(
-	    $ssl_contexts{"*"}->{'ctx'},
+	    $ssl_contexts{$ctx_key}->{'ctx'},
 	    sub {
 		my $ssl = shift;
 		my $h = Net::SSLeay::get_servername($ssl);
@@ -4836,6 +4838,7 @@ if (defined(&Net::SSLeay::CTX_set_tlsext_servername_callback)) {
 			Net::SSLeay::set_SSL_CTX($ssl, $c->{'ctx'});
 			}
 		});
+	}
 	}
 return undef;
 }


### PR DESCRIPTION
On servers with multiple domains sharing a dedicated IP, or where the server hostname resolves to an IP that has a different domain's ipcert entry, Webmin serves the wrong SSL certificate. The SNI hostname sent by the client is ignored for connections to dedicated IPs.

**Cause:** `setup_ssl_contexts()` in miniserv.pl registers `CTX_set_tlsext_servername_callback` only on the default (`*`) context. Per-IP contexts created from `ipcert` entries do not get the callback. When a client connects to a dedicated IP, miniserv uses the per-IP context directly, the SNI callback never fires, and the client receives whatever certificate is assigned to that IP regardless of the requested hostname.

**Fix:** Register the same SNI callback on every context in `%ssl_contexts`. The callback function is unchanged. Clients without SNI still receive the per-IP certificate (unchanged behavior). Clients with SNI get the correct certificate matched by hostname.

Related: https://github.com/virtualmin/virtualmin-gpl/pull/1229

If there are any further concerns, please do not hesitate to let me know.