### PR TITLE
Fix bridge handling for interfaces with arbitrary names

### DIFF
--- a/net/debian-linux-lib.pl
+++ b/net/debian-linux-lib.pl
@@ -72,6 +72,8 @@ foreach $iface (@ifaces) {
 				$cfg->{'ether'} = $v[1];
 				}
 			elsif ($param eq 'bridge_ports') {
+				# An interface with bridge ports is a bridge
+				$cfg->{'bridge'} = 1;
 				$cfg->{'bridgeto'} = $value;
 				}
 			elsif ($param eq 'bridge_stp') {

--- a/net/linux-lib.pl
+++ b/net/linux-lib.pl
@@ -618,8 +618,10 @@ sub destroy_interface_device
 {
 my ($a) = @_;
 my $name = $a->{'fullname'} || $a->{'name'};
+# Check the bridge flag too, as bridges can have arbitrary names
 if (&has_command("ip") && $a->{'virtual'} eq '' &&
-    &iface_type($name) =~ /(?:Bonded|VLAN|Bridge)$/) {
+    ($a->{'bridge'} ||
+     &iface_type($name) =~ /(?:Bonded|VLAN|Bridge)$/)) {
 	my $out = &backquote_logged(
 		"ip link delete ".quotemeta($name)." 2>&1");
 	&error("Failed to delete virtual interface : $out") if ($?);


### PR DESCRIPTION
Hey Jamie,

This small last PR fixes deletion of bridges with arbitrary names, like vmbr0, by honoring the boot config bridge flag instead of relying only on name patterns.

It also makes the Debian config parser treat any interface with bridge_ports as a bridge, which previously caused bridge options to be lost on re-save.