### PR TITLE
Fix SELinux labeling for Webmin runtime data

### DIFF
--- a/makerpm.pl
+++ b/makerpm.pl
@@ -316,7 +316,7 @@ if [ "\$1" = 0 ]; then
 		# has taken it's place. Rename away the /etc/webmin directory
 		rm -rf /etc/webmin.rpmsave
 		mv /etc/webmin /etc/webmin.rpmsave
-		if command -v semanage >/dev/null 2>&1; then
+		if type semanage >/dev/null 2>&1; then
 			semanage fcontext -d "/var/webmin(/.*)?" >/dev/null 2>&1 || true
 		fi
 		rm -rf /var/webmin

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -316,7 +316,7 @@ if [ "\$1" = 0 ]; then
 		# has taken it's place. Rename away the /etc/webmin directory
 		rm -rf /etc/webmin.rpmsave
 		mv /etc/webmin /etc/webmin.rpmsave
-		if type semanage >/dev/null 2>&1; then
+		if command -v semanage >/dev/null 2>&1; then
 			semanage fcontext -d "/var/webmin(/.*)?" >/dev/null 2>&1 || true
 		fi
 		rm -rf /var/webmin

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -316,6 +316,9 @@ if [ "\$1" = 0 ]; then
 		# has taken it's place. Rename away the /etc/webmin directory
 		rm -rf /etc/webmin.rpmsave
 		mv /etc/webmin /etc/webmin.rpmsave
+		if command -v semanage >/dev/null 2>&1; then
+			semanage fcontext -d "/var/webmin(/.*)?" >/dev/null 2>&1 || true
+		fi
 		rm -rf /var/webmin
 	fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -663,9 +663,12 @@ if [ ! -f "$config_dir/.pre-install" ]; then
 fi
 
 # Test if we have systemd system
-systemctlcmd=$(command -v systemctl 2>/dev/null || :)
-if [ -x "$systemctlcmd" ]; then
-    initsys=$(cat /proc/1/comm 2>/dev/null)
+systemctlcmd=
+if type systemctl >/dev/null 2>&1; then
+    systemctlcmd=systemctl
+fi
+if [ "$systemctlcmd" != "" ]; then
+    initsys=`cat /proc/1/comm 2>/dev/null`
     if [ "$initsys" != "systemd" ]; then
         systemctlcmd=""
     fi
@@ -738,7 +741,7 @@ echo "echo Reloading Webmin server in $wadir" >>$config_dir/.reload-init
 echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.reload-init
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
 # Switch to systemd from init (intermediate)
-if [ "$killmodenonesh" = "1" ] && [ -x "$systemctlcmd" ]; then
+if [ "$killmodenonesh" = "1" ] && [ "$systemctlcmd" != "" ]; then
 	current_version=`cat "$config_dir/version" 2>/dev/null`
 	ancient_version=`echo $current_version 1.994 | awk '{if ($1 < $2) print 1; else print 0}'`
 	if [ "$ancient_version" = "1" ]; then
@@ -776,7 +779,7 @@ ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill 
 ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
 
 # For systemd create different start/stop scripts
-if [ -x "$systemctlcmd" ]; then
+if [ "$systemctlcmd" != "" ]; then
 	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 	# Start systemd
 	echo "#!/bin/sh" >$config_dir/start
@@ -959,7 +962,7 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $config_dir .."
 	rm -rf "$config_dir"
 	echo "Deleting $var_dir .."
-	if [ "$var_dir" = "/var/webmin" ] && command -v semanage >/dev/null 2>&1; then
+	if [ "$var_dir" = "/var/webmin" ] && type semanage >/dev/null 2>&1; then
 		semanage fcontext -d "/var/webmin(/.*)?" >/dev/null 2>&1 || true
 	fi
 	rm -rf "$var_dir"
@@ -1017,21 +1020,21 @@ fix_selinux_var_dir()
 	/var/webmin) ;;
 	*) return 0 ;;
 	esac
-	if ! command -v selinuxenabled >/dev/null 2>&1 ||
+	if ! type selinuxenabled >/dev/null 2>&1 ||
 	   ! selinuxenabled >/dev/null 2>&1; then
 		return 0
 	fi
 	restored=0
-	if command -v semanage >/dev/null 2>&1; then
+	if type semanage >/dev/null 2>&1; then
 		if semanage fcontext -m -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1 ||
 		   semanage fcontext -a -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1; then
-			if command -v restorecon >/dev/null 2>&1; then
+			if type restorecon >/dev/null 2>&1; then
 				restorecon -R "$selinux_var_dir" >/dev/null 2>&1 && restored=1
 			fi
 		fi
 	fi
 	# chcon is an immediate fallback only; semanage above makes it persistent.
-	if [ "$restored" != "1" ] && command -v chcon >/dev/null 2>&1; then
+	if [ "$restored" != "1" ] && type chcon >/dev/null 2>&1; then
 		chcon -R -t var_run_t "$selinux_var_dir" >/dev/null 2>&1 || true
 	fi
 	return 0

--- a/setup.sh
+++ b/setup.sh
@@ -663,15 +663,12 @@ if [ ! -f "$config_dir/.pre-install" ]; then
 fi
 
 # Test if we have systemd system
