### PR TITLE
Fix to require trusted proxies for SSL client cert headers

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -1542,16 +1542,25 @@ if ($headerhost) {
 	$headerhost = undef if (!&check_ipaddress($headerhost) &&
 				!&check_ip6address($headerhost));
 	}
-# If trusted_proxies is configured, header-supplied client IP and SSL
-# client info are only honored when the direct TCP peer is in that list.
-# Otherwise drop them so an attacker reaching miniserv directly cannot
-# spoof X-Forwarded-For or X-SSL-Client-* to bypass auth.
-if ($config{'trust_real_ip'} && $config{'trusted_proxies'} ne '' &&
-    !&ip_match($acptip, $localip,
-	       split(/\s+/, $config{'trusted_proxies'}))) {
+# If trusted_proxies is configured, header-supplied client IP is only
+# honored when the direct TCP peer is in that list. Proxied SSL client
+# cert headers carry authentication identity, so only honor those from
+# an explicitly trusted proxy.
+my @trusted_proxies = split(/\s+/, $config{'trusted_proxies'} || "");
+my $trusted_proxy = @trusted_proxies &&
+	&ip_match($acptip, $localip, @trusted_proxies);
+my $trust_ssl_client_headers = $config{'trust_real_ip'} &&
+	!$config{'no_trust_ssl'} && $trusted_proxy;
+if ($config{'trust_real_ip'} && @trusted_proxies && !$trusted_proxy) {
 	print DEBUG "handle_request: peer $acptip not in trusted_proxies; ".
-		    "ignoring forwarding and SSL client headers\n";
+		    "ignoring forwarding headers\n";
 	$headerhost = undef;
+	}
+if (!$trust_ssl_client_headers) {
+	print DEBUG "handle_request: ignoring SSL client headers from ".
+		    "peer $acptip\n"
+		if ($header{'x-ssl-client-dn'} ||
+		    $header{'x-ssl-client-verify'});
 	delete $header{'x-ssl-client-dn'};
 	delete $header{'x-ssl-client-verify'};
 	}

--- a/webmin/postinstall.pl
+++ b/webmin/postinstall.pl
@@ -60,8 +60,12 @@ if (!-r $first_install_file || $miniserv{'login_script'} eq $record_login_cmd) {
 	$miniserv{'failed_script'} = $record_failed_cmd;
 	}
 
-# Disable trusting SSL certs unless already enabled
-if (!$miniserv{'trust_real_ip'} && !defined($miniserv{'no_trust_ssl'})) {
+# Disable trusting SSL certs unless already enabled. Legacy configs with
+# trust_real_ip but no trusted proxy cannot safely authenticate from
+# proxied SSL client cert headers.
+my @trusted_proxies = split(/\s+/, $miniserv{'trusted_proxies'} || "");
+if ((!$miniserv{'trust_real_ip'} || !@trusted_proxies) &&
+    !defined($miniserv{'no_trust_ssl'})) {
 	$miniserv{'no_trust_ssl'} = 1;
 	}
 


### PR DESCRIPTION
Hey Jamie!

This PR tightens handling of proxied SSL client certificate headers so they are only honored when Webmin is configured to trust SSL headers and the direct TCP peer matches an explicit `trusted_proxies` entry.

The change preserves legacy forwarded-IP behavior for `trust_real_ip`, but prevents ambiguous legacy configs with no trusted proxy from accepting spoofable `X-SSL-Client-*` headers as authentication identity. During postinstall, such legacy configs now default to `no_trust_ssl=1`.