### PR TITLE
net/linux-lib.pl: Fix bonding interface activation and use escape_shellarg

### DIFF
--- a/net/linux-lib.pl
+++ b/net/linux-lib.pl
@@ -276,14 +276,44 @@ if (!&has_command("ifconfig") && &has_command("ip")) {
 
 my $cmd;
 if (&has_command("ip")) {
+	# Create bonding device if it doesn't exist yet
+	if ($a->{'bond'} && !$old) {
+		my $out = &backquote_logged("ip link add ".&escape_shellarg($a->{'name'})." type bond 2>&1");
+		&error("Failed to create bond device : ".&html_escape($out)) if ($?);
+		if ($a->{'mode'}) {
+			$out = &backquote_logged("ip link set ".&escape_shellarg($a->{'name'})." type bond mode ".&escape_shellarg($a->{'mode'})." 2>&1");
+			&error("Failed to set bond mode : ".&html_escape($out)) if ($?);
+			}
+		if ($a->{'miimon'}) {
+			$out = &backquote_logged("ip link set ".&escape_shellarg($a->{'name'})." type bond miimon ".&escape_shellarg($a->{'miimon'})." 2>&1");
+			&error("Failed to set bond miimon : ".&html_escape($out)) if ($?);
+			}
+		if ($a->{'updelay'}) {
+			$out = &backquote_logged("ip link set ".&escape_shellarg($a->{'name'})." type bond updelay ".&escape_shellarg($a->{'updelay'})." 2>&1");
+			&error("Failed to set bond updelay : ".&html_escape($out)) if ($?);
+			}
+		if ($a->{'downdelay'}) {
+			$out = &backquote_logged("ip link set ".&escape_shellarg($a->{'name'})." type bond downdelay ".&escape_shellarg($a->{'downdelay'})." 2>&1");
+			&error("Failed to set bond downdelay : ".&html_escape($out)) if ($?);
+			}
+		foreach my $slave (split(/\s+/, $a->{'partner'})) {
+			$out = &backquote_logged("ip link set ".&escape_shellarg($slave)." down 2>&1");
+			&error("Failed to set slave down : ".&html_escape($out)) if ($?);
+			$out = &backquote_logged("ip link set ".&escape_shellarg($slave)." master ".&escape_shellarg($a->{'name'})." 2>&1");
+			&error("Failed to add bond slave : ".&html_escape($out)) if ($?);
+			}
+		$out = &backquote_logged("ip link set ".&escape_shellarg($a->{'name'})." up 2>&1");
+		&error("Failed to bring up bond device : ".&html_escape($out)) if ($?);
+		}
+
 	# If the IP is changing, first remove it then re-add
 	my $readd = 0;
 	if ($old && $old->{'address'}) {
 		if ($old->{'address'} ne $a->{'address'} ||
 		    $old->{'netmask'} ne $a->{'netmask'}) {
-			my $rcmd = "ip addr del ".quotemeta($old->{'address'}).
+			my $rcmd = "ip addr del ".&escape_shellarg($old->{'address'}).
 				   "/".&mask_to_prefix($old->{'netmask'}).
-				   " dev ".quotemeta($a->{'name'});
+				   " dev ".&escape_shellarg($a->{'name'});
 			&system_logged("$rcmd >/dev/null 2>&1");
 			$readd = 1;
 			}
@@ -294,19 +324,19 @@ if (&has_command("ip")) {
 
 	# Build ip command to add the new IP
 	if ($readd && $a->{'address'}) {
-		$cmd .= "ip addr add ".quotemeta($a->{'address'});
+		$cmd .= "ip addr add ".&escape_shellarg($a->{'address'});
 		if ($a->{'netmask'}) {
 			$cmd .= "/".&mask_to_prefix($a->{'netmask'});
 			}
 		if ($a->{'broadcast'}) {
-			$cmd .= " broadcast ".quotemeta($a->{'broadcast'});
+			$cmd .= " broadcast ".&escape_shellarg($a->{'broadcast'});
 			}
 		if($a->{'vlan'} == 1) {
-			$cmd .= " dev ".quotemeta($a->{'physical'}).".".
-				quotemeta($a->{'vlanid'});
+			$cmd .= " dev ".&escape_shellarg($a->{'physical'}).".".
+				&escape_shellarg($a->{'vlanid'});
 			}
 		else {
-			$cmd .= " dev ".quotemeta($a->{'name'});
+			$cmd .= " dev ".&escape_shellarg($a->{'name'});
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

On systems where the `ip` command path is taken in `activate_interface()` (which is now the default since `ip` is prioritized over `ifconfig`), activating a bonding interface fails with:

    Cannot find device "bond0"

This happens because the code attempts `ip addr add ... dev bond0` without first creating the bond device.

Additionally, `quotemeta()` is used for shell argument quoting, which escapes dots in IP addresses unnecessarily. While this doesn't break functionality (the shell strips the backslashes), `escape_shellarg()` is the correct function and produces cleaner log output.

## Fix

1. Create the bonding device (`ip link add ... type bond`) with proper mode/miimon/slave configuration before assigning the IP address.
2. Replace `quotemeta()` with `escape_shellarg()` in the `ip` command path.

## Testing

Tested on Debian 12 (bookworm) with bonding interface creation via the Network Configuration module.
