### PR TITLE
MM-12032 Fix bond/VLAN/bridge not removed from active list on delete

### DIFF
--- a/net/debian-linux-lib.pl
+++ b/net/debian-linux-lib.pl
@@ -230,12 +230,12 @@ if ($cfg->{'bridge'}) {
 
 # Set bonding parameters
 if(($cfg->{'bond'} == 1) && ($gconfig{'os_version'} >= 5)) {
-	push(@options, [&bonding_option('mode').' '.$cfg->{'mode'}]);
-	push(@options, [&bonding_option('miimon').' '.$cfg->{'miimon'}]) if ($cfg->{'miimon'});
-	push(@options, [&bonding_option('updelay').' '.$cfg->{'updelay'}]) if ($cfg->{'updelay'});
-	push(@options, [&bonding_option('downdelay').' '.$cfg->{'downdelay'}]) if ($cfg->{'downdelay'});
-	push(@options, [&bonding_option('primary').' '.$cfg->{'primary'}]) if ($cfg->{'primary'});
-	push(@options, ['slaves '.$cfg->{'partner'}]);
+	push(@options, [&bonding_option('mode'), $cfg->{'mode'}]);
+	push(@options, [&bonding_option('miimon'), $cfg->{'miimon'}]) if ($cfg->{'miimon'});
+	push(@options, [&bonding_option('updelay'), $cfg->{'updelay'}]) if ($cfg->{'updelay'});
+	push(@options, [&bonding_option('downdelay'), $cfg->{'downdelay'}]) if ($cfg->{'downdelay'});
+	push(@options, [&bonding_option('primary'), $cfg->{'primary'}]) if ($cfg->{'primary'});
+	push(@options, ['slaves', $cfg->{'partner'}]);
 	}
 elsif ($cfg->{'bond'} == 1) {
 	push(@options, ['up', '/sbin/ifenslave '.$cfg->{'name'}." ".

--- a/net/delete_bifcs.cgi
+++ b/net/delete_bifcs.cgi
@@ -51,6 +51,10 @@ foreach $d (reverse(@d)) {
 					else {&unload_module($b->{'name'});}
 					}
 				}
+			# Remove the virtual device after deactivation
+			if (defined(&destroy_interface_device)) {
+				&destroy_interface_device($b);
+				}
 			}
 
 		# Delete config

--- a/net/linux-lib.pl
+++ b/net/linux-lib.pl
@@ -329,9 +329,22 @@ if (&has_command("ip") && $a->{'bond'} && $a->{'up'} && !$old) {
 		}
 	}
 
-if (($a->{'bond'} || $a->{'vlan'} || !&has_command("ifconfig")) &&
-    &has_command("ip")) {
-	# For a real interface, activate or de-activate the link
+if (&has_command("ip") && $a->{'bridge'} && $a->{'up'} && !$old) {
+	# Create the bridge before assigning addresses to it.
+	my $cmd = "ip link add ".quotemeta($a->{'name'})." type bridge";
+	my $out = &backquote_logged("$cmd 2>&1");
+	&error("Failed to create bridge device : $out") if ($?);
+	if ($a->{'bridgeto'}) {
+		$cmd = "ip link set dev ".quotemeta($a->{'bridgeto'}).
+			" master ".quotemeta($a->{'name'});
+		$out = &backquote_logged("$cmd 2>&1");
+		&error("Failed to add interface to bridge : $out") if ($?);
+		}
+	}
+
+if (&has_command("ip")) {
+	# Manage link state for all interfaces when ip is used, since ip is also
+	# used for address assignment below regardless of ifconfig availability.
 	if ($a->{'virtual'} eq '' && $a->{'up'} && (!$old || !$old->{'up'})) {
 		# Bring up
 		my $cmd = "ip link set dev ".quotemeta($devname)." up";
@@ -592,6 +605,20 @@ elsif (&has_command("ifconfig")) {
 	}
 else {
 	&error("Both the ifconfig and ip commands are missing");
+	}
+}
+
+# destroy_interface_device(&details)
+# Remove a virtual network device (bond, VLAN, bridge) from the kernel.
+# Should be called after deactivate_interface when deleting, not just
+# deactivating, a virtual interface.
+sub destroy_interface_device
+{
+my ($a) = @_;
+if (&has_command("ip") && $a->{'virtual'} eq '' &&
+    (&use_ifup_command($a) || $a->{'bridge'})) {
+	&backquote_logged("ip link delete ".
+		quotemeta($a->{'fullname'} || $a->{'name'})." 2>&1");
 	}
 }
 

--- a/net/save_bifc.cgi
+++ b/net/save_bifc.cgi
@@ -32,6 +32,10 @@ if ($in{'delete'} || $in{'unapply'}) {
 			else {
 				&deactivate_interface($act);
 				}
+			# Remove the virtual device after deactivation
+			if (defined(&destroy_interface_device)) {
+				&destroy_interface_device($b);
+				}
 			}
 
 		}

--- a/net/t/run-tests.t
+++ b/net/t/run-tests.t
@@ -964,4 +964,89 @@ is_deeply(\@commands,
 	    "cd / ; ifconfig eth0.10 10\\.0\\.0\\.2 netmask 255\\.255\\.255\\.0 up 2>&1" ],
 	  "Linux VLAN interface falls back to vconfig without ip");
 
+# Test: Bond deactivation only brings it down, does not delete device
+@commands = ( );
+{
+no warnings 'redefine';
+local *main::has_command = sub {
+	return $_[0] eq "ip" ? "/sbin/ip" : undef;
+	};
+main::deactivate_interface({
+	'name' => 'bond0',
+	'fullname' => 'bond0',
+	'virtual' => '',
+	'address' => '10.0.0.2',
+	'netmask' => '255.255.255.0',
+	'address6' => [ ],
+	'netmask6' => [ ],
+	'up' => 1
+	});
+}
+is_deeply(\@commands, [
+	"ip addr del 10\\.0\\.0\\.2\\/24 dev bond0 2>&1",
+	"ip link set dev bond0 down 2>&1"
+	], "Linux bond deactivation removes address and brings link down");
+
+# Test: Bond deletion removes virtual device after deactivation
+@commands = ( );
+{
+no warnings 'redefine';
+no warnings 'once';
+local $main::gconfig{'os_type'} = 'debian-linux';
+local $main::gconfig{'os_version'} = 12;
+local *main::has_command = sub {
+	return $_[0] eq "ip" ? "/sbin/ip" :
+	       $_[0] eq "ifup" ? "/sbin/ifup" : undef;
+	};
+main::deactivate_interface({
+	'name' => 'bond0',
+	'fullname' => 'bond0',
+	'virtual' => '',
+	'address' => '10.0.0.2',
+	'netmask' => '255.255.255.0',
+	'address6' => [ ],
+	'netmask6' => [ ],
+	'up' => 1
+	});
+# Simulate delete path: destroy_interface_device after deactivation
+my $b = { 'name' => 'bond0', 'fullname' => 'bond0', 'virtual' => '' };
+main::destroy_interface_device($b);
+}
+is_deeply(\@commands, [
+	"ip addr del 10\\.0\\.0\\.2\\/24 dev bond0 2>&1",
+	"ip link set dev bond0 down 2>&1",
+	"ip link delete bond0 2>&1"
+	], "Linux bond deletion removes device after deactivation");
+
+# Test: VLAN deletion removes virtual device after deactivation
+@commands = ( );
+{
+no warnings 'redefine';
+no warnings 'once';
+local $main::gconfig{'os_type'} = 'debian-linux';
+local $main::gconfig{'os_version'} = 12;
+local *main::has_command = sub {
+	return $_[0] eq "ip" ? "/sbin/ip" :
+	       $_[0] eq "ifup" ? "/sbin/ifup" : undef;
+	};
+main::deactivate_interface({
+	'name' => 'eth0.10',
+	'fullname' => 'eth0.10',
+	'virtual' => '',
+	'address' => '10.0.10.2',
+	'netmask' => '255.255.255.0',
+	'address6' => [ ],
+	'netmask6' => [ ],
+	'up' => 1
+	});
+# Simulate delete path: destroy_interface_device after deactivation
+my $b = { 'name' => 'eth0.10', 'fullname' => 'eth0.10', 'virtual' => '' };
+main::destroy_interface_device($b);
+}
+is_deeply(\@commands, [
+	"ip addr del 10\\.0\\.10\\.2\\/24 dev eth0\\.10 2>&1",
+	"ip link set dev eth0\\.10 down 2>&1",
+	"ip link delete eth0\\.10 2>&1"
+	], "Linux VLAN deletion removes device after deactivation");
+
 done_testing();


### PR DESCRIPTION
This PR fixes multiple related issues found while working on bonding
interfaces:

**1. Virtual devices not removed on delete**

When deleting a bond, VLAN or bridge interface via "Delete and Apply",
the interface disappears from the boot configuration but is still
showing in the "Active Now" list. Only a reboot makes it go away.

The reason is that delete_bifcs.cgi and save_bifc.cgi only called
deactivate_interface() which does ip addr del + ip link set down.
That brings the link down but the kernel keeps virtual devices until
they are removed with ip link delete.

Fix: Added destroy_interface_device() in linux-lib.pl that calls
ip link delete. It is called from both CGIs after deactivation.
Uses defined(&destroy_interface_device) as guard so other OS
backends are not affected.

**2. Bridge interfaces not created during activation**

Creating a bridge interface and clicking "Save and Apply" fails with:
"Failed to bring up link: Cannot find device br0". The bridge device
does not exist in the kernel because nobody creates it.

Unlike bond (81d44f8) and VLAN (7761066) interfaces, bridges had no
ip link add type bridge in activate_interface().

Fix: Added bridge creation block in activate_interface() following
the same pattern as bond and VLAN.

**3. Bonding options causing trailing whitespace**

After creating a bonding interface with miimon, updelay or downdelay
values, every save adds more spaces to these values in
/etc/network/interfaces. After a few saves the values are broken and
"Save and Apply" does not work anymore.

The cause is that bonding options were pushed as single-element arrays:
  push(@options, ['bond-miimon 100']);

The write loop uses "\t$param $value\n" which adds a space after the
value because $value is empty.

Fix: Changed to key-value pairs:
  push(@options, ['bond-miimon', '100']);

**4. Interfaces getting IP but staying DOWN**

After deactivating a normal ethernet interface and then activating it
again, the interface gets its IP address back but stays DOWN. It is
not reachable on the network.

The ip link set up/down block in activate_interface() was guarded by:
  if (($a->{'bond'} || $a->{'vlan'} || !&has_command("ifconfig")) && ...)

But ip addr add runs always when ip is available - the elsif path
with ifconfig/ifup is never used. So the address was set but the link
was never brought up.

Fix: Changed condition to if (&has_command("ip")) since the ip command
is used for address assignment anyway.

**Testing:**

Tested on Debian 12 with bonding (mode 0, 1), VLAN (802.1Q) and
bridge interfaces. Create + Save and Apply, Deactivate, Activate,
Delete and Apply all work. Unit tests added in net/t/run-tests.t.
