### PR TITLE
Fix #2810

### DIFF
--- a/xmlrpc-lib.pl
+++ b/xmlrpc-lib.pl
@@ -18,7 +18,13 @@ my ($base64) = &find_xmls("base64", $value, 1);
 my ($struct) = &find_xmls("struct", $value, 1);
 my ($array) = &find_xmls("array", $value, 1);
 if ($scalar) {
-	return $scalar->[1]->[2] // "";
+    my ($type, $content) = ($scalar->[0], $scalar->[1]->[2] // "");
+
+    return int($content) if ($type eq "int" || $type eq "i4");
+    return $content ? 1 : 0 if ($type eq "boolean");
+    return $content + 0.0 if ($type eq "double");
+
+    return $content;
 	}
 elsif ($date) {
 	# Need to decode date


### PR DESCRIPTION
XML-RPC now retains type information on scalars.

**Note: I am not a perl coder and the actual implementation is implemented using AI.**

However, it fixes our use cases and looks ok to me, but I cannot judge on idiomaticness and edge cases.