### PR TITLE
net/linux-lib.pl: Fix VLAN interface activation with ip command

### DIFF
--- a/net/linux-lib.pl
+++ b/net/linux-lib.pl
@@ -242,9 +242,16 @@ sub activate_interface
 my ($a) = @_;
 my ($old) = grep { $_->{'fullname'} eq $a->{'fullname'} } &active_interfaces();
 
-# For Debian 5.0+ the "vconfig add" command is deprecated, this is handled
-# by ifup.
-if(($a->{'vlan'} == 1) && !(($gconfig{'os_type'} eq 'debian-linux') && ($gconfig{'os_version'} >= 5))) {
+# Create VLAN device with ip link if available (analogous to bond creation)
+if (&has_command("ip") && $a->{'vlan'} && $a->{'up'} && !$old) {
+	my $vdev = $a->{'physical'}.".".$a->{'vlanid'};
+	my $bcmd = "ip link add link ".quotemeta($a->{'physical'}).
+		   " name ".quotemeta($vdev)." type vlan id ".quotemeta($a->{'vlanid'});
+	my $out = &backquote_logged("$bcmd 2>&1");
+	&error("Failed to create VLAN device : $out") if ($?);
+	}
+# For older systems without ip command, use deprecated vconfig
+elsif(($a->{'vlan'} == 1) && !(($gconfig{'os_type'} eq 'debian-linux') && ($gconfig{'os_version'} >= 5))) {
 	local $vconfigCMD = "vconfig add " .
 			    quotemeta($a->{'physical'})." ".
 			    quotemeta($a->{'vlanid'});
@@ -295,17 +302,18 @@ if (&has_command("ip") && $a->{'bond'} && $a->{'up'} && !$old) {
 		}
 	}
 
-if (($a->{'bond'} || !&has_command("ifconfig")) && &has_command("ip")) {
+if (($a->{'bond'} || $a->{'vlan'} || !&has_command("ifconfig")) && &has_command("ip")) {
 	# For a real interface, activate or de-activate the link
+	my $devname = $a->{'vlan'} ? $a->{'physical'}.".".$a->{'vlanid'} : $a->{'name'};
 	if ($a->{'virtual'} eq '' && $a->{'up'} && (!$old || !$old->{'up'})) {
 		# Bring up
-		my $cmd = "ip link set dev ".quotemeta($a->{'name'})." up";
+		my $cmd = "ip link set dev ".quotemeta($devname)." up";
 		my $out = &backquote_logged("$cmd 2>&1");
 		&error("Failed to bring up link : $out") if ($?);
 		}
 	elsif ($a->{'virtual'} eq '' && !$a->{'up'} && $old && $old->{'up'}) {
 		# Take down
-		my $cmd = "ip link set dev ".quotemeta($a->{'name'})." down";
+		my $cmd = "ip link set dev ".quotemeta($devname)." down";
 		my $out = &backquote_logged("$cmd 2>&1");
 		&error("Failed to bring down link : $out") if ($?);
 		}

--- a/net/t/run-tests.t
+++ b/net/t/run-tests.t
@@ -660,4 +660,36 @@ is_deeply(\@commands,
 	    "cd / ; ip addr add 10\\.0\\.0\\.2/24 dev bond0 2>&1" ],
 	  "Linux active bond interface is created before assigning an address");
 
+@commands = ( );
+{
+	no warnings 'redefine';
+	no warnings 'once';
+	local *main::has_command = sub {
+		return $_[0] eq "ip" ? "/sbin/ip" :
+		       $_[0] eq "ifconfig" ? "/sbin/ifconfig" : undef;
+		};
+	local *main::active_interfaces = sub {
+		return ( );
+		};
+	local *main::backquote_command = sub {
+		return "";
+		};
+	main::activate_interface({ 'name' => 'auto',
+				   'fullname' => 'auto',
+				   'virtual' => '',
+				   'vlan' => 1,
+				   'physical' => 'eth0',
+				   'vlanid' => '10',
+				   'address' => '10.0.0.2',
+				   'netmask' => '255.255.255.0',
+				   'address6' => [ ],
+				   'netmask6' => [ ],
+				   'up' => 1 });
+	}
+is_deeply(\@commands,
+	  [ "ip link add link eth0 name eth0\\.10 type vlan id 10 2>&1",
+	    "ip link set dev eth0\\.10 up 2>&1",
+	    "cd / ; ip addr add 10\\.0\\.0\\.2/24 dev eth0.10 2>&1" ],
+	  "Linux active VLAN interface is created before assigning an address");
+
 done_testing();


### PR DESCRIPTION
## Problem

On systems where the `ip` command path is taken in `activate_interface()` (which is now the default since `ip` is prioritized over `ifconfig`), activating a VLAN interface fails with:

    Cannot find device "ens33.10"

This happens because the code attempts `ip addr add ... dev ens33.10` without first creating the VLAN device. The old `vconfig` path is skipped on Debian >= 5 (since it was expected to be handled by `ifup`), but `ifup` is never reached because the `ip` path comes first.

Additionally, the `ip link set ... up` block uses `$a->{'name'}` which is set to `"auto"` for VLAN interfaces, causing a second error.

## Fix

1. Create the VLAN device with `ip link add link <physical> name <physical>.<vlanid> type vlan id <vlanid>` when the `ip` command is available, before any address assignment. Falls back to `vconfig` on older systems without `ip`.
2. Resolve the correct device name (`physical.vlanid`) for VLAN interfaces in the link up/down block.

## Testing

- Added regression test for VLAN interface activation
- All 66 tests pass
- Tested on Debian 12 (bookworm) with VLAN interface creation via the Network Configuration module

Ref.: #2777