### PR TITLE
Fix cron-lib.pl regex to also handle Debian 12 } brace syntax

### DIFF
--- a/cron/cron-lib.pl
+++ b/cron/cron-lib.pl
@@ -745,7 +745,7 @@ sub is_run_parts
 local ($cmd) = @_;
 local $rp = $config{'run_parts'};
 $cmd =~ s/\s*#.*$//;
-return $rp && $cmd =~ /$rp(.*)\s+(\-\-\S+\s+)*([a-z0-9\.\-\/_]+)(\s*\))?$/i ? $3 : undef;
+return $rp && $cmd =~ /$rp(.*)\s+(\-\-\S+\s+)*([a-z0-9\.\-\/_]+);?\s*[\)\}]?$/i ? $3 : undef;
 }
 
 =head2 can_edit_user(&access, user)


### PR DESCRIPTION
Fix daily cron jobs do now show up on Debian 12.

Regular expression now handles both ) and } line endings.

(Fixes issue webmin#2817)