### PR TITLE
Don't wait forever for a client that connects but never sends

### DIFF
--- a/miniserv.pl
+++ b/miniserv.pl
@@ -915,6 +915,13 @@ while(1) {
 				# Initialize SSL for this connection
 				if ($use_ssl) {
 					my $byte = '';
+					# Don't wait forever for a client that
+					# connects but never sends anything
+					my $pmask;
+					vec($pmask, fileno(SOCK), 1) = 1;
+					select($pmask, undef, undef,
+					       $config{'peek_timeout'} || 60)
+						|| exit;
 					# Look at the first byte of the socket
 					# buffer but don't consume it
 					recv(SOCK, $byte, 1, MSG_PEEK);


### PR DESCRIPTION
Fixes this issue: https://forum.virtualmin.com/t/webin-hogging-cpu-ram-im-not-sure/137770

This isn't actually a CPU issue, that's something else, but a bunch of miniserv processes hanging around is a bug, and I found it reproduced on one of my servers, as well. The processes are waiting on `select` that never fires for clients that don't send anything after the initial connection; there are connection timeouts that can happen later but this specific case never gets there.