-systemctlcmd=
-if type systemctl >/dev/null 2>&1; then
-    systemctlcmd=systemctl
-fi
-if [ "$systemctlcmd" != "" ]; then
-    initsys=`cat /proc/1/comm 2>/dev/null`
-    if [ "$initsys" != "systemd" ]; then
-        systemctlcmd=""
-    fi
+systemctlcmd=`command -v systemctl 2>/dev/null`
+if [ -x "$systemctlcmd" ]; then
+	initsys=`cat /proc/1/comm 2>/dev/null`
+	if [ "$initsys" != "systemd" ]; then
+		systemctlcmd=""
+	fi
 fi
 
 # Re-generating main scripts
@@ -741,7 +738,7 @@ echo "echo Reloading Webmin server in $wadir" >>$config_dir/.reload-init
 echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.reload-init
 echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
 # Switch to systemd from init (intermediate)
-if [ "$killmodenonesh" = "1" ] && [ "$systemctlcmd" != "" ]; then
+if [ "$killmodenonesh" = "1" ] && [ -x "$systemctlcmd" ]; then
 	current_version=`cat "$config_dir/version" 2>/dev/null`
 	ancient_version=`echo $current_version 1.994 | awk '{if ($1 < $2) print 1; else print 0}'`
 	if [ "$ancient_version" = "1" ]; then
@@ -779,7 +776,7 @@ ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill 
 ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
 
 # For systemd create different start/stop scripts
-if [ "$systemctlcmd" != "" ]; then
+if [ -x "$systemctlcmd" ]; then
 	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 	# Start systemd
 	echo "#!/bin/sh" >$config_dir/start
@@ -962,7 +959,7 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $config_dir .."
 	rm -rf "$config_dir"
 	echo "Deleting $var_dir .."
-	if [ "$var_dir" = "/var/webmin" ] && type semanage >/dev/null 2>&1; then
+	if [ "$var_dir" = "/var/webmin" ] && command -v semanage >/dev/null 2>&1; then
 		semanage fcontext -d "/var/webmin(/.*)?" >/dev/null 2>&1 || true
 	fi
 	rm -rf "$var_dir"
@@ -1020,21 +1017,21 @@ fix_selinux_var_dir()
 	/var/webmin) ;;
 	*) return 0 ;;
 	esac
-	if ! type selinuxenabled >/dev/null 2>&1 ||
+	if ! command -v selinuxenabled >/dev/null 2>&1 ||
 	   ! selinuxenabled >/dev/null 2>&1; then
 		return 0
 	fi
 	restored=0
-	if type semanage >/dev/null 2>&1; then
+	if command -v semanage >/dev/null 2>&1; then
 		if semanage fcontext -m -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1 ||
 		   semanage fcontext -a -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1; then
-			if type restorecon >/dev/null 2>&1; then
+			if command -v restorecon >/dev/null 2>&1; then
 				restorecon -R "$selinux_var_dir" >/dev/null 2>&1 && restored=1
 			fi
 		fi
 	fi
 	# chcon is an immediate fallback only; semanage above makes it persistent.
-	if [ "$restored" != "1" ] && type chcon >/dev/null 2>&1; then
+	if [ "$restored" != "1" ] && command -v chcon >/dev/null 2>&1; then
 		chcon -R -t var_run_t "$selinux_var_dir" >/dev/null 2>&1 || true
 	fi
 	return 0

--- a/setup.sh
+++ b/setup.sh
@@ -959,6 +959,9 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $config_dir .."
 	rm -rf "$config_dir"
 	echo "Deleting $var_dir .."
+	if [ "$var_dir" = "/var/webmin" ] && command -v semanage >/dev/null 2>&1; then
+		semanage fcontext -d "/var/webmin(/.*)?" >/dev/null 2>&1 || true
+	fi
 	rm -rf "$var_dir"
 	echo "Done!"
 fi
@@ -1006,6 +1009,34 @@ for m in ldap-client ldap-server ldap-useradmin mailboxes mysql postgresql serve
 done
 echo ".. done"
 echo ""
+
+fix_selinux_var_dir()
+{
+	selinux_var_dir="$1"
+	case "$selinux_var_dir" in
+	/var/webmin) ;;
+	*) return 0 ;;
+	esac
+	if ! command -v selinuxenabled >/dev/null 2>&1 ||
+	   ! selinuxenabled >/dev/null 2>&1; then
+		return 0
+	fi
+	restored=0
+	if command -v semanage >/dev/null 2>&1; then
+		if semanage fcontext -m -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1 ||
+		   semanage fcontext -a -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1; then
+			if command -v restorecon >/dev/null 2>&1; then
+				restorecon -R "$selinux_var_dir" >/dev/null 2>&1 && restored=1
+			fi
+		fi
+	fi
+	# chcon is an immediate fallback only; semanage above makes it persistent.
+	if [ "$restored" != "1" ] && command -v chcon >/dev/null 2>&1; then
+		chcon -R -t var_run_t "$selinux_var_dir" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+fix_selinux_var_dir "$var_dir"
 
 # Save target directory if one was specified
 if [ "$wadir" != "$srcdir" ]; then


### PR DESCRIPTION
Hello Jamie,

This PR adds SELinux context handling for Webmin’s default runtime directory on EL systems.

Setup now persists and applies a `var_run_t` fcontext rule when SELinux is enabled, falls back safely when SELinux tooling is unavailable, and removes the local fcontext rule when `/var/webmin` is deleted during uninstall.

Discussed originally here:
https://forum.virtualmin.com/t/usermin-needs-selinux-fix/137474